### PR TITLE
feat(distributed): add WorkerStore API for worker pool observability

### DIFF
--- a/distributed/memory_worker_store.go
+++ b/distributed/memory_worker_store.go
@@ -1,0 +1,177 @@
+package distributed
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// ListWorkers returns a paginated list of worker entries matching the filter.
+func (s *MemoryStateManager) ListWorkers(_ context.Context, filter WorkerFilter) (*WorkerPage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Collect matching entries
+	var all []*WorkerEntry
+	for id, entry := range s.states {
+		we := memoryEntryToWorkerEntry(id, entry)
+		if !matchesWorkerFilter(we, filter) {
+			continue
+		}
+		all = append(all, we)
+	}
+
+	// Sort by updated_at, then message_id
+	if filter.OrderDesc {
+		sort.Slice(all, func(i, j int) bool {
+			if !all[i].UpdatedAt.Equal(all[j].UpdatedAt) {
+				return all[i].UpdatedAt.After(all[j].UpdatedAt)
+			}
+			return all[i].MessageID > all[j].MessageID
+		})
+	} else {
+		sort.Slice(all, func(i, j int) bool {
+			if !all[i].UpdatedAt.Equal(all[j].UpdatedAt) {
+				return all[i].UpdatedAt.Before(all[j].UpdatedAt)
+			}
+			return all[i].MessageID < all[j].MessageID
+		})
+	}
+
+	// Apply cursor-based pagination
+	startIdx := 0
+	if filter.Cursor != "" {
+		cur, err := decodeWorkerCursor(filter.Cursor)
+		if err != nil {
+			return nil, err
+		}
+		for i, e := range all {
+			if filter.OrderDesc {
+				if e.UpdatedAt.Before(cur.UpdatedAt) || (e.UpdatedAt.Equal(cur.UpdatedAt) && e.MessageID < cur.ID) {
+					startIdx = i
+					break
+				}
+			} else {
+				if e.UpdatedAt.After(cur.UpdatedAt) || (e.UpdatedAt.Equal(cur.UpdatedAt) && e.MessageID > cur.ID) {
+					startIdx = i
+					break
+				}
+			}
+		}
+	}
+
+	limit := filter.EffectiveLimit()
+	end := startIdx + limit + 1 // +1 to detect hasMore
+	if end > len(all) {
+		end = len(all)
+	}
+	page := all[startIdx:end]
+
+	hasMore := len(page) > limit
+	if hasMore {
+		page = page[:limit]
+	}
+
+	var nextCursor string
+	if hasMore && len(page) > 0 {
+		last := page[len(page)-1]
+		nextCursor = encodeWorkerCursor(workerCursor{
+			UpdatedAt: last.UpdatedAt,
+			ID:        last.MessageID,
+		})
+	}
+
+	return &WorkerPage{
+		Entries:    page,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}
+
+// CountWorkers returns the number of worker entries matching the filter.
+func (s *MemoryStateManager) CountWorkers(_ context.Context, filter WorkerFilter) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var count int64
+	for id, entry := range s.states {
+		we := memoryEntryToWorkerEntry(id, entry)
+		if matchesWorkerFilter(we, filter) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// GetWorker returns a single worker entry by message ID.
+func (s *MemoryStateManager) GetWorker(_ context.Context, messageID string) (*WorkerEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, exists := s.states[messageID]
+	if !exists {
+		return nil, nil
+	}
+	return memoryEntryToWorkerEntry(messageID, entry), nil
+}
+
+func memoryEntryToWorkerEntry(id string, entry *stateEntry) *WorkerEntry {
+	status := WorkerStateProcessing
+	if entry.state == stateCompleted {
+		status = WorkerStateCompleted
+	}
+
+	var eventName string
+	var metadata map[string]string
+	if entry.payload != nil {
+		eventName = entry.payload.EventName
+		metadata = entry.payload.Metadata
+	}
+
+	return &WorkerEntry{
+		MessageID: id,
+		Status:    status,
+		EventName: eventName,
+		Metadata:  metadata,
+		ExpiresAt: entry.expiresAt,
+		CreatedAt: entry.updatedAt, // memory backend doesn't track createdAt separately
+		UpdatedAt: entry.updatedAt,
+	}
+}
+
+func matchesWorkerFilter(entry *WorkerEntry, filter WorkerFilter) bool {
+	if len(filter.Status) > 0 {
+		matched := false
+		for _, s := range filter.Status {
+			if entry.Status == s {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if filter.EventName != "" && entry.EventName != filter.EventName {
+		return false
+	}
+	if filter.WorkerID != "" && entry.WorkerID != filter.WorkerID {
+		return false
+	}
+	if filter.StaleTimeout > 0 {
+		cutoff := time.Now().Add(-filter.StaleTimeout)
+		if entry.Status != WorkerStateProcessing || !entry.UpdatedAt.Before(cutoff) {
+			return false
+		}
+	}
+	if !filter.CreatedAfter.IsZero() && entry.CreatedAt.Before(filter.CreatedAfter) {
+		return false
+	}
+	if !filter.CreatedBefore.IsZero() && !entry.CreatedAt.Before(filter.CreatedBefore) {
+		return false
+	}
+	return true
+}
+
+// Compile-time check that MemoryStateManager implements WorkerStore.
+var _ WorkerStore = (*MemoryStateManager)(nil)

--- a/distributed/mongodb_worker_store.go
+++ b/distributed/mongodb_worker_store.go
@@ -1,0 +1,207 @@
+package distributed
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// workerCursor represents the pagination cursor state for worker queries.
+type workerCursor struct {
+	UpdatedAt time.Time `json:"u"`
+	ID        string    `json:"i"`
+}
+
+// ListWorkers returns a paginated list of worker entries matching the filter.
+func (s *MongoStateManager) ListWorkers(ctx context.Context, filter WorkerFilter) (*WorkerPage, error) {
+	mongoFilter := s.buildWorkerFilter(filter)
+
+	// Apply cursor for pagination
+	if filter.Cursor != "" {
+		cur, err := decodeWorkerCursor(filter.Cursor)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cursor: %w", err)
+		}
+
+		var cursorFilter bson.M
+		if filter.OrderDesc {
+			cursorFilter = bson.M{
+				"$or": []bson.M{
+					{"updated_at": bson.M{"$lt": cur.UpdatedAt}},
+					{
+						"updated_at": cur.UpdatedAt,
+						"_id":        bson.M{"$lt": cur.ID},
+					},
+				},
+			}
+		} else {
+			cursorFilter = bson.M{
+				"$or": []bson.M{
+					{"updated_at": bson.M{"$gt": cur.UpdatedAt}},
+					{
+						"updated_at": cur.UpdatedAt,
+						"_id":        bson.M{"$gt": cur.ID},
+					},
+				},
+			}
+		}
+
+		if len(mongoFilter) > 0 {
+			mongoFilter = bson.M{"$and": []bson.M{mongoFilter, cursorFilter}}
+		} else {
+			mongoFilter = cursorFilter
+		}
+	}
+
+	// Build sort
+	sortOrder := 1
+	if filter.OrderDesc {
+		sortOrder = -1
+	}
+	sort := bson.D{
+		{Key: "updated_at", Value: sortOrder},
+		{Key: "_id", Value: sortOrder},
+	}
+
+	// Query one extra to detect next page
+	limit := int64(filter.EffectiveLimit() + 1)
+
+	findOpts := options.Find().
+		SetSort(sort).
+		SetLimit(limit)
+
+	cursor, err := s.collection.Find(ctx, mongoFilter, findOpts)
+	if err != nil {
+		return nil, fmt.Errorf("list workers: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var entries []*WorkerEntry
+	for cursor.Next(ctx) {
+		var doc stateDocument
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode worker: %w", err)
+		}
+		entries = append(entries, stateDocToWorkerEntry(&doc))
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("cursor error: %w", err)
+	}
+
+	hasMore := len(entries) > filter.EffectiveLimit()
+	if hasMore {
+		entries = entries[:filter.EffectiveLimit()]
+	}
+
+	var nextCursor string
+	if hasMore && len(entries) > 0 {
+		last := entries[len(entries)-1]
+		nextCursor = encodeWorkerCursor(workerCursor{
+			UpdatedAt: last.UpdatedAt,
+			ID:        last.MessageID,
+		})
+	}
+
+	return &WorkerPage{
+		Entries:    entries,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}
+
+// CountWorkers returns the number of worker entries matching the filter.
+func (s *MongoStateManager) CountWorkers(ctx context.Context, filter WorkerFilter) (int64, error) {
+	mongoFilter := s.buildWorkerFilter(filter)
+	count, err := s.collection.CountDocuments(ctx, mongoFilter)
+	if err != nil {
+		return 0, fmt.Errorf("count workers: %w", err)
+	}
+	return count, nil
+}
+
+// GetWorker returns a single worker entry by message ID.
+func (s *MongoStateManager) GetWorker(ctx context.Context, messageID string) (*WorkerEntry, error) {
+	var doc stateDocument
+	err := s.collection.FindOne(ctx, bson.M{"_id": messageID}).Decode(&doc)
+	if err == mongo.ErrNoDocuments {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get worker: %w", err)
+	}
+	return stateDocToWorkerEntry(&doc), nil
+}
+
+// buildWorkerFilter creates a MongoDB filter from WorkerFilter.
+func (s *MongoStateManager) buildWorkerFilter(filter WorkerFilter) bson.M {
+	m := bson.M{}
+
+	if len(filter.Status) > 0 {
+		statuses := make([]string, len(filter.Status))
+		for i, st := range filter.Status {
+			statuses[i] = string(st)
+		}
+		m["status"] = bson.M{"$in": statuses}
+	}
+	if filter.EventName != "" {
+		m["event_name"] = filter.EventName
+	}
+	if filter.WorkerID != "" {
+		m["worker_id"] = filter.WorkerID
+	}
+	if filter.StaleTimeout > 0 {
+		cutoff := time.Now().Add(-filter.StaleTimeout)
+		m["status"] = statusProcessing
+		m["updated_at"] = bson.M{"$lt": cutoff}
+	}
+	if !filter.CreatedAfter.IsZero() || !filter.CreatedBefore.IsZero() {
+		createdAt := bson.M{}
+		if !filter.CreatedAfter.IsZero() {
+			createdAt["$gte"] = filter.CreatedAfter
+		}
+		if !filter.CreatedBefore.IsZero() {
+			createdAt["$lt"] = filter.CreatedBefore
+		}
+		m["created_at"] = createdAt
+	}
+
+	return m
+}
+
+// stateDocToWorkerEntry converts a stateDocument to a WorkerEntry.
+func stateDocToWorkerEntry(doc *stateDocument) *WorkerEntry {
+	return &WorkerEntry{
+		MessageID: doc.ID,
+		Status:    WorkerState(doc.Status),
+		WorkerID:  doc.WorkerID,
+		EventName: doc.EventName,
+		Metadata:  doc.Metadata,
+		ExpiresAt: doc.ExpiresAt,
+		CreatedAt: doc.CreatedAt,
+		UpdatedAt: doc.UpdatedAt,
+	}
+}
+
+func encodeWorkerCursor(c workerCursor) string {
+	data, _ := json.Marshal(c)
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func decodeWorkerCursor(str string) (workerCursor, error) {
+	var c workerCursor
+	data, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return c, err
+	}
+	err = json.Unmarshal(data, &c)
+	return c, err
+}
+
+// Compile-time check that MongoStateManager implements WorkerStore.
+var _ WorkerStore = (*MongoStateManager)(nil)

--- a/distributed/worker_store.go
+++ b/distributed/worker_store.go
@@ -1,0 +1,62 @@
+package distributed
+
+import (
+	"context"
+	"time"
+)
+
+// WorkerState represents the state of a worker entry.
+type WorkerState string
+
+const (
+	WorkerStateProcessing WorkerState = "processing"
+	WorkerStateCompleted  WorkerState = "completed"
+	WorkerStateReleased   WorkerState = "released"
+)
+
+// WorkerEntry represents a worker state entry for API responses.
+type WorkerEntry struct {
+	MessageID string            `json:"message_id"`
+	Status    WorkerState       `json:"status"`
+	WorkerID  string            `json:"worker_id,omitempty"`
+	EventName string            `json:"event_name,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	ExpiresAt time.Time         `json:"expires_at"`
+	CreatedAt time.Time         `json:"created_at"`
+	UpdatedAt time.Time         `json:"updated_at"`
+}
+
+// WorkerFilter specifies criteria for querying worker entries.
+type WorkerFilter struct {
+	Status        []WorkerState
+	EventName     string
+	WorkerID      string
+	StaleTimeout  time.Duration
+	CreatedAfter  time.Time
+	CreatedBefore time.Time
+	Cursor        string
+	Limit         int
+	OrderDesc     bool
+}
+
+// EffectiveLimit returns the limit to use for queries, defaulting to 50.
+func (f WorkerFilter) EffectiveLimit() int {
+	if f.Limit <= 0 || f.Limit > 1000 {
+		return 50
+	}
+	return f.Limit
+}
+
+// WorkerPage represents a paginated list of worker entries.
+type WorkerPage struct {
+	Entries    []*WorkerEntry `json:"entries"`
+	NextCursor string         `json:"next_cursor,omitempty"`
+	HasMore    bool           `json:"has_more"`
+}
+
+// WorkerStore provides read-only access to worker pool state for observability.
+type WorkerStore interface {
+	ListWorkers(ctx context.Context, filter WorkerFilter) (*WorkerPage, error)
+	CountWorkers(ctx context.Context, filter WorkerFilter) (int64, error)
+	GetWorker(ctx context.Context, messageID string) (*WorkerEntry, error)
+}

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -2,27 +2,40 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/rbaliyan/event/v3/distributed"
 	"github.com/rbaliyan/event/v3/monitor"
 	pb "github.com/rbaliyan/event/v3/monitor/proto"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
+// Option configures the Handler.
+type Option func(*Handler)
+
+// WithWorkerStore enables the /v1/workers endpoints for worker pool state.
+func WithWorkerStore(ws distributed.WorkerStore) Option {
+	return func(h *Handler) {
+		h.workerStore = ws
+	}
+}
+
 // Handler implements http.Handler for the monitor service using protoJSON.
 type Handler struct {
 	store       monitor.Store
+	workerStore distributed.WorkerStore
 	mux         *http.ServeMux
 	marshaler   protojson.MarshalOptions
 	unmarshaler protojson.UnmarshalOptions
 }
 
 // New creates a new HTTP handler for the monitor service.
-func New(store monitor.Store) *Handler {
+func New(store monitor.Store, opts ...Option) *Handler {
 	h := &Handler{
 		store: store,
 		mux:   http.NewServeMux(),
@@ -35,6 +48,10 @@ func New(store monitor.Store) *Handler {
 		},
 	}
 
+	for _, opt := range opts {
+		opt(h)
+	}
+
 	// Register routes following REST conventions
 	// GET /v1/monitor/entries - List entries with query params
 	// GET /v1/monitor/entries/{event_id} - Get entries by event ID
@@ -44,6 +61,13 @@ func New(store monitor.Store) *Handler {
 	h.mux.HandleFunc("/v1/monitor/entries", h.handleEntries)
 	h.mux.HandleFunc("/v1/monitor/entries/", h.handleEntriesWithPath)
 	h.mux.HandleFunc("/v1/monitor/entries/count", h.handleCount)
+
+	// Register worker pool state endpoints if worker store is configured
+	if h.workerStore != nil {
+		h.mux.HandleFunc("/v1/workers", h.handleWorkerList)
+		h.mux.HandleFunc("/v1/workers/", h.handleWorkerByID)
+		h.mux.HandleFunc("/v1/workers/count", h.handleWorkerCount)
+	}
 
 	return h
 }
@@ -277,4 +301,12 @@ func (h *Handler) writeError(w http.ResponseWriter, code int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	w.Write([]byte(`{"error":"` + message + `"}`))
+}
+
+// writeJSON writes a JSON response using encoding/json (for non-protobuf types).
+func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+	}
 }

--- a/monitor/http/workers.go
+++ b/monitor/http/workers.go
@@ -1,0 +1,126 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rbaliyan/event/v3/distributed"
+)
+
+// handleWorkerList handles GET /v1/workers.
+func (h *Handler) handleWorkerList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	filter := parseWorkerFilterFromQuery(r)
+
+	page, err := h.workerStore.ListWorkers(r.Context(), filter)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	h.writeJSON(w, page)
+}
+
+// handleWorkerCount handles GET /v1/workers/count.
+func (h *Handler) handleWorkerCount(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	filter := parseWorkerFilterFromQuery(r)
+
+	count, err := h.workerStore.CountWorkers(r.Context(), filter)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	h.writeJSON(w, map[string]int64{"count": count})
+}
+
+// handleWorkerByID handles GET /v1/workers/{message_id} and dispatches /v1/workers/count.
+func (h *Handler) handleWorkerByID(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/v1/workers/")
+
+	// Dispatch /v1/workers/count to the count handler
+	if path == "count" {
+		h.handleWorkerCount(w, r)
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if path == "" {
+		h.writeError(w, http.StatusBadRequest, "message_id is required")
+		return
+	}
+
+	entry, err := h.workerStore.GetWorker(r.Context(), path)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if entry == nil {
+		h.writeError(w, http.StatusNotFound, "worker entry not found")
+		return
+	}
+
+	h.writeJSON(w, entry)
+}
+
+// parseWorkerFilterFromQuery parses a WorkerFilter from URL query parameters.
+func parseWorkerFilterFromQuery(r *http.Request) distributed.WorkerFilter {
+	q := r.URL.Query()
+	filter := distributed.WorkerFilter{}
+
+	if v := q["status"]; len(v) > 0 {
+		filter.Status = make([]distributed.WorkerState, len(v))
+		for i, s := range v {
+			filter.Status[i] = distributed.WorkerState(s)
+		}
+	}
+	if v := q.Get("event_name"); v != "" {
+		filter.EventName = v
+	}
+	if v := q.Get("worker_id"); v != "" {
+		filter.WorkerID = v
+	}
+	if v := q.Get("stale_timeout"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			filter.StaleTimeout = d
+		}
+	}
+	if v := q.Get("created_after"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			filter.CreatedAfter = t
+		}
+	}
+	if v := q.Get("created_before"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			filter.CreatedBefore = t
+		}
+	}
+	if v := q.Get("cursor"); v != "" {
+		filter.Cursor = v
+	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			filter.Limit = n
+		}
+	}
+	if v := q.Get("order_desc"); v != "" {
+		filter.OrderDesc = v == "true" || v == "1"
+	}
+
+	return filter
+}

--- a/monitor/http/workers_test.go
+++ b/monitor/http/workers_test.go
@@ -1,0 +1,294 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/distributed"
+	"github.com/rbaliyan/event/v3/monitor"
+)
+
+func newWorkerTestHandler(t *testing.T) (*Handler, *distributed.MemoryStateManager) {
+	t.Helper()
+	store := monitor.NewMemoryStore()
+	t.Cleanup(func() { store.Close() })
+
+	sm := distributed.NewMemoryStateManager(distributed.WithCleanup(false, 0))
+	t.Cleanup(sm.Close)
+
+	h := New(store, WithWorkerStore(sm))
+	return h, sm
+}
+
+func TestWorkerEndpointsDisabledWithoutStore(t *testing.T) {
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	h := New(store) // No WithWorkerStore
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workers", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	// Without worker store, the route is not registered and the default mux 404 applies
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestWorkerList(t *testing.T) {
+	h, sm := newWorkerTestHandler(t)
+	ctx := context.Background()
+
+	// Populate some worker entries via Acquire
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+	sm.Acquire(ctx, "msg-3", 5*time.Minute)
+
+	// Mark one as completed
+	sm.MarkProcessed(ctx, "msg-2")
+
+	t.Run("GET /v1/workers lists all entries", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/workers", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var page distributed.WorkerPage
+		if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if len(page.Entries) != 3 {
+			t.Errorf("expected 3 entries, got %d", len(page.Entries))
+		}
+	})
+
+	t.Run("POST /v1/workers returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/workers", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+func TestWorkerListFilterByStatus(t *testing.T) {
+	h, sm := newWorkerTestHandler(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+	sm.MarkProcessed(ctx, "msg-2")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workers?status=processing", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var page distributed.WorkerPage
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Errorf("expected 1 processing entry, got %d", len(page.Entries))
+	}
+	if len(page.Entries) > 0 && page.Entries[0].Status != distributed.WorkerStateProcessing {
+		t.Errorf("expected processing status, got %s", page.Entries[0].Status)
+	}
+}
+
+func TestWorkerListStaleTimeout(t *testing.T) {
+	h, sm := newWorkerTestHandler(t)
+	ctx := context.Background()
+
+	// Acquire with very short TTL so updatedAt is in the past
+	sm.Acquire(ctx, "msg-stale", 5*time.Minute)
+
+	// Sleep briefly to ensure stale detection
+	time.Sleep(10 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/workers?stale_timeout=5ms", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var page distributed.WorkerPage
+	if err := json.Unmarshal(w.Body.Bytes(), &page); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Errorf("expected 1 stale entry, got %d", len(page.Entries))
+	}
+}
+
+func TestWorkerGetByID(t *testing.T) {
+	h, sm := newWorkerTestHandler(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-42", 5*time.Minute)
+
+	t.Run("GET /v1/workers/msg-42 returns entry", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/workers/msg-42", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var entry distributed.WorkerEntry
+		if err := json.Unmarshal(w.Body.Bytes(), &entry); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if entry.MessageID != "msg-42" {
+			t.Errorf("expected msg-42, got %s", entry.MessageID)
+		}
+		if entry.Status != distributed.WorkerStateProcessing {
+			t.Errorf("expected processing, got %s", entry.Status)
+		}
+	})
+
+	t.Run("GET /v1/workers/non-existent returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/workers/non-existent", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+}
+
+func TestWorkerCount(t *testing.T) {
+	h, sm := newWorkerTestHandler(t)
+	ctx := context.Background()
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+	sm.Acquire(ctx, "msg-3", 5*time.Minute)
+	sm.MarkProcessed(ctx, "msg-3")
+
+	t.Run("GET /v1/workers/count returns total", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/workers/count", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]int64
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if resp["count"] != 3 {
+			t.Errorf("expected 3, got %d", resp["count"])
+		}
+	})
+
+	t.Run("GET /v1/workers/count?status=completed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/workers/count?status=completed", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var resp map[string]int64
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if resp["count"] != 1 {
+			t.Errorf("expected 1, got %d", resp["count"])
+		}
+	})
+
+	t.Run("POST /v1/workers/count returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/workers/count", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+func TestWorkerPagination(t *testing.T) {
+	h, sm := newWorkerTestHandler(t)
+	ctx := context.Background()
+
+	// Create entries with slight time gaps for deterministic ordering
+	for i := 0; i < 5; i++ {
+		sm.Acquire(ctx, "msg-"+string(rune('a'+i)), 5*time.Minute)
+		time.Sleep(time.Millisecond) // ensure different updatedAt
+	}
+
+	// First page: limit=2
+	req := httptest.NewRequest(http.MethodGet, "/v1/workers?limit=2", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var page1 distributed.WorkerPage
+	if err := json.Unmarshal(w.Body.Bytes(), &page1); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(page1.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(page1.Entries))
+	}
+	if !page1.HasMore {
+		t.Fatal("expected has_more to be true")
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("expected non-empty next_cursor")
+	}
+
+	// Second page using cursor
+	req = httptest.NewRequest(http.MethodGet, "/v1/workers?limit=2&cursor="+page1.NextCursor, nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var page2 distributed.WorkerPage
+	if err := json.Unmarshal(w.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(page2.Entries) != 2 {
+		t.Fatalf("expected 2 entries on page 2, got %d", len(page2.Entries))
+	}
+	if !page2.HasMore {
+		t.Fatal("expected has_more to be true on page 2")
+	}
+
+	// Verify no overlap
+	for _, e1 := range page1.Entries {
+		for _, e2 := range page2.Entries {
+			if e1.MessageID == e2.MessageID {
+				t.Errorf("entry %s appears on both pages", e1.MessageID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `WorkerStore` interface (`ListWorkers`, `CountWorkers`, `GetWorker`) in the `distributed` package with MongoDB and Memory implementations
- Extend `monitor/http.Handler` with an `Option` pattern and `WithWorkerStore()` to serve `/v1/workers` endpoints alongside existing `/v1/monitor/entries`
- Support filtering by status, event_name, worker_id, stale_timeout, created time range, and cursor-based pagination

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./monitor/http/...` — 20 tests pass (existing + 7 new worker tests)
- [x] `go vet ./distributed/... ./monitor/http/...` clean
- [ ] Verify compass builds with local replace directive
- [ ] Manual test: `curl /events/v1/workers`, `/v1/workers?status=processing`, `/v1/workers/count`, `/v1/workers/{id}`