### PR TITLE
fix: prevent message loss in decode-error and shutdown paths

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -40,6 +41,8 @@ type Bus struct {
 	id              string
 	name            string
 	shutdownChan    chan struct{}
+	inflightWG      sync.WaitGroup
+	drainTimeout    time.Duration
 	transport       transport.Transport
 	logger          *slog.Logger
 	tracingEnabled  bool
@@ -91,6 +94,7 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 		status:           busRunning,
 		id:               NewID(),
 		shutdownChan:     make(chan struct{}),
+		drainTimeout:     o.drainTimeout,
 		transport:        transport,
 		logger:           o.logger.With("component", "bus>"+name),
 		tracingEnabled:   o.tracingEnabled,
@@ -210,6 +214,22 @@ func (b *Bus) sendToDLQ(ctx context.Context, eventName string, msg transport.Mes
 	})
 }
 
+// logFallbackDLQ logs the full raw message as a structured log entry when both
+// decode fails and DLQ storage fails. This provides a last-resort recovery path
+// via centralized logging (e.g., CloudWatch, Datadog, ELK).
+func (b *Bus) logFallbackDLQ(logger *slog.Logger, eventName string, msg transport.Message, decodeErr, dlqErr error) {
+	logger.Error("DLQ_FALLBACK: message preserved in log after DLQ store failure",
+		"event", eventName,
+		"msg_id", msg.ID(),
+		"payload_b64", base64.StdEncoding.EncodeToString(msg.Payload()),
+		"metadata", msg.Metadata(),
+		"decode_error", decodeErr,
+		"dlq_error", dlqErr,
+		"retry_count", msg.RetryCount(),
+		"timestamp", msg.Timestamp(),
+	)
+}
+
 // SupportsRedelivery returns true if the underlying transport supports
 // automatic re-delivery of unacknowledged messages.
 // Returns false if transport does not implement transport.Redeliverable.
@@ -240,6 +260,22 @@ func (b *Bus) Close(ctx context.Context) error {
 
 	// Signal all subscriber goroutines to stop
 	close(b.shutdownChan)
+
+	// Wait for in-flight message handlers to complete
+	if b.drainTimeout > 0 {
+		done := make(chan struct{})
+		go func() {
+			b.inflightWG.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+			b.logger.Info("all in-flight handlers completed")
+		case <-time.After(b.drainTimeout):
+			b.logger.Warn("drain timeout exceeded, proceeding with shutdown",
+				"timeout", b.drainTimeout)
+		}
+	}
 
 	var errs []error
 

--- a/bus_options.go
+++ b/bus_options.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/rbaliyan/event/v3/transport"
 )
@@ -13,6 +14,7 @@ type busOptions struct {
 	tracingEnabled  bool
 	recoveryEnabled bool
 	metricsEnabled  bool
+	drainTimeout    time.Duration
 	// Subscriber middleware stores (applied automatically to all subscribers)
 	idempotencyStore IdempotencyStore
 	poisonDetector   PoisonDetector
@@ -245,6 +247,17 @@ func WithDLQ(store DLQStore) BusOption {
 	return func(o *busOptions) {
 		if store != nil {
 			o.dlqStore = store
+		}
+	}
+}
+
+// WithDrainTimeout sets the maximum time Bus.Close() will wait for in-flight
+// message handlers to complete before proceeding with shutdown.
+// A value of 0 (the default) means no waiting — current behavior is preserved.
+func WithDrainTimeout(d time.Duration) BusOption {
+	return func(o *busOptions) {
+		if d > 0 {
+			o.drainTimeout = d
 		}
 	}
 }

--- a/event.go
+++ b/event.go
@@ -431,7 +431,9 @@ func (e *eventImpl[T]) subscribeLoop(
 				return
 			}
 
+			bus.inflightWG.Add(1)
 			e.processMessage(msg, bus, sub, subOpts, wrappedHandler, logger, bestEffort, 0)
+			bus.inflightWG.Done()
 		}
 	}
 }
@@ -471,11 +473,11 @@ func (e *eventImpl[T]) subscribeWithRawCoalesce(
 
 				// Check for transport-level decode errors — handle inline, no coalescing possible.
 				if decodeErrMsg, isDecodeErr := transport.IsDecodeError(msg.Metadata()); isDecodeErr {
+					decodeErr := errors.New(decodeErrMsg)
 					logger.Error("transport decode error, routing to DLQ",
 						"event", e.Name(), "msg_id", msg.ID(), "error", decodeErrMsg)
-					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, errors.New(decodeErrMsg)); dlqErr != nil {
-						logger.Error("DLQ store failed for decode error",
-							"event", e.Name(), "msg_id", msg.ID(), "dlq_error", dlqErr)
+					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, decodeErr); dlqErr != nil {
+						bus.logFallbackDLQ(logger, e.name, msg, decodeErr, dlqErr)
 					}
 					_ = msg.Ack(nil)
 					continue
@@ -512,7 +514,9 @@ func (e *eventImpl[T]) subscribeWithRawCoalesce(
 				return
 			}
 
+			bus.inflightWG.Add(1)
 			e.processMessage(out.msg, bus, sub, subOpts, wrappedHandler, logger, bestEffort, out.count)
+			bus.inflightWG.Done()
 
 			// Signal coalescer that this key is done.
 			select {
@@ -558,11 +562,11 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 
 				// Check for transport-level decode errors — pass through.
 				if decodeErrMsg, isDecodeErr := transport.IsDecodeError(msg.Metadata()); isDecodeErr {
+					decodeErr := errors.New(decodeErrMsg)
 					logger.Error("transport decode error, routing to DLQ",
 						"event", e.Name(), "msg_id", msg.ID(), "error", decodeErrMsg)
-					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, errors.New(decodeErrMsg)); dlqErr != nil {
-						logger.Error("DLQ store failed for decode error",
-							"event", e.Name(), "msg_id", msg.ID(), "dlq_error", dlqErr)
+					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, decodeErr); dlqErr != nil {
+						bus.logFallbackDLQ(logger, e.name, msg, decodeErr, dlqErr)
 					}
 					_ = msg.Ack(nil)
 					continue
@@ -583,11 +587,11 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 
 				codec, codecOk := payload.Get(contentType)
 				if !codecOk {
+					contentErr := fmt.Errorf("unknown content type: %s", contentType)
 					logger.Error("unknown content type, routing to DLQ",
 						"event", e.Name(), "msg_id", msg.ID(), "content_type", contentType)
-					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, fmt.Errorf("unknown content type: %s", contentType)); dlqErr != nil {
-						logger.Error("DLQ store failed for content type error",
-							"event", e.Name(), "msg_id", msg.ID(), "dlq_error", dlqErr)
+					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, contentErr); dlqErr != nil {
+						bus.logFallbackDLQ(logger, e.name, msg, contentErr, dlqErr)
 					}
 					_ = msg.Ack(nil)
 					continue
@@ -597,8 +601,7 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 					logger.Error("decode error, routing to DLQ",
 						"event", e.Name(), "msg_id", msg.ID(), "error", err)
 					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, err); dlqErr != nil {
-						logger.Error("DLQ store failed for decode error",
-							"event", e.Name(), "msg_id", msg.ID(), "dlq_error", dlqErr)
+						bus.logFallbackDLQ(logger, e.name, msg, err, dlqErr)
 					}
 					_ = msg.Ack(nil)
 					continue
@@ -632,6 +635,8 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 				return
 			}
 
+			bus.inflightWG.Add(1)
+
 			// Build context and call handler directly (payload already decoded).
 			handlerCtx := contextWithInfoCoalesced(out.msg.Context(), out.msg.ID(), e.name, bus.ID(), sub.ID(), out.msg.Metadata(), out.msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, out.count)
 			handlerCtx = ContextWithRawPayload(handlerCtx, out.msg.Payload())
@@ -651,6 +656,8 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 			} else {
 				e.handleResult(out.msg, handlerCtx, handlerErr, logger)
 			}
+
+			bus.inflightWG.Done()
 
 			// Signal coalescer that this key is done.
 			select {
@@ -677,17 +684,14 @@ func (e *eventImpl[T]) processMessage(
 
 	// Check for transport-level decode errors
 	if decodeErrMsg, isDecodeErr := transport.IsDecodeError(msg.Metadata()); isDecodeErr {
+		decodeErr := errors.New(decodeErrMsg)
 		logger.Error("transport decode error, routing to DLQ",
 			"event", e.Name(),
 			"msg_id", msg.ID(),
 			"error", decodeErrMsg)
 
-		if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, errors.New(decodeErrMsg)); dlqErr != nil {
-			logger.Error("DLQ store failed for decode error, acknowledging to prevent infinite loop (potential data loss)",
-				"event", e.Name(),
-				"msg_id", msg.ID(),
-				"dlq_error", dlqErr,
-				"decode_error", decodeErrMsg)
+		if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, decodeErr); dlqErr != nil {
+			bus.logFallbackDLQ(logger, e.name, msg, decodeErr, dlqErr)
 		}
 		_ = msg.Ack(nil)
 		return
@@ -713,17 +717,14 @@ func (e *eventImpl[T]) processMessage(
 
 	codec, codecOk := payload.Get(contentType)
 	if !codecOk {
+		contentErr := fmt.Errorf("unknown content type: %s", contentType)
 		logger.Error("unknown content type, routing to DLQ",
 			"event", e.Name(),
 			"msg_id", msg.ID(),
 			"content_type", contentType)
 
-		if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, fmt.Errorf("unknown content type: %s", contentType)); dlqErr != nil {
-			logger.Error("DLQ store failed for content type error, acknowledging to prevent infinite loop (potential data loss)",
-				"event", e.Name(),
-				"msg_id", msg.ID(),
-				"dlq_error", dlqErr,
-				"content_type", contentType)
+		if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, contentErr); dlqErr != nil {
+			bus.logFallbackDLQ(logger, e.name, msg, contentErr, dlqErr)
 		}
 		if !bestEffort {
 			_ = msg.Ack(nil)
@@ -740,11 +741,7 @@ func (e *eventImpl[T]) processMessage(
 				"error", err)
 
 			if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, err); dlqErr != nil {
-				logger.Error("DLQ store failed for decode error, acknowledging to prevent infinite loop (potential data loss)",
-					"event", e.Name(),
-					"msg_id", msg.ID(),
-					"dlq_error", dlqErr,
-					"decode_error", err)
+				bus.logFallbackDLQ(logger, e.name, msg, err, dlqErr)
 			}
 			if !bestEffort {
 				_ = msg.Ack(nil)

--- a/transport/channel/channel.go
+++ b/transport/channel/channel.go
@@ -32,12 +32,13 @@ import (
 
 // Transport implements transport.Transport using Go channels
 type Transport struct {
-	status     int32
-	events     sync.Map // map[string]*eventChannel
-	bufferSize uint
-	timeout    int64 // stored as nanoseconds for atomic access
-	logger     *slog.Logger
-	onError    func(error)
+	status          int32
+	events          sync.Map // map[string]*eventChannel
+	bufferSize      uint
+	timeout         int64 // stored as nanoseconds for atomic access
+	fallbackTimeout int64 // stored as nanoseconds for atomic access, 0 = use default (30s)
+	logger          *slog.Logger
+	onError         func(error)
 
 	// Metrics
 	meter          metric.Meter
@@ -85,13 +86,14 @@ func New(opts ...Option) *Transport {
 	)
 
 	return &Transport{
-		status:         1,
-		bufferSize:     o.bufferSize,
-		timeout:        int64(o.timeout),
-		logger:         o.logger,
-		onError:        o.onError,
-		meter:          meter,
-		droppedCounter: droppedCounter,
+		status:          1,
+		bufferSize:      o.bufferSize,
+		timeout:         int64(o.timeout),
+		fallbackTimeout: int64(o.fallbackTimeout),
+		logger:          o.logger,
+		onError:         o.onError,
+		meter:           meter,
+		droppedCounter:  droppedCounter,
 	}
 }
 
@@ -296,7 +298,7 @@ func (t *Transport) sendToSubscriber(ctx context.Context, sub *subscription, msg
 	}
 
 	// No timeout - try non-blocking first, then block with a generous ceiling
-	// to prevent permanently blocked publisher goroutines. The 30s ceiling is
+	// to prevent permanently blocked publisher goroutines. The default 30s ceiling is
 	// intentionally large — it indicates a severely backed-up subscriber rather
 	// than normal flow control. For guaranteed delivery, use Redis/NATS/Kafka.
 	select {
@@ -305,7 +307,11 @@ func (t *Transport) sendToSubscriber(ctx context.Context, sub *subscription, msg
 	case sub.Ch() <- msg:
 		return nil
 	default:
-		timer := time.NewTimer(30 * time.Second)
+		ft := time.Duration(atomic.LoadInt64(&t.fallbackTimeout))
+		if ft == 0 {
+			ft = 30 * time.Second
+		}
+		timer := time.NewTimer(ft)
 		defer timer.Stop()
 		select {
 		case <-timer.C:

--- a/transport/channel/options.go
+++ b/transport/channel/options.go
@@ -18,12 +18,13 @@ var (
 
 // options holds configuration for transport (unexported)
 type options struct {
-	bufferSize     uint
-	async          bool
-	workerPoolSize int64
-	timeout        time.Duration
-	onError        func(error)
-	logger         *slog.Logger
+	bufferSize      uint
+	async           bool
+	workerPoolSize  int64
+	timeout         time.Duration
+	fallbackTimeout time.Duration
+	onError         func(error)
+	logger          *slog.Logger
 }
 
 // Option configures the channel transport
@@ -60,6 +61,17 @@ func WithWorkerPoolSize(size int64) Option {
 func WithTimeout(d time.Duration) Option {
 	return func(o *options) {
 		o.timeout = d
+	}
+}
+
+// WithFallbackTimeout sets the ceiling timeout used when no explicit timeout is
+// configured. When a subscriber's channel is full, the publisher blocks for up to
+// this duration before dropping the message. Default is 30 seconds.
+func WithFallbackTimeout(d time.Duration) Option {
+	return func(o *options) {
+		if d > 0 {
+			o.fallbackTimeout = d
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **DLQ fallback logging**: When a decode error occurs and the DLQ store is also unavailable, the full raw message (base64-encoded payload, metadata, error context) is now preserved as a structured log entry for manual recovery. Applied to all 7 decode-error code paths in `event.go`.
- **Graceful drain on shutdown**: `Bus.Close()` now tracks in-flight message handlers via `sync.WaitGroup` and waits up to a configurable `WithDrainTimeout(d)` before proceeding. Default is 0 (no wait), preserving current behavior.
- **Configurable channel backpressure ceiling**: New `channel.WithFallbackTimeout(d)` option replaces the hardcoded 30s fallback in `sendToSubscriber()`. Default remains 30s for backward compatibility.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 29 packages)
- [x] Verified 7 `logFallbackDLQ` call sites in `event.go`
- [x] Verified `inflightWG` usage in `bus.go` and `event.go`
- [x] Verified `fallbackTimeout` wired in channel transport