### PR TITLE
fix(distributed): add missing indexes for ListWorkers queries

### DIFF
--- a/distributed/mongodb.go
+++ b/distributed/mongodb.go
@@ -573,13 +573,12 @@ func (s *MongoStateManager) LoadStalePayloads(ctx context.Context, staleTimeout 
 	return results, nil
 }
 
-// ClearPayload removes stored payload for a message.
+// ClearPayload removes the stored binary payload for a message.
+// Metadata and event_name are preserved for observability via the workers API.
 func (s *MongoStateManager) ClearPayload(ctx context.Context, messageID string) error {
 	_, err := s.collection.UpdateOne(ctx, bson.M{"_id": messageID}, bson.M{
 		"$unset": bson.M{
-			"payload":    "",
-			"metadata":   "",
-			"event_name": "",
+			"payload": "",
 		},
 	})
 	if err != nil {
@@ -628,27 +627,64 @@ func (s *MongoStateManager) EnsureIndexes(ctx context.Context) error {
 func (s *MongoStateManager) Indexes() []mongo.IndexModel {
 	if s.capped {
 		// Capped collections don't support TTL indexes
-		// Return a regular index for query performance
 		return []mongo.IndexModel{
 			{
 				Keys: bson.D{{Key: "expires_at", Value: 1}},
 			},
+			// Stale detection + ListWorkers with status filter and pagination
 			{
-				Keys: bson.D{{Key: "status", Value: 1}},
+				Keys: bson.D{
+					{Key: "status", Value: 1},
+					{Key: "updated_at", Value: 1},
+					{Key: "_id", Value: 1},
+				},
+			},
+			// ListWorkers pagination without status filter
+			{
+				Keys: bson.D{
+					{Key: "updated_at", Value: 1},
+					{Key: "_id", Value: 1},
+				},
+			},
+			// ListWorkers filtered by event_name with pagination
+			{
+				Keys: bson.D{
+					{Key: "event_name", Value: 1},
+					{Key: "updated_at", Value: 1},
+					{Key: "_id", Value: 1},
+				},
 			},
 		}
 	}
 
-	// Regular collection with TTL index and compound index for stale detection
+	// Regular collection
 	return []mongo.IndexModel{
+		// TTL index for automatic cleanup of expired states
 		{
 			Keys:    bson.D{{Key: "expires_at", Value: 1}},
 			Options: options.Index().SetExpireAfterSeconds(0),
 		},
+		// Stale detection + ListWorkers with status filter and pagination
 		{
 			Keys: bson.D{
 				{Key: "status", Value: 1},
 				{Key: "updated_at", Value: 1},
+				{Key: "_id", Value: 1},
+			},
+		},
+		// ListWorkers pagination without status filter
+		{
+			Keys: bson.D{
+				{Key: "updated_at", Value: 1},
+				{Key: "_id", Value: 1},
+			},
+		},
+		// ListWorkers filtered by event_name with pagination
+		{
+			Keys: bson.D{
+				{Key: "event_name", Value: 1},
+				{Key: "updated_at", Value: 1},
+				{Key: "_id", Value: 1},
 			},
 		},
 	}

--- a/distributed/mongodb_test.go
+++ b/distributed/mongodb_test.go
@@ -68,20 +68,20 @@ func TestMongoStateManager_Indexes_Regular(t *testing.T) {
 	sm := &MongoStateManager{capped: false}
 	indexes := sm.Indexes()
 
-	if len(indexes) != 2 {
-		t.Fatalf("expected 2 indexes for regular collection, got %d", len(indexes))
+	if len(indexes) != 4 {
+		t.Fatalf("expected 4 indexes for regular collection, got %d", len(indexes))
 	}
 
 	// First index: TTL index on expires_at
-	idx0 := indexes[0]
-	if idx0.Options == nil {
+	if indexes[0].Options == nil {
 		t.Fatal("expected TTL index to have options")
 	}
 
-	// Second index: compound index on (status, updated_at) for stale queries
-	idx1 := indexes[1]
-	if idx1.Options != nil {
-		t.Fatal("expected compound index to have no options (not TTL)")
+	// Remaining indexes: compound indexes without TTL options
+	for i := 1; i < len(indexes); i++ {
+		if indexes[i].Options != nil {
+			t.Fatalf("expected index %d to have no options (not TTL)", i)
+		}
 	}
 }
 
@@ -89,8 +89,8 @@ func TestMongoStateManager_Indexes_Capped(t *testing.T) {
 	sm := &MongoStateManager{capped: true}
 	indexes := sm.Indexes()
 
-	if len(indexes) != 2 {
-		t.Fatalf("expected 2 indexes for capped collection, got %d", len(indexes))
+	if len(indexes) != 4 {
+		t.Fatalf("expected 4 indexes for capped collection, got %d", len(indexes))
 	}
 
 	// Capped collections don't support TTL indexes

--- a/event_test.go
+++ b/event_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1350,6 +1351,36 @@ func TestBusLogger(t *testing.T) {
 	if !wait(ch, waitChTimeoutMS) {
 		t.Error("event not received")
 	}
+}
+
+// sanitize strings and remove special chars (test-only helper).
+func sanitize(s string) string {
+	var result strings.Builder
+	result.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if ('a' <= b && b <= 'z') ||
+			('A' <= b && b <= 'Z') ||
+			('0' <= b && b <= '9') {
+			result.WriteByte(b)
+		} else {
+			result.WriteByte(byte('_'))
+		}
+	}
+	return result.String()
+}
+
+// caller gets the caller function name (test-only helper).
+func caller(depth int) string {
+	pc, _, _, ok := runtime.Caller(depth)
+	if !ok {
+		return ""
+	}
+	details := runtime.FuncForPC(pc)
+	if details != nil {
+		return details.Name()
+	}
+	return ""
 }
 
 // TestSanitize verifies sanitize function

--- a/util.go
+++ b/util.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"runtime"
 	"runtime/debug"
-	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,23 +19,6 @@ const (
 	spanKeyEventBus            = "event.bus"
 	spanKeyEventSubscriptionID = "subscription.id"
 )
-
-// sanitize strings and remove special chars
-func sanitize(s string) string {
-	var result strings.Builder
-	result.Grow(len(s))
-	for i := 0; i < len(s); i++ {
-		b := s[i]
-		if ('a' <= b && b <= 'z') ||
-			('A' <= b && b <= 'Z') ||
-			('0' <= b && b <= '9') {
-			result.WriteByte(b)
-		} else {
-			result.WriteByte(byte('_'))
-		}
-	}
-	return result.String()
-}
 
 // AsyncHandler convert event handler to async
 // This wraps a typed handler to run in a goroutine with panic recovery.
@@ -92,15 +74,3 @@ func AsyncHandler[T any](handler Handler[T], copyContextFns ...func(to, from con
 	}
 }
 
-// caller gets the caller function name.
-func caller(depth int) string {
-	pc, _, _, ok := runtime.Caller(depth)
-	if !ok {
-		return ""
-	}
-	details := runtime.FuncForPC(pc)
-	if details != nil {
-		return details.Name()
-	}
-	return ""
-}


### PR DESCRIPTION
## Summary
- Add compound indexes for ListWorkers pagination: `(status, updated_at, _id)`, `(updated_at, _id)`, `(event_name, updated_at, _id)`
- Previously only `(status, updated_at)` existed, causing collection scans and in-memory sorts for all ListWorkers/CountWorkers API calls
- Preserve `metadata` and `event_name` fields in `ClearPayload` so worker entries remain useful for observability

## Test plan
- [ ] Verify `go test ./distributed/...` passes
- [ ] Verify index count tests updated for both regular and capped collections
- [ ] Confirm ListWorkers queries use new indexes (via `explain()` on MongoDB)