### PR TITLE
refactor: improve code quality across core package

### DIFF
--- a/ack_policy_test.go
+++ b/ack_policy_test.go
@@ -174,12 +174,10 @@ func TestContextCoalescedCount_DefaultZero(t *testing.T) {
 }
 
 func TestContextCoalescedCount_Set(t *testing.T) {
-	ctx := contextWithInfoCoalesced(
-		context.Background(),
-		"id", "name", "source", "sub",
-		nil, time.Now(), nil, nil,
-		Broadcast, "", "", 5,
-	)
+	ctx := contextWithInfo(context.Background(), contextInfo{
+		id: "id", name: "name", source: "source", subID: "sub",
+		msgTime: time.Now(), mode: Broadcast, coalescedCount: 5,
+	})
 	if count := ContextCoalescedCount(ctx); count != 5 {
 		t.Errorf("expected 5, got %d", count)
 	}

--- a/context.go
+++ b/context.go
@@ -192,24 +192,36 @@ func ContextWithLogger(ctx context.Context, l *slog.Logger) context.Context {
 	return context.WithValue(ctx, eventcontextKey, &eventContextData{logger: l})
 }
 
-func contextWithInfo(ctx context.Context, id, name, source, subID string, metadata map[string]string, msgTime time.Time, l *slog.Logger, b *Bus, mode DeliveryMode, subscriberName, subscriberDescription string) context.Context {
-	return contextWithInfoCoalesced(ctx, id, name, source, subID, metadata, msgTime, l, b, mode, subscriberName, subscriberDescription, 0)
+// contextInfo groups parameters for contextWithInfo to avoid long parameter lists.
+type contextInfo struct {
+	id                    string
+	name                  string
+	source                string
+	subID                 string
+	metadata              map[string]string
+	msgTime               time.Time
+	logger                *slog.Logger
+	bus                   *Bus
+	mode                  DeliveryMode
+	subscriberName        string
+	subscriberDescription string
+	coalescedCount        int
 }
 
-func contextWithInfoCoalesced(ctx context.Context, id, name, source, subID string, metadata map[string]string, msgTime time.Time, l *slog.Logger, b *Bus, mode DeliveryMode, subscriberName, subscriberDescription string, coalescedCount int) context.Context {
+func contextWithInfo(ctx context.Context, info contextInfo) context.Context {
 	return context.WithValue(ctx, eventcontextKey, &eventContextData{
-		eventID:               id,
-		name:                  name,
-		subID:                 subID,
-		source:                source,
-		metadata:              metadata,
-		messageTime:           msgTime,
-		logger:                l,
-		bus:                   b,
-		deliveryMode:          mode,
-		subscriberName:        subscriberName,
-		subscriberDescription: subscriberDescription,
-		coalescedCount:        coalescedCount,
+		eventID:               info.id,
+		name:                  info.name,
+		subID:                 info.subID,
+		source:                info.source,
+		metadata:              info.metadata,
+		messageTime:           info.msgTime,
+		logger:                info.logger,
+		bus:                   info.bus,
+		deliveryMode:          info.mode,
+		subscriberName:        info.subscriberName,
+		subscriberDescription: info.subscriberDescription,
+		coalescedCount:        info.coalescedCount,
 	})
 }
 

--- a/event.go
+++ b/event.go
@@ -644,7 +644,13 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 				defer bus.inflightWG.Done()
 
 				// Build context and call handler directly (payload already decoded).
-				handlerCtx := contextWithInfoCoalesced(out.msg.Context(), out.msg.ID(), e.name, bus.ID(), sub.ID(), out.msg.Metadata(), out.msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, out.count)
+				handlerCtx := contextWithInfo(out.msg.Context(), contextInfo{
+					id: out.msg.ID(), name: e.name, source: bus.ID(), subID: sub.ID(),
+					metadata: out.msg.Metadata(), msgTime: out.msg.Timestamp(),
+					logger: logger, bus: bus, mode: subOpts.mode,
+					subscriberName: subOpts.subscriberName, subscriberDescription: subOpts.subscriberDescription,
+					coalescedCount: out.count,
+				})
 				handlerCtx = ContextWithRawPayload(handlerCtx, out.msg.Payload())
 
 				// Best-effort: ack before handler (at-most-once delivery).
@@ -755,7 +761,12 @@ func (e *eventImpl[T]) processMessage(
 		}
 
 		// Custom decode error handler decides the action
-		decodeCtx := contextWithInfo(detachedContext(msg.Context()), msg.ID(), e.name, bus.ID(), subID, msg.Metadata(), msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription)
+		decodeCtx := contextWithInfo(detachedContext(msg.Context()), contextInfo{
+			id: msg.ID(), name: e.name, source: bus.ID(), subID: subID,
+			metadata: msg.Metadata(), msgTime: msg.Timestamp(),
+			logger: logger, bus: bus, mode: subOpts.mode,
+			subscriberName: subOpts.subscriberName, subscriberDescription: subOpts.subscriberDescription,
+		})
 		decodeResult := e.decodeErrorHandler(decodeCtx, msg, err)
 
 		if bestEffort {
@@ -792,7 +803,13 @@ func (e *eventImpl[T]) processMessage(
 	}
 
 	// Update context values and call handler
-	handlerCtx := contextWithInfoCoalesced(msg.Context(), msg.ID(), e.name, bus.ID(), subID, msg.Metadata(), msg.Timestamp(), logger, bus, subOpts.mode, subOpts.subscriberName, subOpts.subscriberDescription, coalescedCount)
+	handlerCtx := contextWithInfo(msg.Context(), contextInfo{
+		id: msg.ID(), name: e.name, source: bus.ID(), subID: subID,
+		metadata: msg.Metadata(), msgTime: msg.Timestamp(),
+		logger: logger, bus: bus, mode: subOpts.mode,
+		subscriberName: subOpts.subscriberName, subscriberDescription: subOpts.subscriberDescription,
+		coalescedCount: coalescedCount,
+	})
 	handlerCtx = ContextWithRawPayload(handlerCtx, msg.Payload())
 	handlerErr := wrappedHandler(handlerCtx, e, typedData)
 

--- a/option.go
+++ b/option.go
@@ -42,9 +42,10 @@ const (
 var (
 	// DefaultSubscriberTimeout default subscriber timeout (0 = no timeout)
 	DefaultSubscriberTimeout time.Duration = 0
-	// DefaultMaxRetries default max retry attempts (0 = unlimited)
-	DefaultMaxRetries = 0
 )
+
+// DefaultMaxRetries is the default max retry attempts (0 = unlimited).
+const DefaultMaxRetries = 0
 
 // eventOptions holds configuration for events (unexported)
 // These are event-level concerns, not bus-level infrastructure
@@ -403,10 +404,30 @@ func (o *subscribeOptions[T]) transportOptions() []transport.SubscribeOption {
 	}
 
 	if o.ackPolicy != AckExplicit {
-		opts = append(opts, transport.WithAckPolicy(transport.AckPolicy(o.ackPolicy)))
+		opts = append(opts, transport.WithAckPolicy(o.ackPolicy))
 	}
 
 	return opts
+}
+
+// AsWorker configures the subscription for WorkerPool delivery mode.
+// Each message is delivered to only ONE subscriber (load balancing).
+//
+// Example:
+//
+//	orderEvent.Subscribe(ctx, handler, event.AsWorker[Order]())
+func AsWorker[T any]() SubscribeOption[T] {
+	return WithDeliveryMode[T](WorkerPool)
+}
+
+// AsBroadcast configures the subscription for Broadcast delivery mode.
+// All subscribers receive every message. This is the default mode.
+//
+// Example:
+//
+//	orderEvent.Subscribe(ctx, handler, event.AsBroadcast[Order]())
+func AsBroadcast[T any]() SubscribeOption[T] {
+	return WithDeliveryMode[T](Broadcast)
 }
 
 // WithDeliveryMode sets the message delivery mode.

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"runtime"
 	"runtime/debug"
 
 	"go.opentelemetry.io/otel"
@@ -16,8 +15,7 @@ const (
 	spanKeyEventID             = "event.id"
 	spanKeyEventName           = "event.name"
 	spanKeyEventSource         = "event.source"
-	spanKeyEventBus            = "event.bus"
-	spanKeyEventSubscriptionID = "subscription.id"
+	spanKeyEventBus = "event.bus"
 )
 
 // AsyncHandler convert event handler to async
@@ -29,12 +27,9 @@ func AsyncHandler[T any](handler Handler[T], copyContextFns ...func(to, from con
 		// Call handler with go routine
 		go func() {
 			defer func() {
-				_, file, l, _ := runtime.Caller(1)
 				if err := recover(); err != nil {
 					slog.Error("async handler panic recovered",
 						"event", ev.Name(),
-						"line", l,
-						"file", file,
 						"error", err,
 						"stack", string(debug.Stack()),
 					)


### PR DESCRIPTION
## Summary
- Add `AsWorker[T]()` and `AsBroadcast[T]()` convenience subscribe option functions (referenced in docs but missing)
- Change `DefaultMaxRetries` from `var` to `const`
- Refactor `contextWithInfo` to use `contextInfo` struct parameter instead of 13 positional args
- Fix `AsyncHandler` panic recovery: remove misleading `runtime.Caller(1)` — `debug.Stack()` already captures accurate traces
- Remove redundant `AckPolicy` type cast in `transportOptions()`
- Remove unused `spanKeyEventSubscriptionID` constant

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 35 packages)