### PR TITLE
refactor: convert panics to error returns

### DIFF
--- a/distributed/distributed_test.go
+++ b/distributed/distributed_test.go
@@ -234,10 +234,13 @@ func TestRecoveryRunner_RecoverOnce(t *testing.T) {
 	)
 	defer sm.Close()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Acquire a message
 	sm.Acquire(ctx, "msg-1", time.Hour)
@@ -279,10 +282,13 @@ func TestRecoveryRunner_Run(t *testing.T) {
 	)
 	defer sm.Close()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(30*time.Millisecond),
 		WithCheckInterval(20*time.Millisecond),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Start runner in background
 	go runner.Run(ctx)

--- a/distributed/example_test.go
+++ b/distributed/example_test.go
@@ -211,11 +211,15 @@ func ExampleNewRecoveryRunner() {
 	defer sm.Close()
 
 	// Create recovery runner with custom settings
-	runner := distributed.NewRecoveryRunner(sm,
+	runner, err := distributed.NewRecoveryRunner(sm,
 		distributed.WithStaleTimeout(2*time.Minute),
 		distributed.WithCheckInterval(30*time.Second),
 		distributed.WithBatchLimit(100),
 	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
 
 	ctx := context.Background()
 

--- a/distributed/mongodb_integration_test.go
+++ b/distributed/mongodb_integration_test.go
@@ -288,10 +288,13 @@ func TestMongoStateManager_Integration_RecoveryRunner(t *testing.T) {
 
 	ctx := context.Background()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Acquire a message
 	sm.Acquire(ctx, "recovery-1", time.Hour)
@@ -333,11 +336,14 @@ func TestMongoStateManager_Integration_PayloadRecovery(t *testing.T) {
 	// Track re-published events
 	pub := &integrationMockPublisher{}
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 		WithPublisher(pub),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Acquire and store payload (simulates middleware with payload storage)
 	acquired, err := sm.Acquire(ctx, "payload-1", time.Hour)

--- a/distributed/payload_test.go
+++ b/distributed/payload_test.go
@@ -239,10 +239,13 @@ func TestRecoveryRunner_BasicReset(t *testing.T) {
 	defer sm.Close()
 
 	// No Publisher → basic reset mode
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.Acquire(ctx, "msg-2", time.Hour)
@@ -273,11 +276,14 @@ func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
 	defer sm.Close()
 
 	pub := &mockPublisher{}
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 		WithPublisher(pub),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// msg-1: has payload (Phase 1 re-publishes)
 	sm.Acquire(ctx, "msg-1", time.Hour)
@@ -323,10 +329,13 @@ func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
 	sm := NewMemoryStateManager(WithCleanup(false, 0))
 	defer sm.Close()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(0), // No limit
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.Acquire(ctx, "msg-2", time.Hour)
@@ -351,11 +360,14 @@ func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
 
 	pub := &mockPublisher{}
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 		WithPublisher(pub),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Acquire and store payload
 	sm.Acquire(ctx, "msg-1", time.Hour)
@@ -416,10 +428,13 @@ func TestRecoveryRunner_PublishFailure_SkipsEntry(t *testing.T) {
 	// Publisher that always fails
 	failPub := &failingPublisher{err: errors.New("publish failed")}
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithPublisher(failPub),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.StorePayload(ctx, "msg-1", &MessageData{
@@ -469,11 +484,14 @@ func TestRecoveryRunner_WithRealBus(t *testing.T) {
 	defer sm.Close()
 
 	// Bus satisfies Publisher interface
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 		WithPublisher(bus),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.StorePayload(ctx, "msg-1", &MessageData{
@@ -576,18 +594,11 @@ func TestRecoveryMetrics_BatchNilSafe(t *testing.T) {
 	m.recordResetN(ctx, -1)
 }
 
-func TestNewRecoveryRunner_NilCoordinator_Panics(t *testing.T) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic for nil coordinator")
-		}
-		msg, ok := r.(string)
-		if !ok || msg != "distributed: NewRecoveryRunner requires a non-nil Coordinator" {
-			t.Fatalf("unexpected panic message: %v", r)
-		}
-	}()
-	NewRecoveryRunner(nil)
+func TestNewRecoveryRunner_NilCoordinator_ReturnsError(t *testing.T) {
+	_, err := NewRecoveryRunner(nil)
+	if err == nil {
+		t.Fatal("expected error for nil coordinator")
+	}
 }
 
 func TestRecoveryMetrics_Creation(t *testing.T) {
@@ -639,9 +650,12 @@ func TestRecoveryRunner_RecoverOnce_NoStaleEntries(t *testing.T) {
 	sm := NewMemoryStateManager(WithCleanup(false, 0))
 	defer sm.Close()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(time.Minute),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// No entries at all
 	recovered, err := runner.RecoverOnce(ctx)
@@ -683,10 +697,13 @@ func TestRecoveryRunner_WithMetrics(t *testing.T) {
 		t.Fatalf("failed to create metrics: %v", err)
 	}
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithRecoveryMetrics(metrics),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	time.Sleep(60 * time.Millisecond)

--- a/distributed/recovery.go
+++ b/distributed/recovery.go
@@ -2,6 +2,7 @@ package distributed
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync/atomic"
 	"time"
@@ -192,14 +193,14 @@ func WithPublisher(pub Publisher) RecoveryOption {
 // NewRecoveryRunner creates a new stale state recovery runner.
 //
 // Parameters:
-//   - coord: The coordinator to monitor for stale states
+//   - coord: The coordinator to monitor for stale states (must not be nil)
 //   - opts: Optional configuration (Publisher, timeouts, logger, etc.)
 //
-// Returns a configured runner. Call Run() to start background recovery
-// or RecoverOnce() for manual recovery.
-func NewRecoveryRunner(coord Coordinator, opts ...RecoveryOption) *RecoveryRunner {
+// Returns a configured runner and an error if coord is nil.
+// Call Run() to start background recovery or RecoverOnce() for manual recovery.
+func NewRecoveryRunner(coord Coordinator, opts ...RecoveryOption) (*RecoveryRunner, error) {
 	if coord == nil {
-		panic("distributed: NewRecoveryRunner requires a non-nil Coordinator")
+		return nil, fmt.Errorf("distributed: NewRecoveryRunner requires a non-nil Coordinator")
 	}
 
 	o := &recoveryOptions{
@@ -219,7 +220,7 @@ func NewRecoveryRunner(coord Coordinator, opts ...RecoveryOption) *RecoveryRunne
 		logger:        o.logger,
 		backoff:       o.backoff,
 		metrics:       o.metrics,
-	}
+	}, nil
 }
 
 // Run starts the background recovery loop.

--- a/distributed/redis_integration_test.go
+++ b/distributed/redis_integration_test.go
@@ -292,10 +292,13 @@ func TestRedisStateManager_Integration_RecoveryRunner(t *testing.T) {
 
 	ctx := context.Background()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Acquire a message
 	sm.Acquire(ctx, "recovery-1", time.Hour)
@@ -335,10 +338,13 @@ func TestRedisStateManager_Integration_RecoveryRunnerBackground(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(30*time.Millisecond),
 		WithCheckInterval(20*time.Millisecond),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Start runner in background
 	go runner.Run(ctx)

--- a/distributed/redis_test.go
+++ b/distributed/redis_test.go
@@ -352,10 +352,13 @@ func TestRedisStateManager_RecoveryRunner(t *testing.T) {
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 
@@ -445,11 +448,14 @@ func TestRedisStateManager_PayloadRecovery(t *testing.T) {
 	ctx := context.Background()
 
 	pub := &mockPublisher{}
-	runner := NewRecoveryRunner(sm,
+	runner, err := NewRecoveryRunner(sm,
 		WithStaleTimeout(50*time.Millisecond),
 		WithBatchLimit(10),
 		WithPublisher(pub),
 	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
 
 	// Acquire and store payload (simulates middleware behavior)
 	sm.Acquire(ctx, "msg-recovery-1", time.Hour)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -322,19 +322,21 @@ func IsTimeout(err error) bool {
 	return errors.Is(err, ErrTimeout)
 }
 
-// RequireNotNil panics if the value is nil with a descriptive message.
+// RequireNotNil returns an error wrapping ErrInvalidArgument if the value is nil.
 // Use this in constructors for required parameters that must not be nil.
 // Handles both untyped nil and typed nil (e.g., var db *sql.DB = nil).
 //
 // Example:
 //
-//	func NewStore(db *sql.DB) *Store {
-//	    errors.RequireNotNil(db, "db")
-//	    return &Store{db: db}
+//	func NewStore(db *sql.DB) (*Store, error) {
+//	    if err := errors.RequireNotNil(db, "db"); err != nil {
+//	        return nil, err
+//	    }
+//	    return &Store{db: db}, nil
 //	}
-func RequireNotNil(value any, name string) {
+func RequireNotNil(value any, name string) error {
 	if value == nil {
-		panic(fmt.Sprintf("%s must not be nil", name))
+		return fmt.Errorf("%s must not be nil: %w", name, ErrInvalidArgument)
 	}
 	// Check for typed nils using reflection
 	// This handles cases like var db *sql.DB = nil
@@ -343,39 +345,45 @@ func RequireNotNil(value any, name string) {
 	if (kind == reflect.Ptr || kind == reflect.Interface ||
 		kind == reflect.Map || kind == reflect.Slice ||
 		kind == reflect.Chan || kind == reflect.Func) && v.IsNil() {
-		panic(fmt.Sprintf("%s must not be nil", name))
+		return fmt.Errorf("%s must not be nil: %w", name, ErrInvalidArgument)
 	}
+	return nil
 }
 
-// RequireNotEmpty panics if the string is empty with a descriptive message.
+// RequireNotEmpty returns an error wrapping ErrInvalidArgument if the string is empty.
 // Use this in constructors for required string parameters.
 //
 // Example:
 //
-//	func NewSaga(name string) *Saga {
-//	    errors.RequireNotEmpty(name, "name")
-//	    return &Saga{name: name}
+//	func NewSaga(name string) (*Saga, error) {
+//	    if err := errors.RequireNotEmpty(name, "name"); err != nil {
+//	        return nil, err
+//	    }
+//	    return &Saga{name: name}, nil
 //	}
-func RequireNotEmpty(value string, name string) {
+func RequireNotEmpty(value string, name string) error {
 	if value == "" {
-		panic(fmt.Sprintf("%s must not be empty", name))
+		return fmt.Errorf("%s must not be empty: %w", name, ErrInvalidArgument)
 	}
+	return nil
 }
 
-// RequirePositive panics if the integer is not positive (> 0).
+// RequirePositive returns an error wrapping ErrInvalidArgument if the integer is not positive (> 0).
 // Use this in constructors for required positive integer parameters.
-func RequirePositive(value int, name string) {
+func RequirePositive(value int, name string) error {
 	if value <= 0 {
-		panic(fmt.Sprintf("%s must be positive, got %d", name, value))
+		return fmt.Errorf("%s must be positive, got %d: %w", name, value, ErrInvalidArgument)
 	}
+	return nil
 }
 
-// RequireNonNegative panics if the integer is negative.
+// RequireNonNegative returns an error wrapping ErrInvalidArgument if the integer is negative.
 // Use this in constructors for parameters that must be >= 0.
-func RequireNonNegative(value int, name string) {
+func RequireNonNegative(value int, name string) error {
 	if value < 0 {
-		panic(fmt.Sprintf("%s must be non-negative, got %d", name, value))
+		return fmt.Errorf("%s must be non-negative, got %d: %w", name, value, ErrInvalidArgument)
 	}
+	return nil
 }
 
 // IsMaxRetriesExceeded checks if an error indicates max retries exceeded.

--- a/event.go
+++ b/event.go
@@ -431,9 +431,11 @@ func (e *eventImpl[T]) subscribeLoop(
 				return
 			}
 
-			bus.inflightWG.Add(1)
-			e.processMessage(msg, bus, sub, subOpts, wrappedHandler, logger, bestEffort, 0)
-			bus.inflightWG.Done()
+			func() {
+				bus.inflightWG.Add(1)
+				defer bus.inflightWG.Done()
+				e.processMessage(msg, bus, sub, subOpts, wrappedHandler, logger, bestEffort, 0)
+			}()
 		}
 	}
 }
@@ -514,9 +516,11 @@ func (e *eventImpl[T]) subscribeWithRawCoalesce(
 				return
 			}
 
-			bus.inflightWG.Add(1)
-			e.processMessage(out.msg, bus, sub, subOpts, wrappedHandler, logger, bestEffort, out.count)
-			bus.inflightWG.Done()
+			func() {
+				bus.inflightWG.Add(1)
+				defer bus.inflightWG.Done()
+				e.processMessage(out.msg, bus, sub, subOpts, wrappedHandler, logger, bestEffort, out.count)
+			}()
 
 			// Signal coalescer that this key is done.
 			select {
@@ -635,29 +639,30 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 				return
 			}
 
-			bus.inflightWG.Add(1)
+			func() {
+				bus.inflightWG.Add(1)
+				defer bus.inflightWG.Done()
 
-			// Build context and call handler directly (payload already decoded).
-			handlerCtx := contextWithInfoCoalesced(out.msg.Context(), out.msg.ID(), e.name, bus.ID(), sub.ID(), out.msg.Metadata(), out.msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, out.count)
-			handlerCtx = ContextWithRawPayload(handlerCtx, out.msg.Payload())
+				// Build context and call handler directly (payload already decoded).
+				handlerCtx := contextWithInfoCoalesced(out.msg.Context(), out.msg.ID(), e.name, bus.ID(), sub.ID(), out.msg.Metadata(), out.msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, out.count)
+				handlerCtx = ContextWithRawPayload(handlerCtx, out.msg.Payload())
 
-			// Best-effort: ack before handler (at-most-once delivery).
-			if bestEffort {
-				_ = out.msg.Ack(nil)
-			}
-
-			handlerErr := wrappedHandler(handlerCtx, e, out.value)
-
-			if bestEffort {
-				if handlerErr != nil {
-					logger.Warn("best-effort handler error suppressed",
-						"event", e.Name(), "msg_id", out.msg.ID(), "error", handlerErr)
+				// Best-effort: ack before handler (at-most-once delivery).
+				if bestEffort {
+					_ = out.msg.Ack(nil)
 				}
-			} else {
-				e.handleResult(out.msg, handlerCtx, handlerErr, logger)
-			}
 
-			bus.inflightWG.Done()
+				handlerErr := wrappedHandler(handlerCtx, e, out.value)
+
+				if bestEffort {
+					if handlerErr != nil {
+						logger.Warn("best-effort handler error suppressed",
+							"event", e.Name(), "msg_id", out.msg.ID(), "error", handlerErr)
+					}
+				} else {
+					e.handleResult(out.msg, handlerCtx, handlerErr, logger)
+				}
+			}()
 
 			// Signal coalescer that this key is done.
 			select {

--- a/testing.go
+++ b/testing.go
@@ -18,24 +18,20 @@ var testBusCounter uint64
 // The transport parameter is required - use channel.New() for in-memory testing.
 // Has recovery/tracing/metrics disabled for simpler testing.
 // Each call generates a unique bus name, safe for parallel tests.
-// Panics if transport is nil (test setup error).
+// Returns an error if transport is nil or bus creation fails.
 //
 // Example:
 //
 //	import "github.com/rbaliyan/event/v3/transport/channel"
-//	bus := event.TestBus(channel.New())
-func TestBus(t transport.Transport) *Bus {
+//	bus, err := event.TestBus(channel.New())
+func TestBus(t transport.Transport) (*Bus, error) {
 	n := atomic.AddUint64(&testBusCounter, 1)
-	bus, err := NewBus(fmt.Sprintf("test-bus-%d", n),
+	return NewBus(fmt.Sprintf("test-bus-%d", n),
 		WithTransport(t),
 		WithRecovery(false),
 		WithTracing(false),
 		WithMetrics(false),
 	)
-	if err != nil {
-		panic("event.TestBus: " + err.Error())
-	}
-	return bus
 }
 
 // RecordedMessage represents a message that was published during a test
@@ -59,15 +55,15 @@ type RecordingTransport struct {
 // Example:
 //
 //	import "github.com/rbaliyan/event/v3/transport/channel"
-//	transport := event.NewRecordingTransport(channel.New())
-func NewRecordingTransport(t transport.Transport) *RecordingTransport {
+//	transport, err := event.NewRecordingTransport(channel.New())
+func NewRecordingTransport(t transport.Transport) (*RecordingTransport, error) {
 	if t == nil {
-		panic("event: transport is required for NewRecordingTransport")
+		return nil, fmt.Errorf("event: transport is required for NewRecordingTransport")
 	}
 	return &RecordingTransport{
 		Transport: t,
 		messages:  make([]RecordedMessage, 0),
-	}
+	}, nil
 }
 
 // Publish records the message and delegates to the underlying transport
@@ -246,16 +242,16 @@ type BlockingTransport struct {
 // Example:
 //
 //	import "github.com/rbaliyan/event/v3/transport/channel"
-//	transport := event.NewBlockingTransport(channel.New())
-func NewBlockingTransport(t transport.Transport) *BlockingTransport {
+//	transport, err := event.NewBlockingTransport(channel.New())
+func NewBlockingTransport(t transport.Transport) (*BlockingTransport, error) {
 	if t == nil {
-		panic("event: transport is required for NewBlockingTransport")
+		return nil, fmt.Errorf("event: transport is required for NewBlockingTransport")
 	}
 	return &BlockingTransport{
 		Transport: t,
 		blockCh:   make(chan struct{}),
 		blocked:   true,
-	}
+	}, nil
 }
 
 // Publish blocks until Release is called, then delegates to underlying transport
@@ -322,14 +318,14 @@ type FailingTransport struct {
 // Example:
 //
 //	import "github.com/rbaliyan/event/v3/transport/channel"
-//	transport := event.NewFailingTransport(channel.New())
-func NewFailingTransport(t transport.Transport) *FailingTransport {
+//	transport, err := event.NewFailingTransport(channel.New())
+func NewFailingTransport(t transport.Transport) (*FailingTransport, error) {
 	if t == nil {
-		panic("event: transport is required for NewFailingTransport")
+		return nil, fmt.Errorf("event: transport is required for NewFailingTransport")
 	}
 	return &FailingTransport{
 		Transport: t,
-	}
+	}, nil
 }
 
 // Publish fails if configured, otherwise delegates to underlying transport

--- a/transaction/manager.go
+++ b/transaction/manager.go
@@ -72,6 +72,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 )
 
 // ErrTransactionFailed is returned when a transaction cannot be completed.
@@ -337,7 +338,7 @@ func (m *SQLManager) Begin(ctx context.Context) (Transaction, error) {
 //
 //	    return nil // Triggers commit
 //	})
-func (m *SQLManager) Execute(ctx context.Context, fn func(tx Transaction) error) error {
+func (m *SQLManager) Execute(ctx context.Context, fn func(tx Transaction) error) (retErr error) {
 	tx, err := m.Begin(ctx)
 	if err != nil {
 		return err
@@ -346,7 +347,7 @@ func (m *SQLManager) Execute(ctx context.Context, fn func(tx Transaction) error)
 	defer func() {
 		if p := recover(); p != nil {
 			_ = tx.Rollback()
-			panic(p)
+			retErr = fmt.Errorf("transaction panicked: %v: %w", p, ErrTransactionFailed)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- Convert all `panic()` calls to proper error returns across the event library
- `errors.RequireNotNil/RequireNotEmpty/RequirePositive/RequireNonNegative` now return `error` wrapping `ErrInvalidArgument`
- `distributed.NewRecoveryRunner` returns `(*RecoveryRunner, error)` instead of panicking on nil coordinator
- `transaction.SQLManager.Execute` catches panics and returns `ErrTransactionFailed` via named return instead of re-panicking
- `TestBus`, `NewRecordingTransport`, `NewBlockingTransport`, `NewFailingTransport` return `(*T, error)`
- Wrap `inflightWG.Add/Done` in deferred closure for panic safety

## Test plan

- [x] `go test ./...` passes (all 27 packages)
- [x] All test callers updated to handle new error returns
- [x] Nil coordinator test converted from panic expectation to error check