### PR TITLE
fix: improve coherent design, robustness, and interface quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,25 @@ orderEvent.Subscribe(ctx, collectAnalytics,
 
 All three backends implement both `Coordinator` and `PayloadStore` interfaces.
 
+### Worker Observability
+
+Query active and completed worker states using the `WorkerStore` interface
+(implemented by `MongoStateManager` and `MemoryStateManager`):
+
+```go
+page, _ := sm.ListWorkers(ctx, distributed.WorkerFilter{
+    Status: []distributed.WorkerState{distributed.WorkerStateProcessing},
+    Limit:  100,
+})
+
+count, _ := sm.CountWorkers(ctx, distributed.WorkerFilter{
+    StaleTimeout: 5 * time.Minute,
+})
+```
+
+**Note**: `RedisStateManager` does not implement `WorkerStore` due to
+Redis SCAN's O(N) cost.
+
 ## Transactional Outbox Pattern
 
 Ensure atomic publish with database writes:
@@ -549,6 +568,20 @@ Endpoints:
 - `GET /v1/monitor/entries` - List entries with filters
 - `GET /v1/monitor/entries/{event_id}` - Get entries for an event
 - `DELETE /v1/monitor/entries?older_than=1h` - Delete old entries
+
+### Worker Pool State (HTTP)
+
+When using distributed worker pools with MongoDB, expose worker state
+via the monitor HTTP handler:
+
+```go
+handler := monitorhttp.New(store, monitorhttp.WithWorkerStore(sm))
+```
+
+Endpoints:
+- `GET /v1/workers` - List workers (filters: status, event_name, stale_timeout, cursor, limit)
+- `GET /v1/workers/{message_id}` - Get single worker
+- `GET /v1/workers/count` - Count workers matching filter
 
 ## Schema Registry
 

--- a/bus.go
+++ b/bus.go
@@ -33,7 +33,7 @@ const (
 // Using the same name across distributed systems enables:
 // - WorkerPool mode: load balancing across instances (one receives)
 // - Broadcast mode: all instances receive messages
-var DefaultBusName = "event-bus"
+const DefaultBusName = "event-bus"
 
 // Bus is an event bus that manages events and their lifecycle
 type Bus struct {

--- a/distributed/memory_worker_store.go
+++ b/distributed/memory_worker_store.go
@@ -45,18 +45,24 @@ func (s *MemoryStateManager) ListWorkers(_ context.Context, filter WorkerFilter)
 		if err != nil {
 			return nil, err
 		}
+		found := false
 		for i, e := range all {
 			if filter.OrderDesc {
 				if e.UpdatedAt.Before(cur.UpdatedAt) || (e.UpdatedAt.Equal(cur.UpdatedAt) && e.MessageID < cur.ID) {
 					startIdx = i
+					found = true
 					break
 				}
 			} else {
 				if e.UpdatedAt.After(cur.UpdatedAt) || (e.UpdatedAt.Equal(cur.UpdatedAt) && e.MessageID > cur.ID) {
 					startIdx = i
+					found = true
 					break
 				}
 			}
+		}
+		if !found {
+			return &WorkerPage{Entries: nil, HasMore: false}, nil
 		}
 	}
 

--- a/distributed/memory_worker_store_test.go
+++ b/distributed/memory_worker_store_test.go
@@ -1,0 +1,340 @@
+package distributed
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func newTestMemoryWorkerStore(t *testing.T) *MemoryStateManager {
+	t.Helper()
+	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	t.Cleanup(sm.Close)
+	return sm
+}
+
+func TestMemoryListWorkers(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+	sm.Acquire(ctx, "msg-3", 5*time.Minute)
+
+	page, err := sm.ListWorkers(ctx, WorkerFilter{})
+	if err != nil {
+		t.Fatalf("ListWorkers: %v", err)
+	}
+	if len(page.Entries) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(page.Entries))
+	}
+}
+
+func TestMemoryListWorkersFilterStatus(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+	sm.MarkProcessed(ctx, "msg-2")
+
+	t.Run("processing only", func(t *testing.T) {
+		page, err := sm.ListWorkers(ctx, WorkerFilter{
+			Status: []WorkerState{WorkerStateProcessing},
+		})
+		if err != nil {
+			t.Fatalf("ListWorkers: %v", err)
+		}
+		if len(page.Entries) != 1 {
+			t.Errorf("expected 1 processing entry, got %d", len(page.Entries))
+		}
+		if len(page.Entries) > 0 && page.Entries[0].Status != WorkerStateProcessing {
+			t.Errorf("expected processing, got %s", page.Entries[0].Status)
+		}
+	})
+
+	t.Run("completed only", func(t *testing.T) {
+		page, err := sm.ListWorkers(ctx, WorkerFilter{
+			Status: []WorkerState{WorkerStateCompleted},
+		})
+		if err != nil {
+			t.Fatalf("ListWorkers: %v", err)
+		}
+		if len(page.Entries) != 1 {
+			t.Errorf("expected 1 completed entry, got %d", len(page.Entries))
+		}
+		if len(page.Entries) > 0 && page.Entries[0].Status != WorkerStateCompleted {
+			t.Errorf("expected completed, got %s", page.Entries[0].Status)
+		}
+	})
+}
+
+func TestMemoryListWorkersStaleTimeout(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-stale", 5*time.Minute)
+	time.Sleep(15 * time.Millisecond)
+	sm.Acquire(ctx, "msg-fresh", 5*time.Minute)
+
+	page, err := sm.ListWorkers(ctx, WorkerFilter{
+		StaleTimeout: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("ListWorkers: %v", err)
+	}
+	if len(page.Entries) != 1 {
+		t.Errorf("expected 1 stale entry, got %d", len(page.Entries))
+	}
+	if len(page.Entries) > 0 && page.Entries[0].MessageID != "msg-stale" {
+		t.Errorf("expected msg-stale, got %s", page.Entries[0].MessageID)
+	}
+}
+
+func TestMemoryListWorkersCreatedRange(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	time.Sleep(5 * time.Millisecond)
+	midpoint := time.Now()
+	time.Sleep(5 * time.Millisecond)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+
+	t.Run("created after midpoint", func(t *testing.T) {
+		page, err := sm.ListWorkers(ctx, WorkerFilter{
+			CreatedAfter: midpoint,
+		})
+		if err != nil {
+			t.Fatalf("ListWorkers: %v", err)
+		}
+		if len(page.Entries) != 1 {
+			t.Errorf("expected 1 entry after midpoint, got %d", len(page.Entries))
+		}
+	})
+
+	t.Run("created before midpoint", func(t *testing.T) {
+		page, err := sm.ListWorkers(ctx, WorkerFilter{
+			CreatedBefore: midpoint,
+		})
+		if err != nil {
+			t.Fatalf("ListWorkers: %v", err)
+		}
+		if len(page.Entries) != 1 {
+			t.Errorf("expected 1 entry before midpoint, got %d", len(page.Entries))
+		}
+	})
+}
+
+func TestMemoryListWorkersOrderDesc(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-a", 5*time.Minute)
+	time.Sleep(2 * time.Millisecond)
+	sm.Acquire(ctx, "msg-b", 5*time.Minute)
+	time.Sleep(2 * time.Millisecond)
+	sm.Acquire(ctx, "msg-c", 5*time.Minute)
+
+	page, err := sm.ListWorkers(ctx, WorkerFilter{OrderDesc: true})
+	if err != nil {
+		t.Fatalf("ListWorkers: %v", err)
+	}
+	if len(page.Entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(page.Entries))
+	}
+	// Descending: msg-c (newest) should be first
+	if page.Entries[0].MessageID != "msg-c" {
+		t.Errorf("expected msg-c first (newest), got %s", page.Entries[0].MessageID)
+	}
+	if page.Entries[2].MessageID != "msg-a" {
+		t.Errorf("expected msg-a last (oldest), got %s", page.Entries[2].MessageID)
+	}
+}
+
+func TestMemoryListWorkersPagination(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	for i := 0; i < 5; i++ {
+		sm.Acquire(ctx, "msg-"+string(rune('a'+i)), 5*time.Minute)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// First page
+	page1, err := sm.ListWorkers(ctx, WorkerFilter{Limit: 2})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if len(page1.Entries) != 2 {
+		t.Fatalf("expected 2 entries on page 1, got %d", len(page1.Entries))
+	}
+	if !page1.HasMore {
+		t.Fatal("expected HasMore on page 1")
+	}
+	if page1.NextCursor == "" {
+		t.Fatal("expected non-empty cursor on page 1")
+	}
+
+	// Second page
+	page2, err := sm.ListWorkers(ctx, WorkerFilter{Limit: 2, Cursor: page1.NextCursor})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(page2.Entries) != 2 {
+		t.Fatalf("expected 2 entries on page 2, got %d", len(page2.Entries))
+	}
+	if !page2.HasMore {
+		t.Fatal("expected HasMore on page 2")
+	}
+
+	// Third page (last)
+	page3, err := sm.ListWorkers(ctx, WorkerFilter{Limit: 2, Cursor: page2.NextCursor})
+	if err != nil {
+		t.Fatalf("page 3: %v", err)
+	}
+	if len(page3.Entries) != 1 {
+		t.Fatalf("expected 1 entry on page 3, got %d", len(page3.Entries))
+	}
+	if page3.HasMore {
+		t.Fatal("expected no more pages")
+	}
+
+	// Verify no overlap between pages
+	seen := make(map[string]bool)
+	for _, e := range page1.Entries {
+		seen[e.MessageID] = true
+	}
+	for _, e := range page2.Entries {
+		if seen[e.MessageID] {
+			t.Errorf("duplicate entry %s on page 2", e.MessageID)
+		}
+		seen[e.MessageID] = true
+	}
+	for _, e := range page3.Entries {
+		if seen[e.MessageID] {
+			t.Errorf("duplicate entry %s on page 3", e.MessageID)
+		}
+	}
+}
+
+func TestMemoryListWorkersCursorPastEnd(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+
+	// Get cursor from first page
+	page1, err := sm.ListWorkers(ctx, WorkerFilter{Limit: 1})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if len(page1.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(page1.Entries))
+	}
+
+	// Create a cursor pointing past all entries
+	futureCursor := encodeWorkerCursor(workerCursor{
+		UpdatedAt: time.Now().Add(time.Hour),
+		ID:        "zzz",
+	})
+
+	page2, err := sm.ListWorkers(ctx, WorkerFilter{Cursor: futureCursor})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(page2.Entries) != 0 {
+		t.Errorf("expected 0 entries for cursor past end, got %d", len(page2.Entries))
+	}
+	if page2.HasMore {
+		t.Error("expected HasMore=false for cursor past end")
+	}
+}
+
+func TestMemoryListWorkersInvalidCursor(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	_, err := sm.ListWorkers(ctx, WorkerFilter{Cursor: "not-valid-base64!"})
+	if err == nil {
+		t.Error("expected error for invalid cursor")
+	}
+}
+
+func TestMemoryCountWorkers(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-1", 5*time.Minute)
+	sm.Acquire(ctx, "msg-2", 5*time.Minute)
+	sm.Acquire(ctx, "msg-3", 5*time.Minute)
+	sm.MarkProcessed(ctx, "msg-3")
+
+	t.Run("total count", func(t *testing.T) {
+		count, err := sm.CountWorkers(ctx, WorkerFilter{})
+		if err != nil {
+			t.Fatalf("CountWorkers: %v", err)
+		}
+		if count != 3 {
+			t.Errorf("expected 3, got %d", count)
+		}
+	})
+
+	t.Run("count processing", func(t *testing.T) {
+		count, err := sm.CountWorkers(ctx, WorkerFilter{
+			Status: []WorkerState{WorkerStateProcessing},
+		})
+		if err != nil {
+			t.Fatalf("CountWorkers: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("expected 2 processing, got %d", count)
+		}
+	})
+
+	t.Run("count completed", func(t *testing.T) {
+		count, err := sm.CountWorkers(ctx, WorkerFilter{
+			Status: []WorkerState{WorkerStateCompleted},
+		})
+		if err != nil {
+			t.Fatalf("CountWorkers: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("expected 1 completed, got %d", count)
+		}
+	})
+}
+
+func TestMemoryGetWorker(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	sm.Acquire(ctx, "msg-42", 5*time.Minute)
+
+	entry, err := sm.GetWorker(ctx, "msg-42")
+	if err != nil {
+		t.Fatalf("GetWorker: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if entry.MessageID != "msg-42" {
+		t.Errorf("expected msg-42, got %s", entry.MessageID)
+	}
+	if entry.Status != WorkerStateProcessing {
+		t.Errorf("expected processing, got %s", entry.Status)
+	}
+}
+
+func TestMemoryGetWorkerNotFound(t *testing.T) {
+	ctx := context.Background()
+	sm := newTestMemoryWorkerStore(t)
+
+	entry, err := sm.GetWorker(ctx, "non-existent")
+	if err != nil {
+		t.Fatalf("GetWorker: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("expected nil for non-existent, got %+v", entry)
+	}
+}

--- a/distributed/mongodb_worker_store.go
+++ b/distributed/mongodb_worker_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -129,7 +130,7 @@ func (s *MongoStateManager) CountWorkers(ctx context.Context, filter WorkerFilte
 func (s *MongoStateManager) GetWorker(ctx context.Context, messageID string) (*WorkerEntry, error) {
 	var doc stateDocument
 	err := s.collection.FindOne(ctx, bson.M{"_id": messageID}).Decode(&doc)
-	if err == mongo.ErrNoDocuments {
+	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, nil
 	}
 	if err != nil {
@@ -142,7 +143,13 @@ func (s *MongoStateManager) GetWorker(ctx context.Context, messageID string) (*W
 func (s *MongoStateManager) buildWorkerFilter(filter WorkerFilter) bson.M {
 	m := bson.M{}
 
-	if len(filter.Status) > 0 {
+	if filter.StaleTimeout > 0 {
+		// StaleTimeout implies processing status with stale updated_at.
+		// This is mutually exclusive with the Status filter.
+		cutoff := time.Now().Add(-filter.StaleTimeout)
+		m["status"] = statusProcessing
+		m["updated_at"] = bson.M{"$lt": cutoff}
+	} else if len(filter.Status) > 0 {
 		statuses := make([]string, len(filter.Status))
 		for i, st := range filter.Status {
 			statuses[i] = string(st)
@@ -154,11 +161,6 @@ func (s *MongoStateManager) buildWorkerFilter(filter WorkerFilter) bson.M {
 	}
 	if filter.WorkerID != "" {
 		m["worker_id"] = filter.WorkerID
-	}
-	if filter.StaleTimeout > 0 {
-		cutoff := time.Now().Add(-filter.StaleTimeout)
-		m["status"] = statusProcessing
-		m["updated_at"] = bson.M{"$lt": cutoff}
 	}
 	if !filter.CreatedAfter.IsZero() || !filter.CreatedBefore.IsZero() {
 		createdAt := bson.M{}

--- a/distributed/redis.go
+++ b/distributed/redis.go
@@ -458,6 +458,10 @@ func (s *RedisStateManager) ClearPayload(ctx context.Context, messageID string) 
 	return s.client.Del(ctx, s.payloadKey(messageID)).Err()
 }
 
+// RedisStateManager does not implement WorkerStore because listing
+// worker entries via Redis SCAN is O(N) and impractical at scale.
+// Use MongoStateManager or MemoryStateManager for worker observability.
+
 // Compile-time interface checks
 var (
 	_ Coordinator   = (*RedisStateManager)(nil)

--- a/distributed/worker_store.go
+++ b/distributed/worker_store.go
@@ -39,10 +39,19 @@ type WorkerFilter struct {
 	OrderDesc     bool
 }
 
-// EffectiveLimit returns the limit to use for queries, defaulting to 50.
+// DefaultWorkerLimit is the default page size when Limit is 0.
+const DefaultWorkerLimit = 100
+
+// MaxWorkerLimit is the maximum allowed page size.
+const MaxWorkerLimit = 1000
+
+// EffectiveLimit returns the limit to use for queries, applying defaults and bounds.
 func (f WorkerFilter) EffectiveLimit() int {
-	if f.Limit <= 0 || f.Limit > 1000 {
-		return 50
+	if f.Limit <= 0 {
+		return DefaultWorkerLimit
+	}
+	if f.Limit > MaxWorkerLimit {
+		return MaxWorkerLimit
 	}
 	return f.Limit
 }

--- a/event_test.go
+++ b/event_test.go
@@ -1352,7 +1352,7 @@ func TestBusLogger(t *testing.T) {
 	}
 }
 
-// TestSanitize verifies Sanitize function
+// TestSanitize verifies sanitize function
 func TestSanitize(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -1369,17 +1369,17 @@ func TestSanitize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			if got := Sanitize(tt.input); got != tt.expected {
-				t.Errorf("Sanitize(%s) = %s, want %s", tt.input, got, tt.expected)
+			if got := sanitize(tt.input); got != tt.expected {
+				t.Errorf("sanitize(%s) = %s, want %s", tt.input, got, tt.expected)
 			}
 		})
 	}
 }
 
-// TestCaller verifies Caller function
+// TestCaller verifies caller function
 func TestCaller(t *testing.T) {
 	// Test calling from this function
-	name := Caller(1)
+	name := caller(1)
 	if name == "" {
 		t.Error("expected non-empty caller name")
 	}
@@ -1388,7 +1388,7 @@ func TestCaller(t *testing.T) {
 	}
 
 	// Test invalid depth
-	name = Caller(100)
+	name = caller(100)
 	if name != "" {
 		t.Errorf("expected empty string for invalid depth, got %s", name)
 	}

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -15,13 +15,18 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// handlerOptions holds configuration for the Handler.
+type handlerOptions struct {
+	workerStore distributed.WorkerStore
+}
+
 // Option configures the Handler.
-type Option func(*Handler)
+type Option func(*handlerOptions)
 
 // WithWorkerStore enables the /v1/workers endpoints for worker pool state.
 func WithWorkerStore(ws distributed.WorkerStore) Option {
-	return func(h *Handler) {
-		h.workerStore = ws
+	return func(o *handlerOptions) {
+		o.workerStore = ws
 	}
 }
 
@@ -36,9 +41,15 @@ type Handler struct {
 
 // New creates a new HTTP handler for the monitor service.
 func New(store monitor.Store, opts ...Option) *Handler {
+	o := &handlerOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	h := &Handler{
-		store: store,
-		mux:   http.NewServeMux(),
+		store:       store,
+		workerStore: o.workerStore,
+		mux:         http.NewServeMux(),
 		marshaler: protojson.MarshalOptions{
 			EmitUnpopulated: true,
 			UseProtoNames:   true,
@@ -46,10 +57,6 @@ func New(store monitor.Store, opts ...Option) *Handler {
 		unmarshaler: protojson.UnmarshalOptions{
 			DiscardUnknown: true,
 		},
-	}
-
-	for _, opt := range opts {
-		opt(h)
 	}
 
 	// Register routes following REST conventions
@@ -300,13 +307,16 @@ func (h *Handler) writeResponse(w http.ResponseWriter, msg proto.Message) {
 func (h *Handler) writeError(w http.ResponseWriter, code int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	w.Write([]byte(`{"error":"` + message + `"}`))
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
 
 // writeJSON writes a JSON response using encoding/json (for non-protobuf types).
 func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(v); err != nil {
+	data, err := json.Marshal(v)
+	if err != nil {
 		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
 }

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -37,7 +37,7 @@ var (
 )
 
 // DefaultBusName is used as default consumer group
-var DefaultBusName = "event-bus"
+const DefaultBusName = "event-bus"
 
 // Transport implements transport.Transport using Kafka
 type Transport struct {

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -48,7 +48,7 @@ type Client interface {
 var ErrClientRequired = errors.New("redis client is required")
 
 // DefaultBusName is used as default consumer group
-var DefaultBusName = "event-bus"
+const DefaultBusName = "event-bus"
 
 // Transport implements transport.Transport using Redis Streams
 type Transport struct {

--- a/util.go
+++ b/util.go
@@ -21,8 +21,8 @@ const (
 	spanKeyEventSubscriptionID = "subscription.id"
 )
 
-// Sanitize strings and remove special chars
-func Sanitize(s string) string {
+// sanitize strings and remove special chars
+func sanitize(s string) string {
 	var result strings.Builder
 	result.Grow(len(s))
 	for i := 0; i < len(s); i++ {
@@ -92,8 +92,8 @@ func AsyncHandler[T any](handler Handler[T], copyContextFns ...func(to, from con
 	}
 }
 
-// Caller get caller function name
-func Caller(depth int) string {
+// caller gets the caller function name.
+func caller(depth int) string {
 	pc, _, _, ok := runtime.Caller(depth)
 	if !ok {
 		return ""


### PR DESCRIPTION
## Summary
- Fix buildWorkerFilter bug where StaleTimeout overwrites Status filter
- Fix errors.Is usage, memory cursor pagination, writeJSON/writeError safety
- Fix monitor/http Option pattern to use `func(*handlerOptions)`
- Align EffectiveLimit with monitor.Store defaults (100/1000)
- Unexport dead exports (Caller, Sanitize), make DefaultBusName const
- Add Redis WorkerStore omission godoc
- Add 11 direct memory WorkerStore tests
- Update README with Worker Observability and HTTP endpoint docs

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (27 packages, including new memory_worker_store_test.go)
- [x] Verify writeJSON marshals to bytes before writing
- [x] Verify writeError uses proper JSON encoding
- [x] Verify memory cursor past-end returns empty page