### PR TITLE
feat(distributed): automatic payload recovery for non-redeliverable transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .vscode/
+.claude/

--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ func main() {
 | Native Deduplication | ❌ | ✅ | ❌ | ❌ |
 | Native DLQ/DLT | ❌ | ❌ | ✅ | ❌ |
 | Publish Support | ✅ | ✅ | ✅ | ❌ |
-| WorkerPool Mode | ✅ | ✅ | ✅ | ❌ |
+| WorkerPool Mode | ✅ | ✅ | ✅ | via `distributed`* |
+
+\* MongoDB CDC supports WorkerPool mode through the `distributed` package, which emulates worker semantics using database atomic state transitions. See [Distributed WorkerPool](#distributed-workerpool).
 
 ## Health Checks
 
@@ -351,6 +353,73 @@ orderEvent.Subscribe(ctx, trackAnalytics,
 
 // Each order goes to 1 processor AND 1 analytics worker
 ```
+
+## Distributed WorkerPool
+
+The `distributed` package enables WorkerPool semantics on Broadcast-only transports (like MongoDB Change Streams) using database atomic state transitions. Only one worker processes each message, with automatic failover and payload recovery.
+
+### Basic Usage
+
+```go
+import "github.com/rbaliyan/event/v3/distributed"
+
+// Create a coordinator (Redis for distributed deployments)
+coord := distributed.NewRedisStateManager(redisClient,
+    distributed.WithCompletedTTL(48*time.Hour),
+)
+
+// Subscribe with WorkerPool emulation
+mongoEvent.Subscribe(ctx, handler,
+    event.WithMiddleware(
+        distributed.WorkerPoolMiddleware[Order](coord, 5*time.Minute),
+    ),
+)
+```
+
+### Payload Recovery
+
+For transports without re-delivery (e.g., MongoDB Change Streams), the middleware automatically stores message payload so the RecoveryRunner can re-publish stale events if a worker crashes:
+
+```go
+coord := distributed.NewMongoStateManager(db)
+
+// RecoveryRunner detects PayloadStore capability automatically
+runner := distributed.NewRecoveryRunner(coord,
+    distributed.WithPublisher(bus),     // enables re-publishing
+    distributed.WithStaleTimeout(2*time.Minute),
+    distributed.WithCheckInterval(30*time.Second),
+)
+
+go runner.Run(ctx)
+```
+
+Recovery is two-phase:
+1. **Re-publish**: Stale entries with stored payload are re-published via the bus with a new event ID
+2. **Reset**: Remaining stale entries (no payload) are reset for reacquisition
+
+### Worker Groups
+
+Use separate coordinators with different prefixes per group:
+
+```go
+smA := distributed.NewRedisStateManager(redis, distributed.WithPrefix("processors:"))
+smB := distributed.NewRedisStateManager(redis, distributed.WithPrefix("analytics:"))
+
+orderEvent.Subscribe(ctx, processOrder,
+    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smA, ttl)))
+orderEvent.Subscribe(ctx, collectAnalytics,
+    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smB, ttl)))
+```
+
+### Coordinator Backends
+
+| Backend | Package | Use Case |
+|---------|---------|----------|
+| Redis | `distributed.NewRedisStateManager` | Distributed deployments (recommended) |
+| MongoDB | `distributed.NewMongoStateManager` | When MongoDB is already your primary store |
+| Memory | `distributed.NewMemoryStateManager` | Single-instance or testing |
+
+All three backends implement both `Coordinator` and `PayloadStore` interfaces.
 
 ## Transactional Outbox Pattern
 
@@ -649,6 +718,7 @@ if err := orderSaga.Execute(ctx, sagaID, order); err != nil {
 | DLQ | ✅ | ✅ | ✅ | ✅ |
 | Scheduler | ✅ | ✅ | ✅ | - |
 | Saga | ✅ | ✅ | ✅ | ✅ |
+| Distributed WP | - | ✅ | ✅ | ✅ |
 
 ## Testing
 

--- a/bus.go
+++ b/bus.go
@@ -182,6 +182,16 @@ func (b *Bus) OutboxStore() OutboxStore {
 	return b.outboxStore
 }
 
+// SupportsRedelivery returns true if the underlying transport supports
+// automatic re-delivery of unacknowledged messages.
+// Returns false if transport does not implement transport.Redeliverable.
+func (b *Bus) SupportsRedelivery() bool {
+	if rd, ok := b.transport.(transport.Redeliverable); ok {
+		return rd.SupportsRedelivery()
+	}
+	return false
+}
+
 // Get returns an event by name
 func (b *Bus) Get(name string) any {
 	b.eventMutex.RLock()

--- a/context.go
+++ b/context.go
@@ -18,6 +18,7 @@ type eventContextData struct {
 	eventID               string
 	subID                 string
 	metadata              map[string]string
+	rawPayload            []byte
 	messageTime           time.Time
 	logger                *slog.Logger
 	bus                   *Bus
@@ -156,22 +157,9 @@ func ContextWithMetadata(ctx context.Context, m map[string]string) context.Conte
 	}
 	s, ok := ctx.Value(eventcontextKey).(*eventContextData)
 	if ok {
-		// Create a new struct to avoid race conditions
-		newData := &eventContextData{
-			name:                  s.name,
-			source:                s.source,
-			eventID:               s.eventID,
-			subID:                 s.subID,
-			metadata:              m,
-			messageTime:           s.messageTime,
-			logger:                s.logger,
-			bus:                   s.bus,
-			deliveryMode:          s.deliveryMode,
-			subscriberName:        s.subscriberName,
-			subscriberDescription: s.subscriberDescription,
-			coalescedCount:        s.coalescedCount,
-		}
-		return context.WithValue(ctx, eventcontextKey, newData)
+		newData := *s
+		newData.metadata = m
+		return context.WithValue(ctx, eventcontextKey, &newData)
 	}
 	return context.WithValue(ctx, eventcontextKey, &eventContextData{metadata: m})
 }
@@ -183,22 +171,9 @@ func ContextWithEventID(ctx context.Context, id string) context.Context {
 	}
 	s, ok := ctx.Value(eventcontextKey).(*eventContextData)
 	if ok {
-		// Create a new struct to avoid race conditions
-		newData := &eventContextData{
-			name:                  s.name,
-			source:                s.source,
-			eventID:               id,
-			subID:                 s.subID,
-			metadata:              s.metadata,
-			messageTime:           s.messageTime,
-			logger:                s.logger,
-			bus:                   s.bus,
-			deliveryMode:          s.deliveryMode,
-			subscriberName:        s.subscriberName,
-			subscriberDescription: s.subscriberDescription,
-			coalescedCount:        s.coalescedCount,
-		}
-		return context.WithValue(ctx, eventcontextKey, newData)
+		newData := *s
+		newData.eventID = id
+		return context.WithValue(ctx, eventcontextKey, &newData)
 	}
 	return context.WithValue(ctx, eventcontextKey, &eventContextData{eventID: id})
 }
@@ -210,22 +185,9 @@ func ContextWithLogger(ctx context.Context, l *slog.Logger) context.Context {
 	}
 	s, ok := ctx.Value(eventcontextKey).(*eventContextData)
 	if ok {
-		// Create a new struct to avoid race conditions
-		newData := &eventContextData{
-			name:                  s.name,
-			source:                s.source,
-			eventID:               s.eventID,
-			subID:                 s.subID,
-			metadata:              s.metadata,
-			messageTime:           s.messageTime,
-			logger:                l,
-			bus:                   s.bus,
-			deliveryMode:          s.deliveryMode,
-			subscriberName:        s.subscriberName,
-			subscriberDescription: s.subscriberDescription,
-			coalescedCount:        s.coalescedCount,
-		}
-		return context.WithValue(ctx, eventcontextKey, newData)
+		newData := *s
+		newData.logger = l
+		return context.WithValue(ctx, eventcontextKey, &newData)
 	}
 	return context.WithValue(ctx, eventcontextKey, &eventContextData{logger: l})
 }
@@ -251,7 +213,32 @@ func contextWithInfoCoalesced(ctx context.Context, id, name, source, subID strin
 	})
 }
 
-// ContextWithEventFromContext copy context baggage
+// ContextWithRawPayload sets the raw message payload bytes in the event context data.
+func ContextWithRawPayload(ctx context.Context, payload []byte) context.Context {
+	if len(payload) == 0 {
+		return ctx
+	}
+	s, ok := ctx.Value(eventcontextKey).(*eventContextData)
+	if ok {
+		newData := *s
+		newData.rawPayload = payload
+		return context.WithValue(ctx, eventcontextKey, &newData)
+	}
+	return context.WithValue(ctx, eventcontextKey, &eventContextData{rawPayload: payload})
+}
+
+// ContextRawPayload returns the raw message payload bytes from the context.
+// Returns nil if not set.
+func ContextRawPayload(ctx context.Context) []byte {
+	s, ok := ctx.Value(eventcontextKey).(*eventContextData)
+	if ok {
+		return s.rawPayload
+	}
+	return nil
+}
+
+// ContextWithEventFromContext copies event context baggage (event ID, name, metadata,
+// raw payload, etc.) from one context to another.
 func ContextWithEventFromContext(to, from context.Context) context.Context {
 	s, ok := from.Value(eventcontextKey).(*eventContextData)
 	if ok {

--- a/distributed/claimer.go
+++ b/distributed/claimer.go
@@ -19,8 +19,9 @@
 //
 // Key components:
 //
-//   - StateManager: Interface for atomic message state transitions
-//   - WorkerPoolMiddleware: Middleware that uses a StateManager to emulate WorkerPool
+//   - Coordinator: Interface for atomic message state transitions
+//   - PayloadStore: Optional interface for persisting message payload for recovery
+//   - WorkerPoolMiddleware: Middleware that uses a Coordinator to emulate WorkerPool
 //   - RedisStateManager: Redis-based implementation using atomic SETNX
 //   - MongoStateManager: MongoDB-based implementation using findOneAndUpdate
 //   - MemoryStateManager: In-memory implementation for single-instance or testing
@@ -45,7 +46,7 @@
 // Example usage with MongoDB transport:
 //
 //	// Create state manager (Redis for distributed deployments)
-//	sm := distributed.NewRedisStateManager(redisClient, distributed.WithStateTTL(5*time.Minute))
+//	sm := distributed.NewRedisStateManager(redisClient, distributed.WithCompletedTTL(48*time.Hour))
 //
 //	// Subscribe with middleware to emulate WorkerPool
 //	mongoEvent.Subscribe(ctx, handler,
@@ -84,9 +85,9 @@ import (
 	"time"
 )
 
-// StateManager provides atomic message state transitions for WorkerPool emulation.
+// Coordinator handles atomic state transitions for WorkerPool emulation.
 //
-// In Broadcast transports where all subscribers receive every message, a StateManager
+// In Broadcast transports where all subscribers receive every message, a Coordinator
 // ensures only one subscriber processes each message using database atomic operations.
 //
 // Implementations must be:
@@ -98,124 +99,110 @@ import (
 //   - RedisStateManager: Uses Redis atomic SETNX for distributed deployments
 //   - MongoStateManager: Uses MongoDB atomic findOneAndUpdate
 //   - MemoryStateManager: In-memory for single-instance or testing
-//
-// Example implementing a custom state manager:
-//
-//	type PostgresStateManager struct {
-//	    db  *sql.DB
-//	    ttl time.Duration
-//	}
-//
-//	func (s *PostgresStateManager) Acquire(ctx context.Context, messageID string, ttl time.Duration) (bool, error) {
-//	    // Atomic INSERT - only succeeds if row doesn't exist
-//	    result, err := s.db.ExecContext(ctx, `
-//	        INSERT INTO message_state (message_id, status, expires_at)
-//	        VALUES ($1, 'processing', $2)
-//	        ON CONFLICT (message_id) DO NOTHING
-//	    `, messageID, time.Now().Add(ttl))
-//	    if err != nil {
-//	        return false, err
-//	    }
-//	    rows, _ := result.RowsAffected()
-//	    return rows > 0, nil
-//	}
-type StateManager interface {
+type Coordinator interface {
 	// Acquire atomically transitions a message to "processing" state.
-	//
-	// If the transition succeeds, returns (true, nil) and the caller should
-	// process the message, then call MarkProcessed() on success or Reset() on failure.
-	//
-	// If the transition fails (another worker acquired it), returns (false, nil)
-	// and the caller should skip processing (return nil to ack).
-	//
-	// The ttl parameter specifies how long the state is valid. After TTL expires,
-	// another worker can acquire the message (useful for crash recovery).
-	//
-	// Parameters:
-	//   - ctx: Context for cancellation and timeouts
-	//   - messageID: Unique identifier for the message (from event.ContextEventID)
-	//   - ttl: How long to hold the state before it expires
 	//
 	// Returns:
 	//   - (true, nil): Acquisition successful, process the message
 	//   - (false, nil): Already acquired by another worker, skip
-	//   - (false, error): Database error (log and decide how to handle)
+	//   - (false, error): Database error
 	Acquire(ctx context.Context, messageID string, ttl time.Duration) (acquired bool, err error)
 
 	// MarkProcessed transitions a message to "completed" state.
-	//
-	// After successful processing, call MarkProcessed to update the state.
-	// This typically either:
-	//   - Extends the state TTL to prevent reprocessing during TTL window
-	//   - Marks the message as "completed" in a persistent store
-	//
-	// If MarkProcessed fails, the message may be reprocessed when the state expires.
-	// Handlers should be idempotent to handle this safely.
-	//
-	// Parameters:
-	//   - ctx: Context for cancellation and timeouts
-	//   - messageID: The message ID that was successfully processed
-	//
-	// Returns error if the state update fails (log but don't fail the handler).
 	MarkProcessed(ctx context.Context, messageID string) error
 
 	// Reset removes the message state to allow immediate reprocessing.
-	//
-	// Call this when processing fails and you want another worker to retry
-	// immediately instead of waiting for the state to expire. This is optional;
-	// letting the state expire naturally is also valid behavior.
-	//
-	// Parameters:
-	//   - ctx: Context for cancellation and timeouts
-	//   - messageID: The message ID to reset
-	//
-	// Returns error if the reset fails (log but don't affect error propagation).
 	Reset(ctx context.Context, messageID string) error
 
-	// ListStale returns message IDs of states that appear stale.
-	//
-	// A stale state is one that has been in "processing" state for longer than
-	// the specified staleTimeout. This typically indicates that the worker
-	// processing the message has crashed or become unresponsive.
-	//
-	// This method enables active recovery: instead of waiting for states
-	// to expire via TTL (passive), a background goroutine can periodically
-	// check for stale states and reset them for faster failover.
-	//
-	// Parameters:
-	//   - ctx: Context for cancellation and timeouts
-	//   - staleTimeout: Duration after which a processing state is considered stale.
-	//     Should be longer than expected handler execution time but shorter than state TTL.
-	//   - limit: Maximum number of stale states to return (0 = no limit)
-	//
-	// Returns:
-	//   - List of message IDs that are stale
-	//   - error if the query fails
-	//
-	// Example staleTimeout values:
-	//   - Handler timeout 30s → staleTimeout 1-2 minutes
-	//   - Handler timeout 1m → staleTimeout 2-3 minutes
-	//   - No timeout → staleTimeout based on expected max processing time
+	// ListStale returns message IDs of states that have been in "processing"
+	// state for longer than staleTimeout.
 	ListStale(ctx context.Context, staleTimeout time.Duration, limit int) ([]string, error)
+}
+
+// PayloadStore persists message payload for recovery when the transport
+// cannot redeliver lost messages (e.g., MongoDB Change Streams).
+//
+// This is an optional interface that Coordinator implementations can also
+// implement. When a Coordinator also implements PayloadStore:
+//   - WorkerPoolMiddleware stores payload after acquiring state
+//   - RecoveryRunner re-publishes stale events via the injected Publisher
+//
+// Implementations:
+//   - MongoStateManager: Stores payload in the same document (atomic with state)
+//   - RedisStateManager: Stores payload in a companion key
+//   - MemoryStateManager: Stores payload in memory (for testing)
+type PayloadStore interface {
+	// StorePayload persists payload alongside a message ID.
+	// Called after a successful Acquire when the transport doesn't support
+	// re-delivery. Not required to be atomic with Acquire.
+	StorePayload(ctx context.Context, messageID string, data *MessageData) error
+
+	// LoadStalePayloads returns stale messages that have stored payload.
+	// Used by RecoveryRunner to re-publish lost events.
+	LoadStalePayloads(ctx context.Context, staleTimeout time.Duration, limit int) ([]*StaleMessage, error)
+
+	// ClearPayload removes stored payload for a message.
+	// Called after successful processing or recovery re-publish.
+	ClearPayload(ctx context.Context, messageID string) error
+}
+
+// Publisher sends events for recovery re-publishing.
+// This interface is satisfied by *event.Bus via its Send method.
+type Publisher interface {
+	Send(ctx context.Context, eventName, eventID string, payload []byte, metadata map[string]string) error
+}
+
+// MessageData holds message payload for recovery re-publishing.
+// Fields are populated from event context in WorkerPoolMiddleware:
+//   - Payload:   event.ContextRawPayload(ctx) — raw message bytes
+//   - Metadata:  event.ContextMetadata(ctx) — message metadata map
+//   - EventName: event.ContextName(ctx) — event routing name
+type MessageData struct {
+	Payload   []byte
+	Metadata  map[string]string
+	EventName string
+}
+
+// StaleMessage is a stale state entry with its stored payload.
+type StaleMessage struct {
+	MessageID string
+	Data      MessageData
+	CreatedAt time.Time
+}
+
+// HasPayload returns true if the stale message has stored payload data.
+func (s *StaleMessage) HasPayload() bool {
+	return len(s.Data.Payload) > 0
 }
 
 // Option configures a state manager implementation.
 type Option func(*stateOptions)
 
+// StaleResetter is an optional interface that Coordinator implementations
+// can provide for efficient batch stale state reset.
+type StaleResetter interface {
+	// ResetStale resets stale states in batch.
+	// Returns the number of states reset.
+	ResetStale(ctx context.Context, staleTimeout time.Duration, limit int) (int64, error)
+}
+
 // stateOptions holds common configuration for state manager implementations.
 type stateOptions struct {
 	prefix         string
-	ttl            time.Duration
 	completionTTL  time.Duration
 	cleanupEnabled bool
 	cleanupPeriod  time.Duration
+	// MongoDB-specific options (only used by NewMongoStateManager)
+	collectionName string
+	capped         bool
+	cappedSize     int64
+	cappedMaxDocs  int64
 }
 
 // defaultStateOptions returns sensible defaults for state manager configuration.
 func defaultStateOptions() *stateOptions {
 	return &stateOptions{
 		prefix:         "state:",
-		ttl:            5 * time.Minute,
 		completionTTL:  24 * time.Hour,
 		cleanupEnabled: true,
 		cleanupPeriod:  time.Hour,
@@ -233,20 +220,6 @@ func defaultStateOptions() *stateOptions {
 func WithPrefix(prefix string) Option {
 	return func(o *stateOptions) {
 		o.prefix = prefix
-	}
-}
-
-// WithStateTTL sets the default TTL for processing states.
-//
-// The TTL should be longer than your handler's maximum execution time.
-// If a worker crashes, other workers can acquire the message after TTL expires.
-//
-// Default: 5 minutes
-func WithStateTTL(ttl time.Duration) Option {
-	return func(o *stateOptions) {
-		if ttl > 0 {
-			o.ttl = ttl
-		}
 	}
 }
 
@@ -273,5 +246,43 @@ func WithCleanup(enabled bool, period time.Duration) Option {
 		if period > 0 {
 			o.cleanupPeriod = period
 		}
+	}
+}
+
+// WithCollection sets the MongoDB collection name for state storage.
+//
+// This option is only used by NewMongoStateManager and is ignored by other
+// state manager implementations.
+//
+// Default: "_message_state"
+func WithCollection(name string) Option {
+	return func(o *stateOptions) {
+		if name != "" {
+			o.collectionName = name
+		}
+	}
+}
+
+// WithCapped enables MongoDB capped collection mode for high-throughput scenarios.
+//
+// This option is only used by NewMongoStateManager and is ignored by other
+// state manager implementations.
+//
+// Capped collections are fixed-size collections that automatically remove
+// the oldest documents when the size limit is reached.
+//
+// Parameters:
+//   - sizeBytes: Maximum collection size in bytes (required, minimum 4096)
+//   - maxDocs: Maximum number of documents (0 = unlimited, size-based only)
+//
+// IMPORTANT LIMITATIONS:
+//   - Reset() becomes a no-op (MongoDB doesn't allow deletes in capped collections)
+//   - No TTL index support
+//   - Failed states wait for size-based removal
+func WithCapped(sizeBytes int64, maxDocs int64) Option {
+	return func(o *stateOptions) {
+		o.capped = true
+		o.cappedSize = sizeBytes
+		o.cappedMaxDocs = maxDocs
 	}
 }

--- a/distributed/distributed_test.go
+++ b/distributed/distributed_test.go
@@ -115,9 +115,6 @@ func TestStateOptions(t *testing.T) {
 	if opts.prefix != "state:" {
 		t.Errorf("expected prefix 'state:', got %q", opts.prefix)
 	}
-	if opts.ttl != 5*time.Minute {
-		t.Errorf("expected ttl 5m, got %v", opts.ttl)
-	}
 	if opts.completionTTL != 24*time.Hour {
 		t.Errorf("expected completionTTL 24h, got %v", opts.completionTTL)
 	}
@@ -128,14 +125,26 @@ func TestStateOptions(t *testing.T) {
 		t.Errorf("expected prefix 'test:', got %q", opts.prefix)
 	}
 
-	WithStateTTL(10 * time.Minute)(opts)
-	if opts.ttl != 10*time.Minute {
-		t.Errorf("expected ttl 10m, got %v", opts.ttl)
-	}
-
 	WithCompletedTTL(48 * time.Hour)(opts)
 	if opts.completionTTL != 48*time.Hour {
 		t.Errorf("expected completionTTL 48h, got %v", opts.completionTTL)
+	}
+
+	// Test MongoDB-specific options
+	WithCollection("custom_states")(opts)
+	if opts.collectionName != "custom_states" {
+		t.Errorf("expected collectionName 'custom_states', got %q", opts.collectionName)
+	}
+
+	WithCapped(1024*1024, 1000)(opts)
+	if !opts.capped {
+		t.Error("expected capped to be true")
+	}
+	if opts.cappedSize != 1024*1024 {
+		t.Errorf("expected cappedSize 1048576, got %d", opts.cappedSize)
+	}
+	if opts.cappedMaxDocs != 1000 {
+		t.Errorf("expected cappedMaxDocs 1000, got %d", opts.cappedMaxDocs)
 	}
 }
 

--- a/distributed/example_test.go
+++ b/distributed/example_test.go
@@ -49,9 +49,8 @@ func Example() {
 // ExampleNewMemoryStateManager demonstrates creating a memory state manager
 // with custom options.
 func ExampleNewMemoryStateManager() {
-	// Create state manager with custom TTL settings
+	// Create state manager with custom settings
 	sm := distributed.NewMemoryStateManager(
-		distributed.WithStateTTL(10*time.Minute),
 		distributed.WithCompletedTTL(24*time.Hour),
 		distributed.WithCleanup(true, 30*time.Minute),
 	)

--- a/distributed/memory.go
+++ b/distributed/memory.go
@@ -19,9 +19,10 @@ type stateEntry struct {
 	state     stateValue
 	expiresAt time.Time
 	updatedAt time.Time
+	payload   *MessageData // optional payload for recovery re-publishing
 }
 
-// MemoryStateManager implements StateManager using in-memory storage.
+// MemoryStateManager implements Coordinator and PayloadStore using in-memory storage.
 //
 // MemoryStateManager is suitable for:
 //   - Single-instance deployments where only one process handles messages
@@ -46,7 +47,6 @@ type stateEntry struct {
 //
 //	// With custom options
 //	sm := distributed.NewMemoryStateManager(
-//	    distributed.WithStateTTL(5*time.Minute),
 //	    distributed.WithCompletedTTL(24*time.Hour),
 //	)
 //
@@ -214,6 +214,53 @@ func (s *MemoryStateManager) ListStale(_ context.Context, staleTimeout time.Dura
 	return stale, nil
 }
 
+// StorePayload persists payload alongside a message ID.
+func (s *MemoryStateManager) StorePayload(_ context.Context, messageID string, data *MessageData) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry, exists := s.states[messageID]; exists {
+		entry.payload = data
+	}
+	return nil
+}
+
+// LoadStalePayloads returns stale messages that have stored payload.
+func (s *MemoryStateManager) LoadStalePayloads(_ context.Context, staleTimeout time.Duration, limit int) ([]*StaleMessage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cutoff := time.Now().Add(-staleTimeout)
+	var result []*StaleMessage
+
+	for id, entry := range s.states {
+		if entry.state == stateProcessing && entry.updatedAt.Before(cutoff) && entry.payload != nil {
+			sm := &StaleMessage{
+				MessageID: id,
+				Data:      *entry.payload,
+				CreatedAt: entry.updatedAt,
+			}
+			result = append(result, sm)
+			if limit > 0 && len(result) >= limit {
+				break
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// ClearPayload removes stored payload for a message.
+func (s *MemoryStateManager) ClearPayload(_ context.Context, messageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if entry, exists := s.states[messageID]; exists {
+		entry.payload = nil
+	}
+	return nil
+}
+
 // ResetStale resets all stale states, allowing them to be reacquired.
 //
 // This is a convenience method that combines ListStale and Reset.
@@ -289,5 +336,9 @@ func (s *MemoryStateManager) cleanupExpired() {
 	}
 }
 
-// Compile-time interface check
-var _ StateManager = (*MemoryStateManager)(nil)
+// Compile-time interface checks
+var (
+	_ Coordinator   = (*MemoryStateManager)(nil)
+	_ PayloadStore  = (*MemoryStateManager)(nil)
+	_ StaleResetter = (*MemoryStateManager)(nil)
+)

--- a/distributed/metrics.go
+++ b/distributed/metrics.go
@@ -1,0 +1,201 @@
+package distributed
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// RecoveryMetrics provides OpenTelemetry metrics for recovery operations.
+//
+// Metrics tracked:
+//   - recovery_events_recovered_total: Counter of events recovered (reset or re-published)
+//   - recovery_events_republished_total: Counter of events re-published with payload
+//   - recovery_events_reset_total: Counter of events reset without payload (legacy)
+//   - recovery_errors_total: Counter of recovery errors
+//   - recovery_events_skipped_total: Counter of events skipped (bus not found, etc.)
+//   - recovery_pass_duration_seconds: Histogram of recovery pass duration
+//
+// Example:
+//
+//	metrics, err := distributed.NewRecoveryMetrics()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	runner := distributed.NewRecoveryRunner(sm,
+//	    distributed.WithRecoveryMetrics(metrics),
+//	)
+type RecoveryMetrics struct {
+	recoveredCounter   metric.Int64Counter
+	republishedCounter metric.Int64Counter
+	resetCounter       metric.Int64Counter
+	errorsCounter      metric.Int64Counter
+	skippedCounter     metric.Int64Counter
+	passDuration       metric.Float64Histogram
+}
+
+// RecoveryMetricsOption configures RecoveryMetrics.
+type RecoveryMetricsOption func(*recoveryMetricsOptions)
+
+type recoveryMetricsOptions struct {
+	meterProvider metric.MeterProvider
+	namespace     string
+}
+
+// WithRecoveryMeterProvider sets a custom OpenTelemetry meter provider.
+func WithRecoveryMeterProvider(mp metric.MeterProvider) RecoveryMetricsOption {
+	return func(o *recoveryMetricsOptions) {
+		o.meterProvider = mp
+	}
+}
+
+// WithRecoveryMetricsNamespace sets a prefix for all metric names.
+func WithRecoveryMetricsNamespace(ns string) RecoveryMetricsOption {
+	return func(o *recoveryMetricsOptions) {
+		o.namespace = ns
+	}
+}
+
+// NewRecoveryMetrics creates recovery metrics registered with the OTel meter provider.
+func NewRecoveryMetrics(opts ...RecoveryMetricsOption) (*RecoveryMetrics, error) {
+	o := &recoveryMetricsOptions{
+		meterProvider: otel.GetMeterProvider(),
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	prefix := ""
+	if o.namespace != "" {
+		prefix = o.namespace + "_"
+	}
+
+	meter := o.meterProvider.Meter("github.com/rbaliyan/event/v3/distributed")
+
+	m := &RecoveryMetrics{}
+	var err error
+
+	m.recoveredCounter, err = meter.Int64Counter(
+		prefix+"recovery_events_recovered_total",
+		metric.WithDescription("Total number of events recovered (reset or re-published)"),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.republishedCounter, err = meter.Int64Counter(
+		prefix+"recovery_events_republished_total",
+		metric.WithDescription("Total number of stale events re-published with stored payload"),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.resetCounter, err = meter.Int64Counter(
+		prefix+"recovery_events_reset_total",
+		metric.WithDescription("Total number of stale events reset without payload (legacy entries)"),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.errorsCounter, err = meter.Int64Counter(
+		prefix+"recovery_errors_total",
+		metric.WithDescription("Total number of recovery errors"),
+		metric.WithUnit("{error}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.skippedCounter, err = meter.Int64Counter(
+		prefix+"recovery_events_skipped_total",
+		metric.WithDescription("Total number of stale events skipped during recovery (bus not found, re-publish failed)"),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.passDuration, err = meter.Float64Histogram(
+		prefix+"recovery_pass_duration_seconds",
+		metric.WithDescription("Duration of a single recovery pass"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (m *RecoveryMetrics) recordRecovered(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.recoveredCounter.Add(ctx, 1)
+}
+
+func (m *RecoveryMetrics) recordRecoveredN(ctx context.Context, n int64) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.recoveredCounter.Add(ctx, n)
+}
+
+func (m *RecoveryMetrics) recordRepublished(ctx context.Context, eventName string) {
+	if m == nil {
+		return
+	}
+	m.republishedCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("event_name", eventName),
+	))
+}
+
+func (m *RecoveryMetrics) recordReset(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.resetCounter.Add(ctx, 1)
+}
+
+func (m *RecoveryMetrics) recordResetN(ctx context.Context, n int64) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.resetCounter.Add(ctx, n)
+}
+
+func (m *RecoveryMetrics) recordError(ctx context.Context, operation string) {
+	if m == nil {
+		return
+	}
+	m.errorsCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("operation", operation),
+	))
+}
+
+func (m *RecoveryMetrics) recordSkipped(ctx context.Context, reason string, eventName string) {
+	if m == nil {
+		return
+	}
+	m.skippedCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("reason", reason),
+		attribute.String("event_name", eventName),
+	))
+}
+
+func (m *RecoveryMetrics) recordPassDuration(ctx context.Context, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.passDuration.Record(ctx, d.Seconds())
+}

--- a/distributed/middleware.go
+++ b/distributed/middleware.go
@@ -2,10 +2,50 @@ package distributed
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rbaliyan/event/v3"
 )
+
+// PoolOption configures WorkerPoolMiddleware behavior.
+type PoolOption func(*poolOptions)
+
+type poolOptions struct {
+	storePayload   *bool // nil = auto-detect from transport, non-nil = explicit
+	maxPayloadSize int   // 0 = no limit
+}
+
+// WithPayloadRecovery explicitly enables payload storage for recovery.
+//
+// When enabled, the middleware stores message payload alongside state so that
+// the RecoveryRunner can re-publish events if the worker crashes. This is
+// required for transports that don't support re-delivery (e.g., MongoDB
+// Change Streams).
+//
+// By default, payload storage is auto-detected from the transport's
+// SupportsRedelivery() capability. Use this option to override the detection
+// or to make the behavior deterministic at construction time.
+func WithPayloadRecovery() PoolOption {
+	return func(o *poolOptions) {
+		t := true
+		o.storePayload = &t
+	}
+}
+
+// WithMaxPayloadSize sets the maximum payload size (in bytes) that will be
+// stored for recovery. If a message payload exceeds this limit, the middleware
+// falls back to regular Acquire without payload storage and logs a warning.
+//
+// Default: 0 (no limit). MongoDB's document limit is 16MB which provides
+// a natural ceiling for MongoDB-backed state managers.
+func WithMaxPayloadSize(size int) PoolOption {
+	return func(o *poolOptions) {
+		if size > 0 {
+			o.maxPayloadSize = size
+		}
+	}
+}
 
 // WorkerPoolMiddleware creates middleware that emulates WorkerPool mode
 // on Broadcast-only transports using atomic database state transitions.
@@ -28,7 +68,7 @@ import (
 //   - Adding worker semantics to existing Broadcast subscriptions
 //
 // Parameters:
-//   - sm: A StateManager implementation (RedisStateManager for distributed)
+//   - coord: A Coordinator implementation (RedisStateManager for distributed)
 //   - stateTTL: How long to hold the state (should exceed handler timeout)
 //
 // Example:
@@ -76,8 +116,27 @@ import (
 //
 //	orderEvent.Subscribe(ctx, collectAnalytics,
 //	    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smB, ttl)))
-func WorkerPoolMiddleware[T any](sm StateManager, stateTTL time.Duration) event.Middleware[T] {
+func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts ...PoolOption) event.Middleware[T] {
+	o := &poolOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Check if coordinator also implements PayloadStore
+	ps, hasPayloadStore := coord.(PayloadStore)
+
 	return func(next event.Handler[T]) event.Handler[T] {
+		// Track whether the transport supports redelivery
+		var (
+			detectOnce   sync.Once
+			storePayload bool // true when transport lacks redelivery
+		)
+
+		// If explicitly configured, set immediately (no auto-detection needed)
+		if o.storePayload != nil {
+			storePayload = *o.storePayload
+		}
+
 		return func(ctx context.Context, ev event.Event[T], data T) error {
 			// Get message ID from context
 			messageID := event.ContextEventID(ctx)
@@ -87,8 +146,18 @@ func WorkerPoolMiddleware[T any](sm StateManager, stateTTL time.Duration) event.
 				return next(ctx, ev, data)
 			}
 
+			// Auto-detect transport capability once per subscriber (skipped if explicit)
+			if o.storePayload == nil {
+				detectOnce.Do(func() {
+					bus := event.ContextBus(ctx)
+					if bus != nil && !bus.SupportsRedelivery() {
+						storePayload = true
+					}
+				})
+			}
+
 			// Attempt to acquire the message state
-			acquired, err := sm.Acquire(ctx, messageID, stateTTL)
+			acquired, err := coord.Acquire(ctx, messageID, stateTTL)
 			if err != nil {
 				// State manager error - log and proceed with processing (fail open)
 				// This prevents message loss at the cost of potential duplicates
@@ -103,7 +172,6 @@ func WorkerPoolMiddleware[T any](sm StateManager, stateTTL time.Duration) event.
 
 			if !acquired {
 				// Another worker already acquired this message - skip silently
-				// Return nil to acknowledge the message without processing
 				logger := event.ContextLogger(ctx)
 				if logger != nil {
 					logger.Debug("message acquired by another worker, skipping",
@@ -112,13 +180,48 @@ func WorkerPoolMiddleware[T any](sm StateManager, stateTTL time.Duration) event.
 				return nil
 			}
 
+			// Store payload for recovery if needed (after successful acquire)
+			payloadStored := false
+			if storePayload && hasPayloadStore {
+				payload := event.ContextRawPayload(ctx)
+
+				if o.maxPayloadSize > 0 && len(payload) > o.maxPayloadSize {
+					logger := event.ContextLogger(ctx)
+					if logger != nil {
+						logger.Warn("payload exceeds max size, skipping payload storage",
+							"message_id", messageID,
+							"payload_size", len(payload),
+							"max_size", o.maxPayloadSize)
+					}
+				} else if len(payload) > 0 {
+					msgData := &MessageData{
+						Payload:   payload,
+						Metadata:  event.ContextMetadata(ctx),
+						EventName: event.ContextName(ctx),
+					}
+					if storeErr := ps.StorePayload(ctx, messageID, msgData); storeErr != nil {
+						logger := event.ContextLogger(ctx)
+						if logger != nil {
+							logger.Warn("failed to store payload for recovery",
+								"message_id", messageID,
+								"error", storeErr)
+						}
+					} else {
+						payloadStored = true
+					}
+				}
+			}
+
 			// We acquired the message state - process it
 			handlerErr := next(ctx, ev, data)
 
 			// Record result
 			if handlerErr == nil {
-				// Success - mark as processed
-				if markErr := sm.MarkProcessed(ctx, messageID); markErr != nil {
+				// Success - mark as processed and clear payload if stored
+				if payloadStored {
+					_ = ps.ClearPayload(ctx, messageID)
+				}
+				if markErr := coord.MarkProcessed(ctx, messageID); markErr != nil {
 					logger := event.ContextLogger(ctx)
 					if logger != nil {
 						logger.Warn("failed to mark message as processed",
@@ -127,13 +230,28 @@ func WorkerPoolMiddleware[T any](sm StateManager, stateTTL time.Duration) event.
 					}
 				}
 			} else {
-				// Failure - reset state for another worker to retry
-				if resetErr := sm.Reset(ctx, messageID); resetErr != nil {
+				// Failure — decide whether to reset or leave for recovery.
+				// When payload was stored, the transport cannot redeliver the
+				// original message. Calling Reset would delete the stored payload,
+				// permanently losing the event. Leave the state in "processing"
+				// so RecoveryRunner can find it via LoadStalePayloads and
+				// re-publish with the stored payload.
+				if payloadStored {
 					logger := event.ContextLogger(ctx)
 					if logger != nil {
-						logger.Warn("failed to reset message state",
+						logger.Info("handler failed, leaving state for recovery re-publish",
 							"message_id", messageID,
-							"error", resetErr)
+							"error", handlerErr)
+					}
+				} else {
+					// No stored payload — safe to reset for immediate retry
+					if resetErr := coord.Reset(ctx, messageID); resetErr != nil {
+						logger := event.ContextLogger(ctx)
+						if logger != nil {
+							logger.Warn("failed to reset message state",
+								"message_id", messageID,
+								"error", resetErr)
+						}
 					}
 				}
 			}

--- a/distributed/middleware_test.go
+++ b/distributed/middleware_test.go
@@ -1,0 +1,339 @@
+package distributed
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3"
+)
+
+// mockCoordinator is a test double for Coordinator.
+type mockCoordinator struct {
+	acquireResult  bool
+	acquireErr     error
+	markProcessed  bool
+	markErr        error
+	resetCalled    bool
+	resetErr       error
+	acquiredMsgIDs []string
+}
+
+func (m *mockCoordinator) Acquire(_ context.Context, messageID string, _ time.Duration) (bool, error) {
+	m.acquiredMsgIDs = append(m.acquiredMsgIDs, messageID)
+	return m.acquireResult, m.acquireErr
+}
+func (m *mockCoordinator) MarkProcessed(_ context.Context, _ string) error {
+	m.markProcessed = true
+	return m.markErr
+}
+func (m *mockCoordinator) Reset(_ context.Context, _ string) error {
+	m.resetCalled = true
+	return m.resetErr
+}
+func (m *mockCoordinator) ListStale(_ context.Context, _ time.Duration, _ int) ([]string, error) {
+	return nil, nil
+}
+
+// mockCoordWithPayload implements both Coordinator and PayloadStore.
+type mockCoordWithPayload struct {
+	mockCoordinator
+	storedPayloads  []*MessageData
+	storeErr        error
+	clearedPayloads []string
+}
+
+func (m *mockCoordWithPayload) StorePayload(_ context.Context, messageID string, data *MessageData) error {
+	m.storedPayloads = append(m.storedPayloads, data)
+	return m.storeErr
+}
+func (m *mockCoordWithPayload) LoadStalePayloads(_ context.Context, _ time.Duration, _ int) ([]*StaleMessage, error) {
+	return nil, nil
+}
+func (m *mockCoordWithPayload) ClearPayload(_ context.Context, messageID string) error {
+	m.clearedPayloads = append(m.clearedPayloads, messageID)
+	return nil
+}
+
+// testHandler is a simple handler that records calls.
+type testHandler[T any] struct {
+	called bool
+	err    error
+}
+
+func (h *testHandler[T]) handle(ctx context.Context, ev event.Event[T], data T) error {
+	h.called = true
+	return h.err
+}
+
+func TestMiddleware_NoEventID_PassesThrough(t *testing.T) {
+	coord := &mockCoordinator{acquireResult: true}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	wrapped := mw(handler.handle)
+
+	// Context without event ID - should pass through to handler
+	ctx := context.Background()
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called when no event ID")
+	}
+	if len(coord.acquiredMsgIDs) > 0 {
+		t.Fatal("expected no Acquire call when no event ID")
+	}
+}
+
+func TestMiddleware_AcquireFails_FailOpen(t *testing.T) {
+	coord := &mockCoordinator{acquireErr: errors.New("redis down")}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	wrapped := mw(handler.handle)
+
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called on Acquire error (fail open)")
+	}
+}
+
+func TestMiddleware_NotAcquired_Skips(t *testing.T) {
+	coord := &mockCoordinator{acquireResult: false}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	wrapped := mw(handler.handle)
+
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if handler.called {
+		t.Fatal("expected handler to NOT be called when not acquired")
+	}
+}
+
+func TestMiddleware_Acquired_CallsHandlerAndMarksProcessed(t *testing.T) {
+	coord := &mockCoordinator{acquireResult: true}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	wrapped := mw(handler.handle)
+
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called")
+	}
+	if !coord.markProcessed {
+		t.Fatal("expected MarkProcessed to be called on success")
+	}
+	if coord.resetCalled {
+		t.Fatal("expected Reset NOT to be called on success")
+	}
+}
+
+func TestMiddleware_HandlerError_ResetsState(t *testing.T) {
+	coord := &mockCoordinator{acquireResult: true}
+	handlerErr := errors.New("processing failed")
+	handler := &testHandler[string]{err: handlerErr}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	wrapped := mw(handler.handle)
+
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	err := wrapped(ctx, nil, "data")
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("expected handler error to be returned, got %v", err)
+	}
+	if coord.markProcessed {
+		t.Fatal("expected MarkProcessed NOT to be called on error")
+	}
+	if !coord.resetCalled {
+		t.Fatal("expected Reset to be called on handler error")
+	}
+}
+
+func TestMiddleware_NoPayloadInContext_NoStore(t *testing.T) {
+	coord := &mockCoordWithPayload{
+		mockCoordinator: mockCoordinator{acquireResult: true},
+	}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	wrapped := mw(handler.handle)
+
+	// Context with event ID but NO raw payload
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called")
+	}
+
+	// No raw payload in context → no StorePayload call → no ClearPayload
+	if len(coord.storedPayloads) > 0 {
+		t.Fatal("expected no StorePayload call when no raw payload in context")
+	}
+	if len(coord.clearedPayloads) > 0 {
+		t.Fatal("expected no ClearPayload call when payload was not stored")
+	}
+}
+
+func TestMiddleware_PayloadStored_ClearedOnSuccess(t *testing.T) {
+	coord := &mockCoordWithPayload{
+		mockCoordinator: mockCoordinator{acquireResult: true},
+	}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	wrapped := mw(handler.handle)
+
+	// Context with event ID AND raw payload
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	ctx = event.ContextWithRawPayload(ctx, []byte(`{"order":"abc"}`))
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called")
+	}
+
+	// Raw payload in context → StorePayload called → ClearPayload on success
+	if len(coord.storedPayloads) != 1 {
+		t.Fatalf("expected 1 StorePayload call, got %d", len(coord.storedPayloads))
+	}
+	if string(coord.storedPayloads[0].Payload) != `{"order":"abc"}` {
+		t.Fatalf("unexpected stored payload: %s", coord.storedPayloads[0].Payload)
+	}
+	if len(coord.clearedPayloads) != 1 || coord.clearedPayloads[0] != "msg-1" {
+		t.Fatalf("expected ClearPayload for msg-1, got %v", coord.clearedPayloads)
+	}
+}
+
+func TestMiddleware_PayloadStored_NotClearedOnHandlerError(t *testing.T) {
+	coord := &mockCoordWithPayload{
+		mockCoordinator: mockCoordinator{acquireResult: true},
+	}
+	handlerErr := errors.New("processing failed")
+	handler := &testHandler[string]{err: handlerErr}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	wrapped := mw(handler.handle)
+
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	ctx = event.ContextWithRawPayload(ctx, []byte(`{"order":"abc"}`))
+	err := wrapped(ctx, nil, "data")
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("expected handler error, got %v", err)
+	}
+
+	// Payload stored but handler failed:
+	// - ClearPayload NOT called (payload preserved for recovery)
+	// - Reset NOT called (would delete payload, losing the event)
+	// - State left in "processing" for RecoveryRunner to re-publish
+	if len(coord.storedPayloads) != 1 {
+		t.Fatalf("expected 1 StorePayload call, got %d", len(coord.storedPayloads))
+	}
+	if len(coord.clearedPayloads) > 0 {
+		t.Fatal("expected no ClearPayload when handler failed")
+	}
+	if coord.resetCalled {
+		t.Fatal("expected Reset NOT to be called when payload was stored (preserves recovery data)")
+	}
+}
+
+func TestMiddleware_StorePayloadFails_NoClearOnSuccess(t *testing.T) {
+	coord := &mockCoordWithPayload{
+		mockCoordinator: mockCoordinator{acquireResult: true},
+		storeErr:        errors.New("store failed"),
+	}
+	handler := &testHandler[string]{}
+
+	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	wrapped := mw(handler.handle)
+
+	// With raw payload in context, StorePayload is called but fails
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	ctx = event.ContextWithRawPayload(ctx, []byte(`{"order":"abc"}`))
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// StorePayload failed → payloadStored=false → no ClearPayload
+	if len(coord.clearedPayloads) > 0 {
+		t.Fatal("expected no ClearPayload when StorePayload failed")
+	}
+	if !coord.markProcessed {
+		t.Fatal("expected MarkProcessed on handler success")
+	}
+}
+
+func TestMiddleware_MaxPayloadSize(t *testing.T) {
+	coord := &mockCoordWithPayload{
+		mockCoordinator: mockCoordinator{acquireResult: true},
+	}
+	handler := &testHandler[string]{}
+
+	// Set max payload size very small (10 bytes)
+	mw := WorkerPoolMiddleware[string](coord, time.Minute,
+		WithPayloadRecovery(),
+		WithMaxPayloadSize(10),
+	)
+	wrapped := mw(handler.handle)
+
+	// Payload exceeds 10 bytes → skipped
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	ctx = event.ContextWithRawPayload(ctx, []byte(`{"order":"abc-very-long-payload"}`))
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called")
+	}
+	if len(coord.storedPayloads) > 0 {
+		t.Fatal("expected no StorePayload call when payload exceeds max size")
+	}
+	if !coord.markProcessed {
+		t.Fatal("expected MarkProcessed on success")
+	}
+}
+
+func TestMiddleware_CoordWithoutPayloadStore(t *testing.T) {
+	// Plain coordinator without PayloadStore
+	coord := &mockCoordinator{acquireResult: true}
+	handler := &testHandler[string]{}
+
+	// Even with WithPayloadRecovery, should work fine (just no payload storage)
+	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	wrapped := mw(handler.handle)
+
+	ctx := event.ContextWithEventID(context.Background(), "msg-1")
+	err := wrapped(ctx, nil, "data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected handler to be called")
+	}
+	if !coord.markProcessed {
+		t.Fatal("expected MarkProcessed on success")
+	}
+}

--- a/distributed/mongodb.go
+++ b/distributed/mongodb.go
@@ -2,6 +2,9 @@ package distributed
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,19 +13,30 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
-// Default collection name for state storage
-const DefaultStateCollection = "_message_state"
+const (
+	// defaultStateCollection is the default MongoDB collection name for state storage.
+	defaultStateCollection = "_message_state"
+
+	// MongoDB document status values.
+	statusProcessing = "processing"
+	statusCompleted  = "completed"
+	statusReleased   = "released"
+)
 
 // stateDocument represents a state record in MongoDB.
 type stateDocument struct {
-	ID        string    `bson:"_id"`
-	Status    string    `bson:"status"`
-	ExpiresAt time.Time `bson:"expires_at"`
-	CreatedAt time.Time `bson:"created_at"`
-	UpdatedAt time.Time `bson:"updated_at"`
+	ID        string            `bson:"_id"`
+	Status    string            `bson:"status"`
+	WorkerID  string            `bson:"worker_id,omitempty"`
+	ExpiresAt time.Time         `bson:"expires_at"`
+	CreatedAt time.Time         `bson:"created_at"`
+	UpdatedAt time.Time         `bson:"updated_at"`
+	Payload   []byte            `bson:"payload,omitempty"`
+	Metadata  map[string]string `bson:"metadata,omitempty"`
+	EventName string            `bson:"event_name,omitempty"`
 }
 
-// MongoStateManager implements StateManager using MongoDB for distributed deployments.
+// MongoStateManager implements Coordinator and PayloadStore using MongoDB for distributed deployments.
 //
 // MongoStateManager uses MongoDB's atomic findOneAndUpdate with conditional filters
 // for race-condition-free message state management. This is ideal when you're already
@@ -39,7 +53,7 @@ type stateDocument struct {
 // Features:
 //   - Atomic state acquisition using findOneAndUpdate with upsert
 //   - Automatic expiration using MongoDB TTL indexes
-//   - Configurable database and collection for multi-tenant deployments
+//   - Configurable collection for multi-tenant deployments
 //   - Optional capped collection for high-throughput scenarios
 //   - Supports MongoDB replica sets and sharded clusters
 //
@@ -50,6 +64,7 @@ type stateDocument struct {
 //	{
 //	    "_id": "msg-123",           // Message ID
 //	    "status": "processing",     // "processing" or "completed"
+//	    "worker_id": "a1b2c3...",   // Unique per Acquire call
 //	    "expires_at": ISODate(...), // TTL expiration
 //	    "created_at": ISODate(...),
 //	    "updated_at": ISODate(...)
@@ -67,8 +82,10 @@ type stateDocument struct {
 //
 // For high-throughput scenarios, you can use a capped collection:
 //
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCapped(100*1024*1024, 100000) // 100MB, 100k docs max
+//	sm := distributed.NewMongoStateManager(db,
+//	    distributed.WithCollection("state_buffer"),
+//	    distributed.WithCapped(100*1024*1024, 100000), // 100MB, 100k docs max
+//	)
 //	sm.CreateCollection(ctx) // Creates capped collection
 //
 // IMPORTANT: Capped collections have limitations:
@@ -83,18 +100,15 @@ type stateDocument struct {
 //	sm.EnsureIndexes(ctx)
 //
 //	// With custom collection
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCollection("my_states")
-//
-//	// With custom database and collection
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithDatabase(client.Database("other_db")).
-//	    WithCollection("my_states")
+//	sm := distributed.NewMongoStateManager(db,
+//	    distributed.WithCollection("my_states"),
+//	)
 //
 //	// With capped collection for high throughput
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCollection("state_buffer").
-//	    WithCapped(100*1024*1024, 0) // 100MB, unlimited docs
+//	sm := distributed.NewMongoStateManager(db,
+//	    distributed.WithCollection("state_buffer"),
+//	    distributed.WithCapped(100*1024*1024, 0), // 100MB, unlimited docs
+//	)
 //	sm.CreateCollection(ctx)
 //
 //	// Use with middleware
@@ -118,9 +132,9 @@ type MongoStateManager struct {
 //
 // Parameters:
 //   - db: A connected MongoDB database
+//   - opts: Optional configuration (WithCollection, WithCapped, WithCompletedTTL)
 //
 // Returns a configured MongoStateManager ready for use.
-// Use WithDatabase() and WithCollection() to customize storage location.
 //
 // Example:
 //
@@ -128,102 +142,30 @@ type MongoStateManager struct {
 //	sm := distributed.NewMongoStateManager(db)
 //
 //	// With custom collection
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCollection("worker_state")
+//	sm := distributed.NewMongoStateManager(db,
+//	    distributed.WithCollection("worker_state"),
+//	)
 //
 //	// Don't forget to create indexes for TTL cleanup
 //	sm.EnsureIndexes(ctx)
-func NewMongoStateManager(db *mongo.Database) *MongoStateManager {
-	opts := defaultStateOptions()
+func NewMongoStateManager(db *mongo.Database, opts ...Option) *MongoStateManager {
+	o := defaultStateOptions()
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	collName := defaultStateCollection
+	if o.collectionName != "" {
+		collName = o.collectionName
+	}
 
 	return &MongoStateManager{
-		collection:    db.Collection(DefaultStateCollection),
-		completionTTL: opts.completionTTL,
+		collection:    db.Collection(collName),
+		completionTTL: o.completionTTL,
+		capped:        o.capped,
+		cappedSize:    o.cappedSize,
+		cappedMaxDocs: o.cappedMaxDocs,
 	}
-}
-
-// WithDatabase sets a different database for state storage.
-//
-// Use this when you want to store states in a different database than
-// the one used for your main application data.
-//
-// Example:
-//
-//	sm := distributed.NewMongoStateManager(appDB).
-//	    WithDatabase(client.Database("state_db"))
-func (s *MongoStateManager) WithDatabase(db *mongo.Database) *MongoStateManager {
-	s.collection = db.Collection(s.collection.Name())
-	return s
-}
-
-// WithCollection sets a custom collection name for state storage.
-//
-// Default: "_message_state"
-//
-// Example:
-//
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCollection("worker_state")
-func (s *MongoStateManager) WithCollection(name string) *MongoStateManager {
-	s.collection = s.collection.Database().Collection(name)
-	return s
-}
-
-// WithCompletedTTL sets how long to remember completed messages.
-//
-// After a message is completed, its ID is remembered for this duration
-// to prevent reprocessing if the same message is delivered again.
-//
-// Default: 24 hours
-func (s *MongoStateManager) WithCompletedTTL(ttl time.Duration) *MongoStateManager {
-	if ttl > 0 {
-		s.completionTTL = ttl
-	}
-	return s
-}
-
-// Collection returns the underlying MongoDB collection.
-func (s *MongoStateManager) Collection() *mongo.Collection {
-	return s.collection
-}
-
-// WithCapped enables capped collection mode for high-throughput scenarios.
-//
-// Capped collections are fixed-size collections that automatically remove
-// the oldest documents when the size limit is reached. This provides:
-//   - Very high write throughput
-//   - Automatic cleanup without TTL indexes
-//   - Predictable storage size
-//
-// Parameters:
-//   - sizeBytes: Maximum collection size in bytes (required, minimum 4096)
-//   - maxDocs: Maximum number of documents (0 = unlimited, size-based only)
-//
-// IMPORTANT LIMITATIONS:
-//   - Reset() becomes a no-op (MongoDB doesn't allow deletes in capped collections)
-//   - No TTL index support (EnsureIndexes skips TTL index for capped collections)
-//   - Failed states wait for size-based removal, not time-based expiration
-//   - Updates cannot increase document size
-//
-// After calling WithCapped(), you must call CreateCollection() to create
-// the capped collection before using the state manager.
-//
-// Example:
-//
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCollection("state_buffer").
-//	    WithCapped(100*1024*1024, 100000) // 100MB, max 100k docs
-//	sm.CreateCollection(ctx) // Creates the capped collection
-func (s *MongoStateManager) WithCapped(sizeBytes int64, maxDocs int64) *MongoStateManager {
-	s.capped = true
-	s.cappedSize = sizeBytes
-	s.cappedMaxDocs = maxDocs
-	return s
-}
-
-// IsCapped returns true if capped collection mode is enabled.
-func (s *MongoStateManager) IsCapped() bool {
-	return s.capped
 }
 
 // CreateCollection creates the state collection.
@@ -236,8 +178,9 @@ func (s *MongoStateManager) IsCapped() bool {
 //
 // Example:
 //
-//	sm := distributed.NewMongoStateManager(db).
-//	    WithCapped(100*1024*1024, 0)
+//	sm := distributed.NewMongoStateManager(db,
+//	    distributed.WithCapped(100*1024*1024, 0),
+//	)
 //	if err := sm.CreateCollection(ctx); err != nil {
 //	    log.Fatal("failed to create collection:", err)
 //	}
@@ -279,19 +222,22 @@ func isNamespaceExistsError(err error) bool {
 	return false
 }
 
+// generateWorkerID creates a unique identifier for an Acquire call.
+func generateWorkerID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
 // Acquire atomically transitions a message to "processing" state using MongoDB findOneAndUpdate.
 //
 // The transition is atomic: the update only succeeds if:
 //   - The document doesn't exist (new state), OR
 //   - The existing state has expired (TTL passed)
 //
-// MongoDB query:
-//
-//	findOneAndUpdate(
-//	    {$or: [{_id: msgID, expires_at: {$lt: now}}, {_id: msgID, status: {$exists: false}}]},
-//	    {$set: {status: "processing", expires_at: now+ttl, ...}},
-//	    {upsert: true}
-//	)
+// Each Acquire call generates a unique worker_id stored in the document.
+// After the atomic update, the returned document's worker_id is compared
+// against the caller's to confirm ownership (deterministic, no timing races).
 //
 // Parameters:
 //   - ctx: Context for cancellation
@@ -305,19 +251,20 @@ func isNamespaceExistsError(err error) bool {
 func (s *MongoStateManager) Acquire(ctx context.Context, messageID string, ttl time.Duration) (bool, error) {
 	now := time.Now()
 	expiresAt := now.Add(ttl)
+	workerID := generateWorkerID()
 
-	// Atomic upsert: only succeeds if document doesn't exist OR has expired
 	filter := bson.M{
 		"_id": messageID,
 		"$or": []bson.M{
-			{"expires_at": bson.M{"$lt": now}},   // Expired state
-			{"status": bson.M{"$exists": false}}, // New document (shouldn't happen with upsert, but safe)
+			{"expires_at": bson.M{"$lt": now}},
+			{"status": bson.M{"$exists": false}},
 		},
 	}
 
 	update := bson.M{
 		"$set": bson.M{
-			"status":     "processing",
+			"status":     statusProcessing,
+			"worker_id":  workerID,
 			"expires_at": expiresAt,
 			"updated_at": now,
 		},
@@ -335,57 +282,25 @@ func (s *MongoStateManager) Acquire(ctx context.Context, messageID string, ttl t
 
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
-			// Document exists with active state - another worker acquired it
 			return false, nil
 		}
-		if err == mongo.ErrNoDocuments {
-			// This can happen if the filter didn't match (active state exists)
-			// Check if document exists with active status
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			// ErrNoDocuments with upsert=true means the filter didn't match
+			// (active non-expired state exists) AND a concurrent insert on
+			// the _id unique index prevented the upsert. Verify the existing
+			// state is still active, otherwise retry with a direct insert.
 			var existing stateDocument
 			findErr := s.collection.FindOne(ctx, bson.M{"_id": messageID}).Decode(&existing)
 			if findErr == nil && existing.ExpiresAt.After(now) {
-				// Active state exists
 				return false, nil
 			}
-			// No document or expired - try insert
-			return s.tryInsert(ctx, messageID, ttl)
+			return s.tryInsert(ctx, messageID, ttl, workerID)
 		}
 		return false, fmt.Errorf("mongodb find and update: %w", err)
 	}
 
-	// Check if we actually got the state (status is processing and our expiry)
-	// Note: MongoDB stores times with millisecond precision, so we truncate before comparing
-	// to avoid false negatives due to nanosecond differences after round-trip.
-	if result.Status == "processing" && result.ExpiresAt.Truncate(time.Millisecond).Equal(expiresAt.Truncate(time.Millisecond)) {
-		return true, nil
-	}
-
-	// Someone else has the state
-	return false, nil
-}
-
-// tryInsert attempts a direct insert when findOneAndUpdate fails.
-func (s *MongoStateManager) tryInsert(ctx context.Context, messageID string, ttl time.Duration) (bool, error) {
-	now := time.Now()
-
-	doc := stateDocument{
-		ID:        messageID,
-		Status:    "processing",
-		ExpiresAt: now.Add(ttl),
-		CreatedAt: now,
-		UpdatedAt: now,
-	}
-
-	_, err := s.collection.InsertOne(ctx, doc)
-	if err != nil {
-		if mongo.IsDuplicateKeyError(err) {
-			// Another worker acquired it
-			return false, nil
-		}
-		return false, fmt.Errorf("mongodb insert: %w", err)
-	}
-
-	return true, nil
+	// Check worker_id to confirm we are the one who acquired the state
+	return result.WorkerID == workerID, nil
 }
 
 // MarkProcessed transitions a message to "completed" state.
@@ -405,7 +320,7 @@ func (s *MongoStateManager) MarkProcessed(ctx context.Context, messageID string)
 	filter := bson.M{"_id": messageID}
 	update := bson.M{
 		"$set": bson.M{
-			"status":     "completed",
+			"status":     statusCompleted,
 			"expires_at": now.Add(s.completionTTL),
 			"updated_at": now,
 		},
@@ -442,7 +357,7 @@ func (s *MongoStateManager) Reset(ctx context.Context, messageID string) error {
 		filter := bson.M{"_id": messageID}
 		update := bson.M{
 			"$set": bson.M{
-				"status":     "released",
+				"status":     statusReleased,
 				"expires_at": now, // Set to now so it's immediately reacquirable
 				"updated_at": now,
 			},
@@ -482,7 +397,7 @@ func (s *MongoStateManager) ListStale(ctx context.Context, staleTimeout time.Dur
 	cutoff := time.Now().Add(-staleTimeout)
 
 	filter := bson.M{
-		"status":     "processing",
+		"status":     statusProcessing,
 		"updated_at": bson.M{"$lt": cutoff},
 	}
 
@@ -527,19 +442,25 @@ func (s *MongoStateManager) ListStale(ctx context.Context, staleTimeout time.Dur
 //
 // Returns the number of states reset.
 func (s *MongoStateManager) ResetStale(ctx context.Context, staleTimeout time.Duration, limit int) (int64, error) {
-	cutoff := time.Now().Add(-staleTimeout)
-
-	filter := bson.M{
-		"status":     "processing",
-		"updated_at": bson.M{"$lt": cutoff},
+	// Use ListStale to get the bounded set of stale IDs, then reset them.
+	// This ensures the limit is always respected (MongoDB's DeleteMany and
+	// UpdateMany do not natively support a limit clause).
+	stale, err := s.ListStale(ctx, staleTimeout, limit)
+	if err != nil {
+		return 0, err
 	}
+	if len(stale) == 0 {
+		return 0, nil
+	}
+
+	filter := bson.M{"_id": bson.M{"$in": stale}}
 
 	if s.capped {
 		// Capped collections don't support deletes, update status instead
 		now := time.Now()
 		update := bson.M{
 			"$set": bson.M{
-				"status":     "released",
+				"status":     statusReleased,
 				"expires_at": now,
 				"updated_at": now,
 			},
@@ -556,6 +477,115 @@ func (s *MongoStateManager) ResetStale(ctx context.Context, staleTimeout time.Du
 		return 0, fmt.Errorf("mongodb delete stale: %w", err)
 	}
 	return result.DeletedCount, nil
+}
+
+// tryInsert attempts a direct insert when findOneAndUpdate fails.
+func (s *MongoStateManager) tryInsert(ctx context.Context, messageID string, ttl time.Duration, workerID string) (bool, error) {
+	now := time.Now()
+
+	doc := stateDocument{
+		ID:        messageID,
+		Status:    statusProcessing,
+		WorkerID:  workerID,
+		ExpiresAt: now.Add(ttl),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	_, err := s.collection.InsertOne(ctx, doc)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("mongodb insert: %w", err)
+	}
+
+	return true, nil
+}
+
+// StorePayload persists message payload alongside state for recovery re-publishing.
+// Uses $set to atomically update the same document that Acquire created.
+func (s *MongoStateManager) StorePayload(ctx context.Context, messageID string, data *MessageData) error {
+	if data == nil || len(data.Payload) == 0 {
+		return nil
+	}
+
+	setFields := bson.M{
+		"payload": data.Payload,
+	}
+	if len(data.Metadata) > 0 {
+		setFields["metadata"] = data.Metadata
+	}
+	if data.EventName != "" {
+		setFields["event_name"] = data.EventName
+	}
+
+	_, err := s.collection.UpdateOne(ctx, bson.M{"_id": messageID}, bson.M{"$set": setFields})
+	if err != nil {
+		return fmt.Errorf("mongodb store payload: %w", err)
+	}
+	return nil
+}
+
+// LoadStalePayloads returns stale messages that have stored payload.
+func (s *MongoStateManager) LoadStalePayloads(ctx context.Context, staleTimeout time.Duration, limit int) ([]*StaleMessage, error) {
+	cutoff := time.Now().Add(-staleTimeout)
+
+	// Only return entries that have payload stored
+	filter := bson.M{
+		"status":     statusProcessing,
+		"updated_at": bson.M{"$lt": cutoff},
+		"payload":    bson.M{"$exists": true},
+	}
+
+	opts := options.Find()
+	if limit > 0 {
+		opts.SetLimit(int64(limit))
+	}
+
+	cursor, err := s.collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("mongodb find stale payloads: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var results []*StaleMessage
+	for cursor.Next(ctx) {
+		var doc stateDocument
+		if err := cursor.Decode(&doc); err != nil {
+			continue
+		}
+		results = append(results, &StaleMessage{
+			MessageID: doc.ID,
+			Data: MessageData{
+				Payload:   doc.Payload,
+				Metadata:  doc.Metadata,
+				EventName: doc.EventName,
+			},
+			CreatedAt: doc.CreatedAt,
+		})
+	}
+
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("mongodb cursor: %w", err)
+	}
+
+	return results, nil
+}
+
+// ClearPayload removes stored payload for a message.
+func (s *MongoStateManager) ClearPayload(ctx context.Context, messageID string) error {
+	_, err := s.collection.UpdateOne(ctx, bson.M{"_id": messageID}, bson.M{
+		"$unset": bson.M{
+			"payload":    "",
+			"metadata":   "",
+			"event_name": "",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("mongodb clear payload: %w", err)
+	}
+	return nil
 }
 
 // EnsureIndexes creates the necessary indexes for the state collection.
@@ -609,14 +639,24 @@ func (s *MongoStateManager) Indexes() []mongo.IndexModel {
 		}
 	}
 
-	// Regular collection with TTL index
+	// Regular collection with TTL index and compound index for stale detection
 	return []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "expires_at", Value: 1}},
 			Options: options.Index().SetExpireAfterSeconds(0),
 		},
+		{
+			Keys: bson.D{
+				{Key: "status", Value: 1},
+				{Key: "updated_at", Value: 1},
+			},
+		},
 	}
 }
 
-// Compile-time interface check
-var _ StateManager = (*MongoStateManager)(nil)
+// Compile-time interface checks
+var (
+	_ Coordinator   = (*MongoStateManager)(nil)
+	_ PayloadStore  = (*MongoStateManager)(nil)
+	_ StaleResetter = (*MongoStateManager)(nil)
+)

--- a/distributed/mongodb_integration_test.go
+++ b/distributed/mongodb_integration_test.go
@@ -39,9 +39,10 @@ func setupMongoStateManager(t *testing.T) (*MongoStateManager, func()) {
 	collName := "state_" + time.Now().Format("20060102150405")
 	db := client.Database(dbName)
 
-	sm := NewMongoStateManager(db).
-		WithCollection(collName).
-		WithCompletedTTL(time.Hour)
+	sm := NewMongoStateManager(db,
+		WithCollection(collName),
+		WithCompletedTTL(time.Hour),
+	)
 
 	if err := sm.EnsureIndexes(context.Background()); err != nil {
 		t.Fatalf("failed to ensure indexes: %v", err)
@@ -321,4 +322,96 @@ func TestMongoStateManager_Integration_RecoveryRunner(t *testing.T) {
 	if !acquired {
 		t.Error("expected acquisition to succeed after recovery")
 	}
+}
+
+func TestMongoStateManager_Integration_PayloadRecovery(t *testing.T) {
+	sm, cleanup := setupMongoStateManager(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Track re-published events
+	pub := &integrationMockPublisher{}
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+		WithPublisher(pub),
+	)
+
+	// Acquire and store payload (simulates middleware with payload storage)
+	acquired, err := sm.Acquire(ctx, "payload-1", time.Hour)
+	if err != nil || !acquired {
+		t.Fatalf("expected acquisition to succeed: acquired=%v err=%v", acquired, err)
+	}
+	err = sm.StorePayload(ctx, "payload-1", &MessageData{
+		Payload:   []byte(`{"order":"abc"}`),
+		Metadata:  map[string]string{"source": "integration-test"},
+		EventName: "order.created",
+	})
+	if err != nil {
+		t.Fatalf("StorePayload failed: %v", err)
+	}
+
+	// Acquire another message without payload (should be reset, not re-published)
+	sm.Acquire(ctx, "no-payload-1", time.Hour)
+
+	// Wait for both to become stale
+	time.Sleep(100 * time.Millisecond)
+
+	// Phase 1: re-publish payload entry, Phase 2: reset no-payload entry
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	if recovered != 2 {
+		t.Fatalf("expected 2 recovered, got %d", recovered)
+	}
+
+	// Publisher should have been called once (for payload-1)
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].eventName != "order.created" {
+		t.Errorf("expected event name 'order.created', got %q", pub.calls[0].eventName)
+	}
+	if string(pub.calls[0].payload) != `{"order":"abc"}` {
+		t.Errorf("unexpected payload: %s", pub.calls[0].payload)
+	}
+
+	// payload-1 should be marked as processed (not acquirable)
+	acquired, _ = sm.Acquire(ctx, "payload-1", time.Hour)
+	if acquired {
+		t.Error("expected payload-1 to NOT be acquirable after recovery (marked processed)")
+	}
+
+	// no-payload-1 should be acquirable after reset
+	acquired, _ = sm.Acquire(ctx, "no-payload-1", time.Hour)
+	if !acquired {
+		t.Error("expected no-payload-1 to be acquirable after reset")
+	}
+}
+
+// integrationMockPublisher records published events for test verification.
+// Uses mockPublishCall to avoid collision with payload_test.go types
+// (both compile together under -tags=integration).
+type integrationMockPublisher struct {
+	calls []mockPublishCall
+}
+
+type mockPublishCall struct {
+	eventName string
+	eventID   string
+	payload   []byte
+	metadata  map[string]string
+}
+
+func (p *integrationMockPublisher) Send(_ context.Context, eventName, eventID string, payload []byte, metadata map[string]string) error {
+	p.calls = append(p.calls, mockPublishCall{
+		eventName: eventName,
+		eventID:   eventID,
+		payload:   payload,
+		metadata:  metadata,
+	})
+	return nil
 }

--- a/distributed/mongodb_test.go
+++ b/distributed/mongodb_test.go
@@ -1,0 +1,127 @@
+package distributed
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func TestGenerateWorkerID(t *testing.T) {
+	// Generate two IDs and verify they are unique and have correct length
+	id1 := generateWorkerID()
+	id2 := generateWorkerID()
+
+	if id1 == "" {
+		t.Fatal("expected non-empty worker ID")
+	}
+	if id2 == "" {
+		t.Fatal("expected non-empty worker ID")
+	}
+	// 12 random bytes → 24 hex characters
+	if len(id1) != 24 {
+		t.Fatalf("expected worker ID length 24, got %d", len(id1))
+	}
+	if id1 == id2 {
+		t.Fatal("expected unique worker IDs")
+	}
+}
+
+func TestIsNamespaceExistsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "namespace exists error (code 48)",
+			err:      mongo.CommandError{Code: 48, Message: "collection already exists"},
+			expected: true,
+		},
+		{
+			name:     "different command error",
+			err:      mongo.CommandError{Code: 11000, Message: "duplicate key"},
+			expected: false,
+		},
+		{
+			name:     "non-command error",
+			err:      mongo.ErrNoDocuments,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNamespaceExistsError(tt.err); got != tt.expected {
+				t.Errorf("isNamespaceExistsError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMongoStateManager_Indexes_Regular(t *testing.T) {
+	// nil db is fine - we're only testing Indexes() which doesn't call MongoDB
+	sm := &MongoStateManager{capped: false}
+	indexes := sm.Indexes()
+
+	if len(indexes) != 2 {
+		t.Fatalf("expected 2 indexes for regular collection, got %d", len(indexes))
+	}
+
+	// First index: TTL index on expires_at
+	idx0 := indexes[0]
+	if idx0.Options == nil {
+		t.Fatal("expected TTL index to have options")
+	}
+
+	// Second index: compound index on (status, updated_at) for stale queries
+	idx1 := indexes[1]
+	if idx1.Options != nil {
+		t.Fatal("expected compound index to have no options (not TTL)")
+	}
+}
+
+func TestMongoStateManager_Indexes_Capped(t *testing.T) {
+	sm := &MongoStateManager{capped: true}
+	indexes := sm.Indexes()
+
+	if len(indexes) != 2 {
+		t.Fatalf("expected 2 indexes for capped collection, got %d", len(indexes))
+	}
+
+	// Capped collections don't support TTL indexes
+	for i, idx := range indexes {
+		if idx.Options != nil {
+			t.Fatalf("expected capped index %d to have no TTL options", i)
+		}
+	}
+}
+
+func TestMongoStatusConstants(t *testing.T) {
+	// Verify constants have expected values (guards against accidental changes)
+	if statusProcessing != "processing" {
+		t.Errorf("statusProcessing = %q, want %q", statusProcessing, "processing")
+	}
+	if statusCompleted != "completed" {
+		t.Errorf("statusCompleted = %q, want %q", statusCompleted, "completed")
+	}
+	if statusReleased != "released" {
+		t.Errorf("statusReleased = %q, want %q", statusReleased, "released")
+	}
+	if defaultStateCollection != "_message_state" {
+		t.Errorf("defaultStateCollection = %q, want %q", defaultStateCollection, "_message_state")
+	}
+}
+
+func TestMongoStateManager_CreateCollection_NonCapped(t *testing.T) {
+	// Non-capped CreateCollection is a no-op
+	sm := &MongoStateManager{capped: false}
+	err := sm.CreateCollection(t.Context())
+	if err != nil {
+		t.Fatalf("expected nil error for non-capped CreateCollection, got %v", err)
+	}
+}

--- a/distributed/payload_test.go
+++ b/distributed/payload_test.go
@@ -1,0 +1,701 @@
+package distributed
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/transport/channel"
+)
+
+func TestMemoryCoordinator_AcquireAndStorePayload(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	// Acquire state
+	acquired, err := sm.Acquire(ctx, "msg-1", time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected acquisition to succeed")
+	}
+
+	// Store payload separately
+	data := &MessageData{
+		Payload:   []byte(`{"key":"value"}`),
+		Metadata:  map[string]string{"source": "test"},
+		EventName: "order.created",
+	}
+	if err := sm.StorePayload(ctx, "msg-1", data); err != nil {
+		t.Fatalf("unexpected StorePayload error: %v", err)
+	}
+
+	// Second acquisition for same message should fail
+	acquired, err = sm.Acquire(ctx, "msg-1", time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if acquired {
+		t.Fatal("expected second acquisition to fail")
+	}
+
+	// Different message should succeed
+	acquired, err = sm.Acquire(ctx, "msg-2", time.Minute)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("expected different message acquisition to succeed")
+	}
+}
+
+func TestMemoryCoordinator_Acquire_Expiry(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	// Acquire with very short TTL
+	acquired, _ := sm.Acquire(ctx, "msg-1", 10*time.Millisecond)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed")
+	}
+
+	// Wait for expiry
+	time.Sleep(20 * time.Millisecond)
+
+	// Should be acquirable again
+	acquired, _ = sm.Acquire(ctx, "msg-1", time.Minute)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed after expiry")
+	}
+}
+
+func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	// Acquire with payload
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		EventName: "order.created",
+	})
+
+	// Acquire without payload (regular acquire)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+
+	// Acquire and complete (should not appear in stale)
+	sm.Acquire(ctx, "msg-3", time.Hour)
+	sm.StorePayload(ctx, "msg-3", &MessageData{Payload: []byte(`completed`)})
+	sm.MarkProcessed(ctx, "msg-3")
+
+	// Make processing entries stale
+	sm.mu.Lock()
+	for id, entry := range sm.states {
+		if id != "msg-3" {
+			entry.updatedAt = time.Now().Add(-5 * time.Minute)
+		}
+	}
+	sm.mu.Unlock()
+
+	// LoadStalePayloads should only return entries WITH payload
+	stale, err := sm.LoadStalePayloads(ctx, time.Minute, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should find only msg-1 (has payload and stale), not msg-2 (no payload) or msg-3 (completed)
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale entry with payload, got %d", len(stale))
+	}
+
+	if stale[0].MessageID != "msg-1" {
+		t.Errorf("expected message ID 'msg-1', got %q", stale[0].MessageID)
+	}
+	if !stale[0].HasPayload() {
+		t.Error("expected payload to be present")
+	}
+	if stale[0].Data.EventName != "order.created" {
+		t.Errorf("expected event name 'order.created', got %q", stale[0].Data.EventName)
+	}
+
+	// Test limit
+	sm.Acquire(ctx, "msg-4", time.Hour)
+	sm.StorePayload(ctx, "msg-4", &MessageData{Payload: []byte(`another`)})
+	sm.mu.Lock()
+	sm.states["msg-4"].updatedAt = time.Now().Add(-5 * time.Minute)
+	sm.mu.Unlock()
+
+	stale, err = sm.LoadStalePayloads(ctx, time.Minute, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale with limit, got %d", len(stale))
+	}
+}
+
+func TestMemoryPayloadStore_ClearPayload(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"key":"value"}`),
+		EventName: "test.event",
+	})
+
+	// Verify payload is stored
+	sm.mu.RLock()
+	entry := sm.states["msg-1"]
+	if entry.payload == nil {
+		t.Fatal("expected payload to be stored")
+	}
+	sm.mu.RUnlock()
+
+	// Clear payload
+	if err := sm.ClearPayload(ctx, "msg-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify payload is cleared
+	sm.mu.RLock()
+	entry = sm.states["msg-1"]
+	if entry.payload != nil {
+		t.Fatal("expected payload to be cleared after ClearPayload")
+	}
+	sm.mu.RUnlock()
+}
+
+func TestStaleMessage_HasPayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      StaleMessage
+		expected bool
+	}{
+		{
+			name:     "with payload",
+			msg:      StaleMessage{Data: MessageData{Payload: []byte(`data`)}},
+			expected: true,
+		},
+		{
+			name:     "empty payload",
+			msg:      StaleMessage{Data: MessageData{Payload: []byte{}}},
+			expected: false,
+		},
+		{
+			name:     "nil payload",
+			msg:      StaleMessage{Data: MessageData{}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.msg.HasPayload(); got != tt.expected {
+				t.Errorf("HasPayload() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCompileTimeChecks(t *testing.T) {
+	// Verify interface implementations
+	var _ Coordinator = (*MemoryStateManager)(nil)
+	var _ PayloadStore = (*MemoryStateManager)(nil)
+}
+
+// mockPublisher records Send calls for testing.
+type mockPublisher struct {
+	calls []publishCall
+}
+
+type publishCall struct {
+	eventName string
+	eventID   string
+	payload   []byte
+	metadata  map[string]string
+}
+
+func (m *mockPublisher) Send(_ context.Context, eventName, eventID string, payload []byte, metadata map[string]string) error {
+	m.calls = append(m.calls, publishCall{
+		eventName: eventName,
+		eventID:   eventID,
+		payload:   payload,
+		metadata:  metadata,
+	})
+	return nil
+}
+
+func TestRecoveryRunner_BasicReset(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	// No Publisher → basic reset mode
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+	)
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+	time.Sleep(60 * time.Millisecond)
+
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recovered != 2 {
+		t.Fatalf("expected 2 recovered, got %d", recovered)
+	}
+
+	// Both should be acquirable again after reset
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Hour)
+	if !acquired {
+		t.Fatal("expected msg-1 to be acquirable after reset")
+	}
+	acquired, _ = sm.Acquire(ctx, "msg-2", time.Hour)
+	if !acquired {
+		t.Fatal("expected msg-2 to be acquirable after reset")
+	}
+}
+
+func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	pub := &mockPublisher{}
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+		WithPublisher(pub),
+	)
+
+	// msg-1: has payload (Phase 1 re-publishes)
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		EventName: "order.created",
+	})
+
+	// msg-2: has payload (Phase 1 re-publishes)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+	sm.StorePayload(ctx, "msg-2", &MessageData{
+		Payload:   []byte(`{"order":2}`),
+		EventName: "order.created",
+	})
+
+	// msg-3: no payload (Phase 2 resets)
+	sm.Acquire(ctx, "msg-3", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	if recovered != 3 {
+		t.Fatalf("expected 3 recovered, got %d", recovered)
+	}
+
+	// Publisher should have 2 calls (msg-1 and msg-2)
+	if len(pub.calls) != 2 {
+		t.Fatalf("expected 2 publish calls, got %d", len(pub.calls))
+	}
+
+	// msg-3 should be acquirable (was reset in Phase 2)
+	acquired, _ := sm.Acquire(ctx, "msg-3", time.Hour)
+	if !acquired {
+		t.Fatal("expected msg-3 to be acquirable after Phase 2 reset")
+	}
+}
+
+func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(0), // No limit
+	)
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+	sm.Acquire(ctx, "msg-3", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	// All 3 should be recovered with no batch limit
+	if recovered != 3 {
+		t.Fatalf("expected 3 recovered, got %d", recovered)
+	}
+}
+
+func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	pub := &mockPublisher{}
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+		WithPublisher(pub),
+	)
+
+	// Acquire and store payload
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		Metadata:  map[string]string{"source": "test"},
+		EventName: "order.created",
+	})
+
+	// Acquire without payload (should be reset, not re-published)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// msg-1 re-published via Publisher, msg-2 reset via StaleResetter
+	if recovered != 2 {
+		t.Fatalf("expected 2 recovered, got %d", recovered)
+	}
+
+	// Publisher should have been called once (for msg-1)
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].eventName != "order.created" {
+		t.Errorf("expected event name 'order.created', got %q", pub.calls[0].eventName)
+	}
+	if string(pub.calls[0].payload) != `{"order":1}` {
+		t.Errorf("unexpected payload: %s", pub.calls[0].payload)
+	}
+
+	// msg-1 should be marked as processed (not reset)
+	sm.mu.RLock()
+	entry, exists := sm.states["msg-1"]
+	sm.mu.RUnlock()
+	if !exists {
+		t.Fatal("expected msg-1 state to still exist (marked processed)")
+	}
+	if entry.state != stateCompleted {
+		t.Fatalf("expected msg-1 state to be completed, got %d", entry.state)
+	}
+
+	// msg-2 should be acquirable after reset
+	acquired, _ := sm.Acquire(ctx, "msg-2", time.Hour)
+	if !acquired {
+		t.Fatal("expected msg-2 to be acquirable after reset")
+	}
+}
+
+func TestRecoveryRunner_PublishFailure_SkipsEntry(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	// Publisher that always fails
+	failPub := &failingPublisher{err: errors.New("publish failed")}
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithPublisher(failPub),
+	)
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		EventName: "order.created",
+	})
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Phase 1 should skip the entry (publish failed), Phase 2 should NOT
+	// reset it because it was handled by Phase 1 (in the exclusion set)
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	// No entries recovered — publish failed, and the entry is excluded from Phase 2
+	if recovered != 0 {
+		t.Fatalf("expected 0 recovered (publish failed), got %d", recovered)
+	}
+}
+
+// failingPublisher always returns an error.
+type failingPublisher struct {
+	err error
+}
+
+func (p *failingPublisher) Send(_ context.Context, _, _ string, _ []byte, _ map[string]string) error {
+	return p.err
+}
+
+func TestRecoveryRunner_WithRealBus(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a real bus with channel transport
+	ch := channel.New()
+	bus, err := event.NewBus("test-recovery", event.WithTransport(ch))
+	if err != nil {
+		t.Fatalf("failed to create bus: %v", err)
+	}
+	defer bus.Close(ctx)
+
+	if err := ch.RegisterEvent(ctx, "order.created"); err != nil {
+		t.Fatalf("failed to register event: %v", err)
+	}
+
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	// Bus satisfies Publisher interface
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+		WithPublisher(bus),
+	)
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		Metadata:  map[string]string{"source": "test"},
+		EventName: "order.created",
+	})
+
+	time.Sleep(60 * time.Millisecond)
+
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("expected 1 recovered, got %d", recovered)
+	}
+
+	sm.mu.RLock()
+	entry, exists := sm.states["msg-1"]
+	sm.mu.RUnlock()
+	if !exists {
+		t.Fatal("expected msg-1 state to still exist (marked processed)")
+	}
+	if entry.state != stateCompleted {
+		t.Fatalf("expected msg-1 state to be completed, got %d", entry.state)
+	}
+}
+
+func TestBus_SupportsRedelivery(t *testing.T) {
+	ctx := context.Background()
+
+	ch := channel.New()
+	bus, err := event.NewBus("test-redelivery", event.WithTransport(ch))
+	if err != nil {
+		t.Fatalf("failed to create bus: %v", err)
+	}
+	defer bus.Close(ctx)
+
+	if bus.SupportsRedelivery() {
+		t.Error("channel transport should not support redelivery")
+	}
+}
+
+func TestPoolOption_WithPayloadRecovery(t *testing.T) {
+	o := &poolOptions{}
+
+	if o.storePayload != nil {
+		t.Fatal("expected storePayload to be nil by default")
+	}
+
+	WithPayloadRecovery()(o)
+	if o.storePayload == nil || !*o.storePayload {
+		t.Fatal("expected storePayload to be true after WithPayloadRecovery")
+	}
+}
+
+func TestPoolOption_WithMaxPayloadSize(t *testing.T) {
+	o := &poolOptions{}
+
+	if o.maxPayloadSize != 0 {
+		t.Fatal("expected maxPayloadSize to be 0 by default")
+	}
+
+	WithMaxPayloadSize(1024 * 1024)(o)
+	if o.maxPayloadSize != 1024*1024 {
+		t.Fatalf("expected maxPayloadSize 1048576, got %d", o.maxPayloadSize)
+	}
+
+	WithMaxPayloadSize(0)(o)
+	if o.maxPayloadSize != 1024*1024 {
+		t.Fatal("expected maxPayloadSize unchanged with 0")
+	}
+	WithMaxPayloadSize(-1)(o)
+	if o.maxPayloadSize != 1024*1024 {
+		t.Fatal("expected maxPayloadSize unchanged with -1")
+	}
+}
+
+func TestRecoveryMetrics_NilSafe(t *testing.T) {
+	ctx := context.Background()
+	var m *RecoveryMetrics
+	m.recordRecovered(ctx)
+	m.recordRecoveredN(ctx, 5)
+	m.recordRepublished(ctx, "test")
+	m.recordReset(ctx)
+	m.recordResetN(ctx, 3)
+	m.recordError(ctx, "acquire")
+	m.recordSkipped(ctx, "bus_not_found", "test")
+	m.recordPassDuration(ctx, time.Second)
+}
+
+func TestRecoveryMetrics_BatchNilSafe(t *testing.T) {
+	var m *RecoveryMetrics
+	ctx := context.Background()
+	// Batch methods with n <= 0 should be no-ops
+	m.recordRecoveredN(ctx, 0)
+	m.recordRecoveredN(ctx, -1)
+	m.recordResetN(ctx, 0)
+	m.recordResetN(ctx, -1)
+}
+
+func TestNewRecoveryRunner_NilCoordinator_Panics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for nil coordinator")
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "distributed: NewRecoveryRunner requires a non-nil Coordinator" {
+			t.Fatalf("unexpected panic message: %v", r)
+		}
+	}()
+	NewRecoveryRunner(nil)
+}
+
+func TestRecoveryMetrics_Creation(t *testing.T) {
+	m, err := NewRecoveryMetrics()
+	if err != nil {
+		t.Fatalf("unexpected error creating metrics: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+
+	ctx := context.Background()
+	m.recordRecovered(ctx)
+	m.recordRepublished(ctx, "order.created")
+	m.recordReset(ctx)
+	m.recordError(ctx, "list_stale")
+	m.recordSkipped(ctx, "bus_not_found", "order.created")
+	m.recordPassDuration(ctx, 100*time.Millisecond)
+}
+
+func TestRecoveryMetrics_WithNamespace(t *testing.T) {
+	m, err := NewRecoveryMetrics(WithRecoveryMetricsNamespace("myapp"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+}
+
+func TestRecoveryOption_WithRecoveryLogger(t *testing.T) {
+	o := &recoveryOptions{}
+	WithRecoveryLogger(nil)(o)
+	if o.logger != nil {
+		t.Fatal("expected nil logger")
+	}
+}
+
+func TestRecoveryOption_WithBackoff(t *testing.T) {
+	o := &recoveryOptions{}
+	WithBackoff(nil)(o)
+	if o.backoff != nil {
+		t.Fatal("expected nil backoff")
+	}
+}
+
+func TestRecoveryRunner_RecoverOnce_NoStaleEntries(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(time.Minute),
+	)
+
+	// No entries at all
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recovered != 0 {
+		t.Fatalf("expected 0 recovered, got %d", recovered)
+	}
+}
+
+func TestMemoryStateManager_CleanupExpired(t *testing.T) {
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	ctx := context.Background()
+	sm.Acquire(ctx, "msg-1", 10*time.Millisecond)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+
+	time.Sleep(20 * time.Millisecond)
+	sm.cleanupExpired()
+
+	sm.mu.RLock()
+	count := len(sm.states)
+	sm.mu.RUnlock()
+
+	if count != 1 {
+		t.Fatalf("expected 1 entry after cleanup, got %d", count)
+	}
+}
+
+func TestRecoveryRunner_WithMetrics(t *testing.T) {
+	ctx := context.Background()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	defer sm.Close()
+
+	metrics, err := NewRecoveryMetrics()
+	if err != nil {
+		t.Fatalf("failed to create metrics: %v", err)
+	}
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithRecoveryMetrics(metrics),
+	)
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	time.Sleep(60 * time.Millisecond)
+
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("expected 1 recovered, got %d", recovered)
+	}
+}

--- a/distributed/recovery.go
+++ b/distributed/recovery.go
@@ -6,26 +6,28 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rbaliyan/event/v3"
 	"github.com/rbaliyan/event/v3/backoff"
 )
 
-// StaleResetter is an optional interface that state managers can implement
-// for efficient batch stale state reset.
-type StaleResetter interface {
-	// ResetStale resets stale states in batch.
-	// Returns the number of states reset.
-	ResetStale(ctx context.Context, staleTimeout time.Duration, limit int) (int64, error)
-}
-
 // RecoveryRunner provides active stale state detection and recovery.
+//
+// Delivery guarantee: at-least-once. If the process crashes between re-publishing
+// an event and marking the old state as processed, the next recovery cycle may
+// re-publish the same event again. Handlers MUST be idempotent.
 //
 // Instead of relying solely on TTL expiration (passive recovery), the runner
 // periodically scans for stale states and resets them for faster failover.
 //
-// How it works:
-//  1. Background goroutine runs at configurable interval (default: 30s)
-//  2. Queries state manager for stale states (processing longer than staleTimeout)
-//  3. Resets stale states so other workers can reacquire them
+// Recovery modes:
+//
+// Basic mode (no Publisher): resets stale states so other workers can reacquire
+// them via the transport's own re-delivery mechanism.
+//
+// Payload-aware mode (with Publisher): if the Coordinator also implements
+// PayloadStore, stale entries with stored payload are re-published via the
+// Publisher before being marked as processed. Remaining stale entries without
+// payload are reset normally.
 //
 // Timing guidelines:
 //
@@ -37,10 +39,11 @@ type StaleResetter interface {
 //
 // Example:
 //
-//	sm := distributed.NewMongoStateManager(db)
-//	runner := distributed.NewRecoveryRunner(sm,
+//	coord := distributed.NewMongoStateManager(db)
+//	runner := distributed.NewRecoveryRunner(coord,
 //	    distributed.WithStaleTimeout(2*time.Minute),
 //	    distributed.WithCheckInterval(30*time.Second),
+//	    distributed.WithPublisher(bus), // enables payload-aware recovery
 //	)
 //
 //	// Start recovery in background
@@ -51,17 +54,30 @@ type StaleResetter interface {
 //	// Or run once for manual recovery
 //	reset, err := runner.RecoverOnce(ctx)
 type RecoveryRunner struct {
-	sm                StateManager
+	coord             Coordinator
+	pub               Publisher
 	staleTimeout      time.Duration
 	checkInterval     time.Duration
 	batchLimit        int
 	logger            *slog.Logger
 	backoff           backoff.Strategy
+	metrics           *RecoveryMetrics
 	consecutiveErrors atomic.Int32
 }
 
 // RecoveryOption configures a RecoveryRunner.
-type RecoveryOption func(*RecoveryRunner)
+type RecoveryOption func(*recoveryOptions)
+
+// recoveryOptions holds configuration for the RecoveryRunner.
+type recoveryOptions struct {
+	pub           Publisher
+	staleTimeout  time.Duration
+	checkInterval time.Duration
+	batchLimit    int
+	logger        *slog.Logger
+	backoff       backoff.Strategy
+	metrics       *RecoveryMetrics
+}
 
 // WithStaleTimeout sets how long a state can be processing before considered stale.
 //
@@ -72,9 +88,9 @@ type RecoveryOption func(*RecoveryRunner)
 //
 // Default: 2 minutes
 func WithStaleTimeout(d time.Duration) RecoveryOption {
-	return func(r *RecoveryRunner) {
+	return func(o *recoveryOptions) {
 		if d > 0 {
-			r.staleTimeout = d
+			o.staleTimeout = d
 		}
 	}
 }
@@ -86,9 +102,9 @@ func WithStaleTimeout(d time.Duration) RecoveryOption {
 //
 // Default: 30 seconds
 func WithCheckInterval(d time.Duration) RecoveryOption {
-	return func(r *RecoveryRunner) {
+	return func(o *recoveryOptions) {
 		if d > 0 {
-			r.checkInterval = d
+			o.checkInterval = d
 		}
 	}
 }
@@ -100,8 +116,8 @@ func WithCheckInterval(d time.Duration) RecoveryOption {
 //
 // Default: 100 (0 = no limit)
 func WithBatchLimit(limit int) RecoveryOption {
-	return func(r *RecoveryRunner) {
-		r.batchLimit = limit
+	return func(o *recoveryOptions) {
+		o.batchLimit = limit
 	}
 }
 
@@ -109,8 +125,8 @@ func WithBatchLimit(limit int) RecoveryOption {
 //
 // If not set, no logging is performed.
 func WithRecoveryLogger(logger *slog.Logger) RecoveryOption {
-	return func(r *RecoveryRunner) {
-		r.logger = logger
+	return func(o *recoveryOptions) {
+		o.logger = logger
 	}
 }
 
@@ -125,7 +141,7 @@ func WithRecoveryLogger(logger *slog.Logger) RecoveryOption {
 //
 // Example:
 //
-//	runner := distributed.NewRecoveryRunner(sm,
+//	runner := distributed.NewRecoveryRunner(coord,
 //	    distributed.WithBackoff(&backoff.Exponential{
 //	        Initial:    time.Second,
 //	        Multiplier: 2.0,
@@ -134,30 +150,76 @@ func WithRecoveryLogger(logger *slog.Logger) RecoveryOption {
 //	    }),
 //	)
 func WithBackoff(strategy backoff.Strategy) RecoveryOption {
-	return func(r *RecoveryRunner) {
-		r.backoff = strategy
+	return func(o *recoveryOptions) {
+		o.backoff = strategy
+	}
+}
+
+// WithRecoveryMetrics sets OpenTelemetry metrics for recovery operations.
+//
+// Example:
+//
+//	metrics, _ := distributed.NewRecoveryMetrics()
+//	runner := distributed.NewRecoveryRunner(coord,
+//	    distributed.WithRecoveryMetrics(metrics),
+//	)
+func WithRecoveryMetrics(m *RecoveryMetrics) RecoveryOption {
+	return func(o *recoveryOptions) {
+		o.metrics = m
+	}
+}
+
+// WithPublisher sets the publisher for payload-aware recovery.
+//
+// When a Publisher is provided and the Coordinator also implements PayloadStore,
+// the recovery runner re-publishes stale events via the Publisher instead of
+// just resetting the state. This is required for transports that don't support
+// re-delivery (e.g., MongoDB Change Streams).
+//
+// The Publisher interface is satisfied by *event.Bus.
+//
+// Example:
+//
+//	runner := distributed.NewRecoveryRunner(coord,
+//	    distributed.WithPublisher(bus),
+//	)
+func WithPublisher(pub Publisher) RecoveryOption {
+	return func(o *recoveryOptions) {
+		o.pub = pub
 	}
 }
 
 // NewRecoveryRunner creates a new stale state recovery runner.
 //
 // Parameters:
-//   - sm: The state manager to monitor for stale states
-//   - opts: Optional configuration
+//   - coord: The coordinator to monitor for stale states
+//   - opts: Optional configuration (Publisher, timeouts, logger, etc.)
 //
 // Returns a configured runner. Call Run() to start background recovery
 // or RecoverOnce() for manual recovery.
-func NewRecoveryRunner(sm StateManager, opts ...RecoveryOption) *RecoveryRunner {
-	r := &RecoveryRunner{
-		sm:            sm,
+func NewRecoveryRunner(coord Coordinator, opts ...RecoveryOption) *RecoveryRunner {
+	if coord == nil {
+		panic("distributed: NewRecoveryRunner requires a non-nil Coordinator")
+	}
+
+	o := &recoveryOptions{
 		staleTimeout:  2 * time.Minute,
 		checkInterval: 30 * time.Second,
 		batchLimit:    100,
 	}
 	for _, opt := range opts {
-		opt(r)
+		opt(o)
 	}
-	return r
+	return &RecoveryRunner{
+		coord:         coord,
+		pub:           o.pub,
+		staleTimeout:  o.staleTimeout,
+		checkInterval: o.checkInterval,
+		batchLimit:    o.batchLimit,
+		logger:        o.logger,
+		backoff:       o.backoff,
+		metrics:       o.metrics,
+	}
 }
 
 // Run starts the background recovery loop.
@@ -198,10 +260,12 @@ func (r *RecoveryRunner) Run(ctx context.Context) {
 					backoffDelay := r.backoff.NextDelay(errCount - 1)
 
 					if backoffDelay > 0 {
+						timer := time.NewTimer(backoffDelay)
 						select {
 						case <-ctx.Done():
+							timer.Stop()
 							return
-						case <-time.After(backoffDelay):
+						case <-timer.C:
 							// Continue after backoff delay
 						}
 					}
@@ -212,7 +276,7 @@ func (r *RecoveryRunner) Run(ctx context.Context) {
 
 				if reset > 0 {
 					if r.logger != nil {
-						r.logger.Info("reset stale states",
+						r.logger.Info("recovered stale states",
 							"count", reset,
 							"stale_timeout", r.staleTimeout)
 					}
@@ -224,34 +288,155 @@ func (r *RecoveryRunner) Run(ctx context.Context) {
 
 // RecoverOnce performs a single recovery pass.
 //
-// This is useful for manual recovery or when you want more control over
-// when recovery runs.
+// Phase 1 (payload-aware): If the Coordinator implements PayloadStore and a
+// Publisher is configured, stale entries with stored payload are re-published
+// via the Publisher and marked as processed.
 //
-// Returns the number of states reset.
+// Phase 2 (basic reset): Remaining stale entries (without payload or when no
+// Publisher is configured) are reset so other workers can reacquire them.
+// Entries that were handled in Phase 1 (including those where MarkProcessed
+// failed) are excluded to prevent double-processing.
+//
+// Returns the number of states recovered (reset or re-published).
 func (r *RecoveryRunner) RecoverOnce(ctx context.Context) (int64, error) {
-	// If state manager implements StaleResetter, use the efficient batch method
-	if resetter, ok := r.sm.(StaleResetter); ok {
-		return resetter.ResetStale(ctx, r.staleTimeout, r.batchLimit)
+	start := time.Now()
+	var total int64
+
+	// Phase 1: Re-publish stale entries that have stored payload.
+	// Collect all handled message IDs to exclude from Phase 2.
+	var phase1IDs map[string]struct{}
+	ps, hasPayloadStore := r.coord.(PayloadStore)
+	if hasPayloadStore && r.pub != nil {
+		count, handled, err := r.recoverPayloadEntries(ctx, ps)
+		phase1IDs = handled
+		if err != nil {
+			r.metrics.recordPassDuration(ctx, time.Since(start))
+			return count, err
+		}
+		total += count
 	}
 
-	// Fall back to list + reset
-	stale, err := r.sm.ListStale(ctx, r.staleTimeout, r.batchLimit)
+	// Phase 2: Reset remaining stale entries (no payload).
+	// When batchLimit is 0 (no limit), pass 0 to resetStaleEntries.
+	remaining := 0
+	if r.batchLimit > 0 {
+		remaining = r.batchLimit - int(total)
+	}
+	if r.batchLimit == 0 || remaining > 0 {
+		count, err := r.resetStaleEntries(ctx, remaining, phase1IDs)
+		if err != nil {
+			r.metrics.recordPassDuration(ctx, time.Since(start))
+			return total, err
+		}
+		total += count
+	}
+
+	r.metrics.recordPassDuration(ctx, time.Since(start))
+	return total, nil
+}
+
+// recoverPayloadEntries re-publishes stale entries that have stored payload.
+// Returns the count of recovered entries and a set of ALL message IDs that
+// were handled (including those where re-publish or MarkProcessed failed).
+// Phase 2 uses this set to avoid double-processing.
+func (r *RecoveryRunner) recoverPayloadEntries(ctx context.Context, ps PayloadStore) (int64, map[string]struct{}, error) {
+	entries, err := ps.LoadStalePayloads(ctx, r.staleTimeout, r.batchLimit)
 	if err != nil {
+		r.metrics.recordError(ctx, "load_stale_payloads")
+		return 0, nil, err
+	}
+
+	handled := make(map[string]struct{}, len(entries))
+	var recovered int64
+	for _, entry := range entries {
+		// Track all entries seen by Phase 1 to exclude from Phase 2
+		handled[entry.MessageID] = struct{}{}
+
+		// Re-publish with a new event ID so WorkerPool can acquire fresh state
+		newID := event.NewID()
+		if err := r.pub.Send(ctx, entry.Data.EventName, newID, entry.Data.Payload, entry.Data.Metadata); err != nil {
+			if r.logger != nil {
+				r.logger.Warn("failed to re-publish stale event, leaving for next cycle",
+					"message_id", entry.MessageID,
+					"event_name", entry.Data.EventName,
+					"error", err)
+			}
+			r.metrics.recordSkipped(ctx, "republish_failed", entry.Data.EventName)
+			continue
+		}
+
+		// Re-publish succeeded — clear payload and mark as processed
+		_ = ps.ClearPayload(ctx, entry.MessageID)
+		if err := r.coord.MarkProcessed(ctx, entry.MessageID); err != nil {
+			if r.logger != nil {
+				r.logger.Warn("failed to mark re-published state as processed",
+					"message_id", entry.MessageID,
+					"error", err)
+			}
+			r.metrics.recordError(ctx, "mark_processed")
+		}
+		recovered++
+		r.metrics.recordRepublished(ctx, entry.Data.EventName)
+		r.metrics.recordRecovered(ctx)
+
+		if r.logger != nil {
+			r.logger.Info("re-published stale event",
+				"old_message_id", entry.MessageID,
+				"new_message_id", newID,
+				"event_name", entry.Data.EventName)
+		}
+	}
+
+	return recovered, handled, nil
+}
+
+// resetStaleEntries resets stale states so other workers can reacquire them.
+// The exclude set contains message IDs already handled by Phase 1 (payload
+// recovery) that should not be reset even if they're still in "processing"
+// state (e.g., when MarkProcessed failed after successful re-publish).
+//
+// Uses ListStale + individual Reset to support the exclusion set. When no
+// IDs need excluding, uses StaleResetter for efficient batch reset if available.
+func (r *RecoveryRunner) resetStaleEntries(ctx context.Context, limit int, exclude map[string]struct{}) (int64, error) {
+	// Use StaleResetter for efficient batch reset when no exclusions needed
+	if len(exclude) == 0 {
+		if sr, ok := r.coord.(StaleResetter); ok {
+			count, err := sr.ResetStale(ctx, r.staleTimeout, limit)
+			if err != nil {
+				r.metrics.recordError(ctx, "reset_stale")
+				return 0, err
+			}
+			r.metrics.recordResetN(ctx, count)
+			r.metrics.recordRecoveredN(ctx, count)
+			return count, nil
+		}
+	}
+
+	// Fall back to ListStale + individual Reset (supports exclusion)
+	stale, err := r.coord.ListStale(ctx, r.staleTimeout, limit)
+	if err != nil {
+		r.metrics.recordError(ctx, "list_stale")
 		return 0, err
 	}
 
-	var reset int64
-	for _, msgID := range stale {
-		if err := r.sm.Reset(ctx, msgID); err != nil {
-			if r.logger != nil {
-				r.logger.Warn("failed to reset stale state",
-					"message_id", msgID,
-					"error", err)
-			}
+	var count int64
+	for _, messageID := range stale {
+		// Skip entries already handled by Phase 1
+		if _, excluded := exclude[messageID]; excluded {
 			continue
 		}
-		reset++
+		if err := r.coord.Reset(ctx, messageID); err != nil {
+			if r.logger != nil {
+				r.logger.Warn("failed to reset stale state",
+					"message_id", messageID,
+					"error", err)
+			}
+			r.metrics.recordError(ctx, "reset")
+			continue
+		}
+		count++
+		r.metrics.recordReset(ctx)
+		r.metrics.recordRecovered(ctx)
 	}
-
-	return reset, nil
+	return count, nil
 }

--- a/distributed/redis.go
+++ b/distributed/redis.go
@@ -4,9 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+)
+
+// Redis state status values (matching MongoDB constants for consistency).
+const (
+	redisStatusProcessing = "processing"
+	redisStatusCompleted  = "completed"
 )
 
 // redisStateValue stores state with timestamps for stale detection.
@@ -16,7 +23,14 @@ type redisStateValue struct {
 	UpdatedAt time.Time `json:"u"`
 }
 
-// RedisStateManager implements StateManager using Redis for distributed deployments.
+// redisPayloadValue stores message payload for recovery re-publishing.
+type redisPayloadValue struct {
+	Payload   []byte            `json:"p,omitempty"`
+	Metadata  map[string]string `json:"m,omitempty"`
+	EventName string            `json:"e,omitempty"`
+}
+
+// RedisStateManager implements Coordinator and PayloadStore using Redis for distributed deployments.
 //
 // RedisStateManager uses Redis SETNX (set if not exists) with TTL for atomic,
 // race-condition-free message state management. This is the recommended implementation
@@ -53,7 +67,6 @@ type redisStateValue struct {
 //	// With custom options
 //	sm := distributed.NewRedisStateManager(rdb,
 //	    distributed.WithPrefix("myapp:worker:"),
-//	    distributed.WithStateTTL(10*time.Minute),
 //	    distributed.WithCompletedTTL(48*time.Hour),
 //	)
 //
@@ -133,7 +146,7 @@ func (s *RedisStateManager) Acquire(ctx context.Context, messageID string, ttl t
 
 	// Create state value with timestamps for stale detection
 	value := redisStateValue{
-		Status:    "processing",
+		Status:    redisStatusProcessing,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -157,50 +170,53 @@ func (s *RedisStateManager) Acquire(ctx context.Context, messageID string, ttl t
 	return true, nil
 }
 
+// markProcessedScript atomically reads the existing state (preserving
+// created_at), builds a completed state value, and overwrites with new TTL.
+// All in a single Lua script — no separate round-trips, no TOCTOU race.
+//
+// KEYS[1] = state key
+// ARGV[1] = completed status string (JSON field value)
+// ARGV[2] = updated_at timestamp (RFC3339)
+// ARGV[3] = TTL in milliseconds
+//
+// Returns: 1 if updated, 0 if key no longer exists (no-op)
+var markProcessedScript = redis.NewScript(`
+local existing = redis.call("GET", KEYS[1])
+if not existing then
+  return 0
+end
+local ok, val = pcall(cjson.decode, existing)
+local created = ARGV[2]
+if ok and val and val.c then
+  created = val.c
+end
+local newVal = cjson.encode({s = ARGV[1], c = created, u = ARGV[2]})
+redis.call("SET", KEYS[1], newVal, "PX", ARGV[3])
+return 1
+`)
+
 // MarkProcessed transitions a message to "completed" state.
 //
-// Updates the state value to "completed" and extends TTL to completionTTL.
-// This prevents the message from being reprocessed if delivered again
-// within the completion window.
-//
-// Redis command: SET {prefix}{messageID} {json_value} EX {completionTTL}
+// Uses a single Lua script to atomically read the existing state (preserving
+// created_at), build the new completed value, and overwrite with completion TTL.
+// If the key was deleted between Acquire and MarkProcessed (e.g., by a
+// concurrent Reset), the update is a no-op — it will not recreate a key
+// that was intentionally removed. In this case MarkProcessed returns nil
+// (silent no-op) since the message state has already been cleared.
 //
 // Parameters:
 //   - ctx: Context for cancellation
 //   - messageID: The message that was successfully processed
 //
-// Returns nil on success, error if Redis operation fails.
+// Returns nil on success (including no-op when key was deleted).
 func (s *RedisStateManager) MarkProcessed(ctx context.Context, messageID string) error {
 	key := s.prefix + messageID
-	now := time.Now()
+	now := time.Now().Format(time.RFC3339Nano)
+	ttlMs := s.completionTTL.Milliseconds()
 
-	// Get existing value to preserve created_at
-	existingBytes, err := s.client.Get(ctx, key).Bytes()
-	var createdAt time.Time
-	if err == nil {
-		var existing redisStateValue
-		if json.Unmarshal(existingBytes, &existing) == nil {
-			createdAt = existing.CreatedAt
-		}
-	}
-	if createdAt.IsZero() {
-		createdAt = now
-	}
-
-	// Update to completed state with longer TTL
-	value := redisStateValue{
-		Status:    "completed",
-		CreatedAt: createdAt,
-		UpdatedAt: now,
-	}
-	valueBytes, err := json.Marshal(value)
+	err := markProcessedScript.Run(ctx, s.client, []string{key}, redisStatusCompleted, now, ttlMs).Err()
 	if err != nil {
-		return fmt.Errorf("marshal state value: %w", err)
-	}
-
-	err = s.client.Set(ctx, key, valueBytes, s.completionTTL).Err()
-	if err != nil {
-		return fmt.Errorf("redis set: %w", err)
+		return fmt.Errorf("redis mark processed: %w", err)
 	}
 
 	return nil
@@ -221,13 +237,66 @@ func (s *RedisStateManager) MarkProcessed(ctx context.Context, messageID string)
 func (s *RedisStateManager) Reset(ctx context.Context, messageID string) error {
 	key := s.prefix + messageID
 
-	// Delete the state so another worker can acquire immediately
-	err := s.client.Del(ctx, key).Err()
+	// Delete the state and payload so another worker can acquire immediately
+	err := s.client.Del(ctx, key, s.payloadKey(messageID)).Err()
 	if err != nil {
 		return fmt.Errorf("redis del: %w", err)
 	}
 
 	return nil
+}
+
+// scanStaleStates iterates Redis state keys via SCAN and returns stale processing entries.
+// Each entry includes the message ID and its parsed state value.
+func (s *RedisStateManager) scanStaleStates(ctx context.Context, cutoff time.Time, limit int) ([]staleEntry, error) {
+	var entries []staleEntry
+	pattern := s.prefix + "*"
+	var cursor uint64
+
+	for {
+		keys, nextCursor, err := s.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return nil, fmt.Errorf("redis scan: %w", err)
+		}
+
+		for _, key := range keys {
+			// Skip payload companion keys
+			if strings.HasSuffix(key, ":payload") {
+				continue
+			}
+
+			valueBytes, err := s.client.Get(ctx, key).Bytes()
+			if err != nil {
+				continue // Key may have expired
+			}
+
+			var value redisStateValue
+			if err := json.Unmarshal(valueBytes, &value); err != nil {
+				continue
+			}
+
+			if value.Status == redisStatusProcessing && value.UpdatedAt.Before(cutoff) {
+				messageID := key[len(s.prefix):]
+				entries = append(entries, staleEntry{messageID: messageID, value: value})
+				if limit > 0 && len(entries) >= limit {
+					return entries, nil
+				}
+			}
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	return entries, nil
+}
+
+// staleEntry pairs a message ID with its parsed state value.
+type staleEntry struct {
+	messageID string
+	value     redisStateValue
 }
 
 // ListStale returns message IDs of states that have been processing
@@ -244,48 +313,15 @@ func (s *RedisStateManager) Reset(ctx context.Context, messageID string) error {
 // Returns list of message IDs that are stale.
 func (s *RedisStateManager) ListStale(ctx context.Context, staleTimeout time.Duration, limit int) ([]string, error) {
 	cutoff := time.Now().Add(-staleTimeout)
-	var stale []string
-
-	// Use SCAN to iterate through keys with our prefix
-	pattern := s.prefix + "*"
-	var cursor uint64
-
-	for {
-		keys, nextCursor, err := s.client.Scan(ctx, cursor, pattern, 100).Result()
-		if err != nil {
-			return nil, fmt.Errorf("redis scan: %w", err)
-		}
-
-		for _, key := range keys {
-			// Get value and check if it's a stale processing state
-			valueBytes, err := s.client.Get(ctx, key).Bytes()
-			if err != nil {
-				continue // Key may have expired
-			}
-
-			var value redisStateValue
-			if err := json.Unmarshal(valueBytes, &value); err != nil {
-				// Legacy format (plain string) - skip
-				continue
-			}
-
-			if value.Status == "processing" && value.UpdatedAt.Before(cutoff) {
-				// Extract message ID from key (remove prefix)
-				messageID := key[len(s.prefix):]
-				stale = append(stale, messageID)
-
-				if limit > 0 && len(stale) >= limit {
-					return stale, nil
-				}
-			}
-		}
-
-		cursor = nextCursor
-		if cursor == 0 {
-			break
-		}
+	entries, err := s.scanStaleStates(ctx, cutoff, limit)
+	if err != nil {
+		return nil, err
 	}
 
+	stale := make([]string, len(entries))
+	for i, e := range entries {
+		stale[i] = e.messageID
+	}
 	return stale, nil
 }
 
@@ -310,19 +346,125 @@ func (s *RedisStateManager) ResetStale(ctx context.Context, staleTimeout time.Du
 		return 0, nil
 	}
 
-	// Build keys to delete
-	keys := make([]string, len(stale))
-	for i, msgID := range stale {
-		keys[i] = s.prefix + msgID
+	// Build keys to delete (state + payload companion keys)
+	keys := make([]string, 0, len(stale)*2)
+	for _, msgID := range stale {
+		keys = append(keys, s.prefix+msgID, s.payloadKey(msgID))
 	}
 
-	deleted, err := s.client.Del(ctx, keys...).Result()
+	_, err = s.client.Del(ctx, keys...).Result()
 	if err != nil {
 		return 0, fmt.Errorf("redis del: %w", err)
 	}
 
-	return deleted, nil
+	// Return the number of stale messages reset (not Redis DEL count which
+	// includes payload companion keys and would be ~2x the actual count).
+	return int64(len(stale)), nil
 }
 
-// Compile-time interface check
-var _ StateManager = (*RedisStateManager)(nil)
+// payloadKey returns the Redis key for storing payload alongside state.
+func (s *RedisStateManager) payloadKey(messageID string) string {
+	return s.prefix + messageID + ":payload"
+}
+
+// storePayloadScript atomically reads the state key TTL and sets the payload
+// key with matching expiry. This avoids the TOCTOU race where the state key
+// could expire between a separate TTL read and the payload SET.
+//
+// KEYS[1] = state key
+// KEYS[2] = payload key
+// ARGV[1] = payload value (JSON)
+//
+// Returns: 1 if stored, 0 if state key has no TTL (skipped)
+var storePayloadScript = redis.NewScript(`
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl <= 0 then
+  return 0
+end
+redis.call("SET", KEYS[2], ARGV[1], "PX", ttl)
+return 1
+`)
+
+// StorePayload persists payload in a separate Redis key alongside the state.
+// Uses a Lua script to atomically read the state key TTL and set the payload
+// with matching expiry, preventing orphaned payload keys.
+func (s *RedisStateManager) StorePayload(ctx context.Context, messageID string, data *MessageData) error {
+	if data == nil || len(data.Payload) == 0 {
+		return nil
+	}
+
+	pv := redisPayloadValue{
+		Payload:   data.Payload,
+		Metadata:  data.Metadata,
+		EventName: data.EventName,
+	}
+	pvBytes, err := json.Marshal(pv)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	stateKey := s.prefix + messageID
+	payloadKey := s.payloadKey(messageID)
+	err = storePayloadScript.Run(ctx, s.client, []string{stateKey, payloadKey}, pvBytes).Err()
+	if err != nil {
+		return fmt.Errorf("redis store payload: %w", err)
+	}
+
+	return nil
+}
+
+// LoadStalePayloads returns stale messages that have stored payload.
+//
+// Performance note: this scans ALL stale state keys via SCAN, then checks each
+// one for a companion payload key. For large key spaces (>10k stale states),
+// consider using MongoDB-backed state management or setting a batch limit on
+// the RecoveryRunner to cap the number of entries processed per cycle.
+func (s *RedisStateManager) LoadStalePayloads(ctx context.Context, staleTimeout time.Duration, limit int) ([]*StaleMessage, error) {
+	cutoff := time.Now().Add(-staleTimeout)
+	// Scan without limit since we need to filter by payload existence after
+	entries, err := s.scanStaleStates(ctx, cutoff, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*StaleMessage
+	for _, e := range entries {
+		// Only return entries that actually have stored payload
+		payloadBytes, err := s.client.Get(ctx, s.payloadKey(e.messageID)).Bytes()
+		if err != nil {
+			continue // no payload stored, skip
+		}
+
+		var pv redisPayloadValue
+		if json.Unmarshal(payloadBytes, &pv) != nil {
+			continue
+		}
+
+		results = append(results, &StaleMessage{
+			MessageID: e.messageID,
+			Data: MessageData{
+				Payload:   pv.Payload,
+				Metadata:  pv.Metadata,
+				EventName: pv.EventName,
+			},
+			CreatedAt: e.value.CreatedAt,
+		})
+		if limit > 0 && len(results) >= limit {
+			return results, nil
+		}
+	}
+
+	return results, nil
+}
+
+// ClearPayload removes stored payload for a message.
+func (s *RedisStateManager) ClearPayload(ctx context.Context, messageID string) error {
+	return s.client.Del(ctx, s.payloadKey(messageID)).Err()
+}
+
+// Compile-time interface checks
+var (
+	_ Coordinator   = (*RedisStateManager)(nil)
+	_ PayloadStore  = (*RedisStateManager)(nil)
+	_ StaleResetter = (*RedisStateManager)(nil)
+)

--- a/distributed/redis.go
+++ b/distributed/redis.go
@@ -442,11 +442,7 @@ func (s *RedisStateManager) LoadStalePayloads(ctx context.Context, staleTimeout 
 
 		results = append(results, &StaleMessage{
 			MessageID: e.messageID,
-			Data: MessageData{
-				Payload:   pv.Payload,
-				Metadata:  pv.Metadata,
-				EventName: pv.EventName,
-			},
+			Data:      MessageData(pv),
 			CreatedAt: e.value.CreatedAt,
 		})
 		if limit > 0 && len(results) >= limit {

--- a/distributed/redis_test.go
+++ b/distributed/redis_test.go
@@ -1,0 +1,489 @@
+package distributed
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func setupRedisStateManager(t *testing.T, opts ...Option) (*RedisStateManager, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewRedisStateManager(client, opts...), mr
+}
+
+func TestRedisStateManager_Acquire(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	t.Run("first acquisition succeeds", func(t *testing.T) {
+		acquired, err := sm.Acquire(ctx, "msg-1", time.Minute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !acquired {
+			t.Fatal("expected acquisition to succeed")
+		}
+	})
+
+	t.Run("second acquisition for same message fails", func(t *testing.T) {
+		acquired, err := sm.Acquire(ctx, "msg-1", time.Minute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if acquired {
+			t.Fatal("expected second acquisition to fail")
+		}
+	})
+
+	t.Run("different messages can be acquired", func(t *testing.T) {
+		acquired, err := sm.Acquire(ctx, "msg-2", time.Minute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !acquired {
+			t.Fatal("expected different message acquisition to succeed")
+		}
+	})
+}
+
+func TestRedisStateManager_Acquire_Expiry(t *testing.T) {
+	sm, mr := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Second)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed")
+	}
+
+	// Fast-forward past expiry
+	mr.FastForward(2 * time.Second)
+
+	// Should be acquirable again after expiry
+	acquired, _ = sm.Acquire(ctx, "msg-1", time.Minute)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed after expiry")
+	}
+}
+
+func TestRedisStateManager_MarkProcessed(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Minute)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed")
+	}
+
+	// Mark processed
+	if err := sm.MarkProcessed(ctx, "msg-1"); err != nil {
+		t.Fatalf("MarkProcessed failed: %v", err)
+	}
+
+	// Should not be acquirable (completed state blocks)
+	acquired, _ = sm.Acquire(ctx, "msg-1", time.Minute)
+	if acquired {
+		t.Fatal("expected acquisition to fail after mark processed")
+	}
+}
+
+func TestRedisStateManager_MarkProcessed_AtomicNoRecreate(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire then reset (simulate another process deleting the key)
+	sm.Acquire(ctx, "msg-1", time.Minute)
+	sm.Reset(ctx, "msg-1")
+
+	// MarkProcessed should be a no-op on a deleted key (Lua script checks existence)
+	if err := sm.MarkProcessed(ctx, "msg-1"); err != nil {
+		t.Fatalf("MarkProcessed failed: %v", err)
+	}
+
+	// Key should NOT exist (Lua script does not recreate deleted keys)
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Minute)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed (MarkProcessed should not have recreated deleted key)")
+	}
+}
+
+func TestRedisStateManager_Reset(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Minute)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed")
+	}
+
+	// Reset
+	if err := sm.Reset(ctx, "msg-1"); err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+
+	// Should be acquirable again
+	acquired, _ = sm.Acquire(ctx, "msg-1", time.Minute)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed after reset")
+	}
+}
+
+func TestRedisStateManager_ListStale(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire some messages
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+	sm.Acquire(ctx, "msg-3", time.Hour)
+
+	// Mark one as processed
+	sm.MarkProcessed(ctx, "msg-2")
+
+	// Wait for stale timeout (stale = UpdatedAt older than staleTimeout)
+	time.Sleep(60 * time.Millisecond)
+
+	// List stale with 50ms timeout
+	stale, err := sm.ListStale(ctx, 50*time.Millisecond, 0)
+	if err != nil {
+		t.Fatalf("ListStale failed: %v", err)
+	}
+
+	// Should find msg-1 and msg-3 (processing and stale), not msg-2 (completed)
+	if len(stale) != 2 {
+		t.Fatalf("expected 2 stale, got %d", len(stale))
+	}
+
+	// Test limit
+	stale, err = sm.ListStale(ctx, 50*time.Millisecond, 1)
+	if err != nil {
+		t.Fatalf("ListStale with limit failed: %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale with limit, got %d", len(stale))
+	}
+}
+
+func TestRedisStateManager_ResetStale(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	reset, err := sm.ResetStale(ctx, 50*time.Millisecond, 0)
+	if err != nil {
+		t.Fatalf("ResetStale failed: %v", err)
+	}
+	if reset != 2 {
+		t.Fatalf("expected 2 reset, got %d", reset)
+	}
+
+	// Should be acquirable again
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Hour)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed after stale reset")
+	}
+}
+
+func TestRedisStateManager_ResetStale_Limit(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.Acquire(ctx, "msg-2", time.Hour)
+	sm.Acquire(ctx, "msg-3", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Reset with limit=1
+	reset, err := sm.ResetStale(ctx, 50*time.Millisecond, 1)
+	if err != nil {
+		t.Fatalf("ResetStale failed: %v", err)
+	}
+	if reset != 1 {
+		t.Fatalf("expected 1 reset with limit, got %d", reset)
+	}
+}
+
+func TestRedisStateManager_StorePayload(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire first (payload key TTL matches state key TTL)
+	sm.Acquire(ctx, "msg-1", time.Minute)
+
+	err := sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		Metadata:  map[string]string{"source": "test"},
+		EventName: "order.created",
+	})
+	if err != nil {
+		t.Fatalf("StorePayload failed: %v", err)
+	}
+}
+
+func TestRedisStateManager_StorePayload_SkipsWhenNoState(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// No Acquire — state key doesn't exist, TTL <= 0
+	err := sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		EventName: "order.created",
+	})
+	if err != nil {
+		t.Fatalf("StorePayload failed: %v", err)
+	}
+
+	// Payload key should NOT exist (skipped to avoid orphaned keys)
+	stale, _ := sm.LoadStalePayloads(ctx, 0, 0)
+	if len(stale) > 0 {
+		t.Fatal("expected no stale payloads when state key doesn't exist")
+	}
+}
+
+func TestRedisStateManager_StorePayload_NilOrEmpty(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-1", time.Minute)
+
+	// Nil data
+	if err := sm.StorePayload(ctx, "msg-1", nil); err != nil {
+		t.Fatalf("StorePayload(nil) failed: %v", err)
+	}
+
+	// Empty payload
+	if err := sm.StorePayload(ctx, "msg-1", &MessageData{Payload: nil}); err != nil {
+		t.Fatalf("StorePayload(empty) failed: %v", err)
+	}
+}
+
+func TestRedisStateManager_LoadStalePayloads(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire and store payload for msg-1
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		EventName: "order.created",
+	})
+
+	// Acquire msg-2 without payload
+	sm.Acquire(ctx, "msg-2", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	// LoadStalePayloads should only return msg-1 (has payload)
+	stale, err := sm.LoadStalePayloads(ctx, 50*time.Millisecond, 0)
+	if err != nil {
+		t.Fatalf("LoadStalePayloads failed: %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale with payload, got %d", len(stale))
+	}
+	if stale[0].MessageID != "msg-1" {
+		t.Errorf("expected msg-1, got %s", stale[0].MessageID)
+	}
+	if string(stale[0].Data.Payload) != `{"order":1}` {
+		t.Errorf("unexpected payload: %s", stale[0].Data.Payload)
+	}
+	if stale[0].Data.EventName != "order.created" {
+		t.Errorf("expected event name order.created, got %s", stale[0].Data.EventName)
+	}
+}
+
+func TestRedisStateManager_ClearPayload(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+	sm.StorePayload(ctx, "msg-1", &MessageData{
+		Payload:   []byte(`{"order":1}`),
+		EventName: "order.created",
+	})
+
+	// Clear payload
+	if err := sm.ClearPayload(ctx, "msg-1"); err != nil {
+		t.Fatalf("ClearPayload failed: %v", err)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	// LoadStalePayloads should find no entries with payload
+	stale, err := sm.LoadStalePayloads(ctx, 50*time.Millisecond, 0)
+	if err != nil {
+		t.Fatalf("LoadStalePayloads failed: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("expected 0 stale with payload after clear, got %d", len(stale))
+	}
+}
+
+func TestRedisStateManager_Prefix(t *testing.T) {
+	sm1, _ := setupRedisStateManager(t, WithPrefix("app1:"))
+	sm2, _ := setupRedisStateManager(t, WithPrefix("app2:"))
+	ctx := context.Background()
+
+	// Same message ID, different prefixes — both should acquire
+	acquired1, _ := sm1.Acquire(ctx, "msg-1", time.Minute)
+	acquired2, _ := sm2.Acquire(ctx, "msg-1", time.Minute)
+
+	if !acquired1 {
+		t.Fatal("expected app1 acquisition to succeed")
+	}
+	if !acquired2 {
+		t.Fatal("expected app2 acquisition to succeed")
+	}
+}
+
+func TestRedisStateManager_RecoveryRunner(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+	)
+
+	sm.Acquire(ctx, "msg-1", time.Hour)
+
+	// Not stale yet
+	reset, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	if reset != 0 {
+		t.Fatalf("expected 0 reset, got %d", reset)
+	}
+
+	// Wait for stale timeout
+	time.Sleep(60 * time.Millisecond)
+
+	reset, err = runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	if reset != 1 {
+		t.Fatalf("expected 1 reset, got %d", reset)
+	}
+
+	// Should be acquirable again
+	acquired, _ := sm.Acquire(ctx, "msg-1", time.Hour)
+	if !acquired {
+		t.Fatal("expected acquisition to succeed after recovery")
+	}
+}
+
+func TestRedisStatusConstants(t *testing.T) {
+	// Verify Redis status constants match expected values
+	if redisStatusProcessing != "processing" {
+		t.Errorf("redisStatusProcessing = %q, want %q", redisStatusProcessing, "processing")
+	}
+	if redisStatusCompleted != "completed" {
+		t.Errorf("redisStatusCompleted = %q, want %q", redisStatusCompleted, "completed")
+	}
+}
+
+func TestRedisStateManager_StorePayload_AtomicTTL(t *testing.T) {
+	sm, mr := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	// Acquire with short TTL
+	sm.Acquire(ctx, "msg-ttl", 5*time.Second)
+
+	err := sm.StorePayload(ctx, "msg-ttl", &MessageData{
+		Payload:   []byte(`{"test":"data"}`),
+		EventName: "test.event",
+	})
+	if err != nil {
+		t.Fatalf("StorePayload failed: %v", err)
+	}
+
+	// Payload key should exist
+	payloadKey := sm.payloadKey("msg-ttl")
+	val, err := mr.Get(payloadKey)
+	if err != nil {
+		t.Fatalf("expected payload key to exist, got error: %v", err)
+	}
+	if val == "" {
+		t.Fatal("expected non-empty payload value")
+	}
+
+	// Payload key TTL should match state key TTL (approximately)
+	payloadTTL := mr.TTL(payloadKey)
+	stateTTL := mr.TTL(sm.prefix + "msg-ttl")
+	if payloadTTL <= 0 {
+		t.Fatal("expected payload key to have TTL")
+	}
+	if stateTTL <= 0 {
+		t.Fatal("expected state key to have TTL")
+	}
+	// Both should be close (within 1 second of each other)
+	diff := payloadTTL - stateTTL
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > time.Second {
+		t.Fatalf("TTL mismatch: payload=%v state=%v diff=%v", payloadTTL, stateTTL, diff)
+	}
+}
+
+func TestRedisStateManager_PayloadRecovery(t *testing.T) {
+	sm, _ := setupRedisStateManager(t)
+	ctx := context.Background()
+
+	pub := &mockPublisher{}
+	runner := NewRecoveryRunner(sm,
+		WithStaleTimeout(50*time.Millisecond),
+		WithBatchLimit(10),
+		WithPublisher(pub),
+	)
+
+	// Acquire and store payload (simulates middleware behavior)
+	sm.Acquire(ctx, "msg-recovery-1", time.Hour)
+	sm.StorePayload(ctx, "msg-recovery-1", &MessageData{
+		Payload:   []byte(`{"order":"abc"}`),
+		Metadata:  map[string]string{"source": "test"},
+		EventName: "order.created",
+	})
+
+	// Acquire without payload (should be reset via Phase 2)
+	sm.Acquire(ctx, "msg-recovery-2", time.Hour)
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Phase 1: re-publish payload entry, Phase 2: reset no-payload entry
+	recovered, err := runner.RecoverOnce(ctx)
+	if err != nil {
+		t.Fatalf("RecoverOnce failed: %v", err)
+	}
+	if recovered != 2 {
+		t.Fatalf("expected 2 recovered, got %d", recovered)
+	}
+
+	// Publisher should have been called once (for msg-recovery-1)
+	if len(pub.calls) != 1 {
+		t.Fatalf("expected 1 publish call, got %d", len(pub.calls))
+	}
+	if pub.calls[0].eventName != "order.created" {
+		t.Errorf("expected event name 'order.created', got %q", pub.calls[0].eventName)
+	}
+
+	// msg-recovery-2 should be acquirable after reset
+	acquired, _ := sm.Acquire(ctx, "msg-recovery-2", time.Hour)
+	if !acquired {
+		t.Fatal("expected msg-recovery-2 to be acquirable after reset")
+	}
+}

--- a/event.go
+++ b/event.go
@@ -648,6 +648,7 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 
 			// Build context and call handler directly (payload already decoded).
 			handlerCtx := contextWithInfoCoalesced(out.msg.Context(), out.msg.ID(), e.name, bus.ID(), sub.ID(), out.msg.Metadata(), out.msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, out.count)
+			handlerCtx = ContextWithRawPayload(handlerCtx, out.msg.Payload())
 
 			// Best-effort: ack before handler (at-most-once delivery).
 			if bestEffort {
@@ -814,6 +815,7 @@ func (e *eventImpl[T]) processMessage(
 
 	// Update context values and call handler
 	handlerCtx := contextWithInfoCoalesced(msg.Context(), msg.ID(), e.name, bus.ID(), subID, msg.Metadata(), msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, coalescedCount)
+	handlerCtx = ContextWithRawPayload(handlerCtx, msg.Payload())
 	handlerErr := wrappedHandler(handlerCtx, e, typedData)
 
 	if bestEffort {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.13
 
 require (
 	github.com/IBM/sarama v1.46.3
+	github.com/alicebob/miniredis/v2 v2.36.1
 	github.com/go-faker/faker/v4 v4.7.0
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.11.1
@@ -47,6 +48,7 @@ require (
 	github.com/xdg-go/scram v1.2.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/IBM/sarama v1.46.3 h1:njRsX6jNlnR+ClJ8XmkO+CM4unbrNr/2vB5KK6UA+IE=
 github.com/IBM/sarama v1.46.3/go.mod h1:GTUYiF9DMOZVe3FwyGT+dtSPceGFIgA+sPc5u6CBwko=
+github.com/alicebob/miniredis/v2 v2.36.1 h1:Dvc5oAnNOr7BIfPn7tF269U8DvRW1dBG2D5n0WrfYMI=
+github.com/alicebob/miniredis/v2 v2.36.1/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -93,6 +95,8 @@ github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gi
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/transport/channel/channel.go
+++ b/transport/channel/channel.go
@@ -418,7 +418,12 @@ func (t *Transport) Health(ctx context.Context) *transport.HealthCheckResult {
 	return result
 }
 
+// SupportsRedelivery returns false because channel transport is in-memory
+// and does not persist messages for re-delivery.
+func (t *Transport) SupportsRedelivery() bool { return false }
+
 // Compile-time interface checks
 var _ transport.Transport = (*Transport)(nil)
 var _ transport.HealthChecker = (*Transport)(nil)
+var _ transport.Redeliverable = (*Transport)(nil)
 var _ transport.Subscription = (*subscription)(nil)

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -655,8 +655,13 @@ func (h *consumerHandler) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 	}
 }
 
+// SupportsRedelivery returns true because Kafka natively supports
+// re-delivery of uncommitted messages via consumer group offset management.
+func (t *Transport) SupportsRedelivery() bool { return true }
+
 // Compile-time checks
 var _ transport.Transport = (*Transport)(nil)
 var _ transport.HealthChecker = (*Transport)(nil)
 var _ transport.LagMonitor = (*Transport)(nil)
+var _ transport.Redeliverable = (*Transport)(nil)
 var _ transport.Subscription = (*subscription)(nil)

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -601,8 +601,13 @@ func (s *jsSubscription) consumeLoop(ctx context.Context, logger *slog.Logger) {
 	}
 }
 
+// SupportsRedelivery returns true because NATS JetStream natively supports
+// re-delivery of unacknowledged messages.
+func (t *JetStreamTransport) SupportsRedelivery() bool { return true }
+
 // Compile-time checks
 var _ transport.Transport = (*JetStreamTransport)(nil)
 var _ transport.HealthChecker = (*JetStreamTransport)(nil)
 var _ transport.LagMonitor = (*JetStreamTransport)(nil)
+var _ transport.Redeliverable = (*JetStreamTransport)(nil)
 var _ transport.Subscription = (*jsSubscription)(nil)

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -761,8 +761,13 @@ func (s *subscription) claimOnce(ctx context.Context, logger *slog.Logger) {
 	}
 }
 
+// SupportsRedelivery returns true because Redis Streams natively supports
+// re-delivery of unacknowledged messages via consumer group pending entries.
+func (t *Transport) SupportsRedelivery() bool { return true }
+
 // Compile-time checks
 var _ transport.Transport = (*Transport)(nil)
 var _ transport.HealthChecker = (*Transport)(nil)
 var _ transport.LagMonitor = (*Transport)(nil)
+var _ transport.Redeliverable = (*Transport)(nil)
 var _ transport.Subscription = (*subscription)(nil)

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -113,6 +113,15 @@ type ConsumerLag struct {
 	PendingMessages int64         `json:"pending_messages"` // Messages delivered but not yet acked
 }
 
+// Redeliverable is an optional interface that transports can implement
+// to indicate they support automatic re-delivery of unacknowledged messages.
+// Transports that do NOT implement this interface are assumed to NOT support
+// re-delivery (safe default — the distributed package will store payload
+// for recovery if the StateManager supports it).
+type Redeliverable interface {
+	SupportsRedelivery() bool
+}
+
 // LagMonitor is an optional interface that transports can implement
 // to report consumer lag metrics for monitoring and alerting.
 type LagMonitor interface {


### PR DESCRIPTION
## Summary

- Add `transport.Redeliverable` interface so transports can declare whether they support automatic re-delivery of unacknowledged messages
- Rename `distributed.StateManager` to `Coordinator` and add `PayloadStore` optional interface for persisting message payload alongside state
- `WorkerPoolMiddleware` auto-detects transport capability at runtime and stores payload for recovery when the transport cannot redeliver (e.g., MongoDB Change Streams)
- `RecoveryRunner` two-phase recovery: Phase 1 re-publishes stale entries with stored payload via the bus, Phase 2 resets remaining stale entries for reacquisition
- All three coordinator backends (Redis, MongoDB, Memory) implement `PayloadStore`
- Add `RecoveryMetrics` for OpenTelemetry observability of recovery operations
- All built-in transports declare redelivery support (Redis/Kafka/NATS: true, Channel: false)

### Breaking Changes

- `distributed.StateManager` renamed to `distributed.Coordinator`
- `distributed.WorkerPoolMiddleware[T](sm, ttl)` signature changed to `distributed.WorkerPoolMiddleware[T](coord, ttl, ...PoolOption)`

## Test plan

- [x] All 58 distributed package tests pass (middleware, payload, MongoDB, Redis)
- [x] All 29 event packages pass `go test ./...`
- [x] `go vet ./...` clean
- [ ] Integration test with MongoDB replica set
- [ ] Manual test: kill worker instance, verify recovery re-publishes event