### PR TITLE
fix: correct stale comment and use const for DefaultSubscriberTimeout

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -82,8 +82,8 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 		name = DefaultBusName
 	}
 
-	// Transport is required - use WithBusTransport() to set it
-	// For channel transport: NewBus(name, WithBusTransport(channel.New()))
+	// Transport is required - use WithTransport() to set it
+	// For channel transport: NewBus(name, WithTransport(channel.New()))
 	transport := o.transport
 	if transport == nil {
 		return nil, ErrTransportRequired

--- a/option.go
+++ b/option.go
@@ -39,7 +39,7 @@ const (
 )
 
 // Default event configuration values
-var (
+const (
 	// DefaultSubscriberTimeout default subscriber timeout (0 = no timeout)
 	DefaultSubscriberTimeout time.Duration = 0
 )


### PR DESCRIPTION
## Summary
- Fix stale `WithBusTransport()` reference in bus.go comment to `WithTransport()`
- Change `DefaultSubscriberTimeout` from `var` to `const`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes