### PR TITLE
fix: correct transaction docs and add errors package tests

### DIFF
--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,180 @@
+package errors
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+func TestRequireNotNil(t *testing.T) {
+	t.Run("untyped nil", func(t *testing.T) {
+		err := RequireNotNil(nil, "db")
+		if err == nil {
+			t.Fatal("expected error for untyped nil")
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Errorf("expected ErrInvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("typed nil pointer", func(t *testing.T) {
+		var db *sql.DB
+		err := RequireNotNil(db, "db")
+		if err == nil {
+			t.Fatal("expected error for typed nil pointer")
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Errorf("expected ErrInvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("typed nil map", func(t *testing.T) {
+		var m map[string]string
+		err := RequireNotNil(m, "config")
+		if err == nil {
+			t.Fatal("expected error for typed nil map")
+		}
+	})
+
+	t.Run("typed nil slice", func(t *testing.T) {
+		var s []int
+		err := RequireNotNil(s, "items")
+		if err == nil {
+			t.Fatal("expected error for typed nil slice")
+		}
+	})
+
+	t.Run("typed nil func", func(t *testing.T) {
+		var fn func()
+		err := RequireNotNil(fn, "callback")
+		if err == nil {
+			t.Fatal("expected error for typed nil func")
+		}
+	})
+
+	t.Run("non-nil pointer", func(t *testing.T) {
+		db := &sql.DB{}
+		err := RequireNotNil(db, "db")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("non-nil value", func(t *testing.T) {
+		err := RequireNotNil(42, "count")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("error message includes name", func(t *testing.T) {
+		err := RequireNotNil(nil, "transport")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); got != "transport must not be nil: invalid argument" {
+			t.Errorf("unexpected message: %s", got)
+		}
+	})
+}
+
+func TestRequireNotEmpty(t *testing.T) {
+	t.Run("empty string", func(t *testing.T) {
+		err := RequireNotEmpty("", "name")
+		if err == nil {
+			t.Fatal("expected error for empty string")
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Errorf("expected ErrInvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("non-empty string", func(t *testing.T) {
+		err := RequireNotEmpty("hello", "name")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("error message includes name", func(t *testing.T) {
+		err := RequireNotEmpty("", "event_name")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); got != "event_name must not be empty: invalid argument" {
+			t.Errorf("unexpected message: %s", got)
+		}
+	})
+}
+
+func TestRequirePositive(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		err := RequirePositive(0, "count")
+		if err == nil {
+			t.Fatal("expected error for zero")
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Errorf("expected ErrInvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		err := RequirePositive(-1, "count")
+		if err == nil {
+			t.Fatal("expected error for negative")
+		}
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		err := RequirePositive(1, "count")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("error message includes value", func(t *testing.T) {
+		err := RequirePositive(-5, "retries")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); got != "retries must be positive, got -5: invalid argument" {
+			t.Errorf("unexpected message: %s", got)
+		}
+	})
+}
+
+func TestRequireNonNegative(t *testing.T) {
+	t.Run("negative", func(t *testing.T) {
+		err := RequireNonNegative(-1, "offset")
+		if err == nil {
+			t.Fatal("expected error for negative")
+		}
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Errorf("expected ErrInvalidArgument, got %v", err)
+		}
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		err := RequireNonNegative(0, "offset")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		err := RequireNonNegative(5, "offset")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("error message includes value", func(t *testing.T) {
+		err := RequireNonNegative(-3, "timeout")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got := err.Error(); got != "timeout must be non-negative, got -3: invalid argument" {
+			t.Errorf("unexpected message: %s", got)
+		}
+	})
+}

--- a/transaction/example_test.go
+++ b/transaction/example_test.go
@@ -482,24 +482,23 @@ func Example_panicRecovery() {
 	//
 	//       return nil
 	//   })
-	//   // ...the transaction is rolled back and the panic is re-raised
+	//   // ...the transaction is rolled back and an error wrapping ErrTransactionFailed is returned
 	//
 	// This ensures data consistency even when unexpected panics occur.
-	// The panic is re-raised after rollback, so it can be caught by
-	// your application's panic handler.
+	// The error wraps ErrTransactionFailed and can be checked with errors.Is().
 
 	fmt.Println("Panic recovery behavior:")
 	fmt.Println("1. Panic occurs in handler")
 	fmt.Println("2. Transaction is rolled back")
-	fmt.Println("3. Panic is re-raised")
-	fmt.Println("4. Application panic handler catches it")
+	fmt.Println("3. Error wrapping ErrTransactionFailed is returned")
+	fmt.Println("4. Caller checks with errors.Is(err, ErrTransactionFailed)")
 
 	// Output:
 	// Panic recovery behavior:
 	// 1. Panic occurs in handler
 	// 2. Transaction is rolled back
-	// 3. Panic is re-raised
-	// 4. Application panic handler catches it
+	// 3. Error wrapping ErrTransactionFailed is returned
+	// 4. Caller checks with errors.Is(err, ErrTransactionFailed)
 }
 
 // Example_keyFunctionPatterns demonstrates common patterns for idempotency key extraction.

--- a/transaction/manager.go
+++ b/transaction/manager.go
@@ -175,7 +175,7 @@ type Manager interface {
 	//
 	// If fn returns nil, the transaction is committed.
 	// If fn returns an error, the transaction is rolled back.
-	// If fn panics, the transaction is rolled back and the panic is re-raised.
+	// If fn panics, the transaction is rolled back and the panic is returned as an error wrapping ErrTransactionFailed.
 	Execute(ctx context.Context, fn func(tx Transaction) error) error
 }
 


### PR DESCRIPTION
## Summary
- Update Execute() godoc to reflect that panics are returned as errors wrapping ErrTransactionFailed (not re-raised)
- Update Example_panicRecovery test to match new behavior
- Add comprehensive unit tests for errors package validation functions (RequireNotNil, RequireNotEmpty, RequirePositive, RequireNonNegative)

## Test plan
- [x] `go test ./...` — all 27 packages pass
- [x] `go build ./...` — clean build