### PR TITLE
fix: use errors.Is for sentinel errors and add SQL table name validation

### DIFF
--- a/checkpoint/mongodb.go
+++ b/checkpoint/mongodb.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -135,7 +136,7 @@ func (s *MongoStore) Save(ctx context.Context, subscriberID string, position tim
 func (s *MongoStore) Load(ctx context.Context, subscriberID string) (time.Time, error) {
 	var doc checkpointDoc
 	err := s.collection.FindOne(ctx, bson.M{"_id": subscriberID}).Decode(&doc)
-	if err == mongo.ErrNoDocuments {
+	if errors.Is(err, mongo.ErrNoDocuments) {
 		// No checkpoint exists - this is not an error
 		return time.Time{}, nil
 	}
@@ -201,7 +202,7 @@ func (s *MongoStore) GetAll(ctx context.Context) (map[string]time.Time, error) {
 func (s *MongoStore) GetCheckpointInfo(ctx context.Context, subscriberID string) (*CheckpointInfo, error) {
 	var doc checkpointDoc
 	err := s.collection.FindOne(ctx, bson.M{"_id": subscriberID}).Decode(&doc)
-	if err == mongo.ErrNoDocuments {
+	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, nil
 	}
 	if err != nil {

--- a/checkpoint/redis.go
+++ b/checkpoint/redis.go
@@ -17,6 +17,7 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"time"
 
@@ -109,7 +110,7 @@ func (s *RedisStore) Save(ctx context.Context, subscriberID string, position tim
 // Returns zero time and nil error if no checkpoint exists.
 func (s *RedisStore) Load(ctx context.Context, subscriberID string) (time.Time, error) {
 	value, err := s.client.HGet(ctx, s.key, subscriberID).Result()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		// No checkpoint exists - this is not an error
 		return time.Time{}, nil
 	}

--- a/idempotency/postgres.go
+++ b/idempotency/postgres.go
@@ -111,7 +111,9 @@ func WithPostgresTTL(ttl time.Duration) PostgresOption {
 //	)
 func WithPostgresTable(table string) PostgresOption {
 	return func(s *PostgresStore) {
-		s.table = table
+		if base.ValidIdentifier(table) {
+			s.table = table
+		}
 	}
 }
 

--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -245,7 +246,7 @@ func (s *MongoStore) Get(ctx context.Context, eventID, subscriptionID string) (*
 
 	var doc MongoEntry
 	err := s.collection.FindOne(ctx, filter).Decode(&doc)
-	if err == mongo.ErrNoDocuments {
+	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, nil
 	}
 	if err != nil {

--- a/monitor/options.go
+++ b/monitor/options.go
@@ -2,6 +2,8 @@ package monitor
 
 import (
 	"time"
+
+	"github.com/rbaliyan/event/v3/store/base"
 )
 
 // storeOptions holds configuration for monitor stores.
@@ -43,7 +45,7 @@ type StoreOption func(*storeOptions)
 //	)
 func WithTableName(name string) StoreOption {
 	return func(o *storeOptions) {
-		if name != "" {
+		if name != "" && base.ValidIdentifier(name) {
 			o.tableName = name
 		}
 	}

--- a/monitor/postgres.go
+++ b/monitor/postgres.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -183,7 +184,7 @@ func (s *PostgresStore) Get(ctx context.Context, eventID, subscriptionID string)
 	`, s.opts.tableName)
 
 	entry, err := s.scanEntry(s.db.QueryRowContext(ctx, query, eventID, subscriptionID))
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/outbox/mongodb.go
+++ b/outbox/mongodb.go
@@ -3,6 +3,7 @@ package outbox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -355,7 +356,7 @@ func (s *MongoStore) GetPending(ctx context.Context, limit int) ([]*Message, err
 	for i := 0; i < limit; i++ {
 		msg, err := s.claimNextPending(ctx)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
+			if errors.Is(err, mongo.ErrNoDocuments) {
 				break // No more pending messages
 			}
 			return messages, fmt.Errorf("claim pending: %w", err)
@@ -398,7 +399,7 @@ func (s *MongoStore) GetPendingMongo(ctx context.Context, limit int) ([]*MongoMe
 	for i := 0; i < limit; i++ {
 		msg, err := s.claimNextPendingMongo(ctx)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
+			if errors.Is(err, mongo.ErrNoDocuments) {
 				break // No more pending messages
 			}
 			return messages, fmt.Errorf("claim pending: %w", err)

--- a/outbox/postgres.go
+++ b/outbox/postgres.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rbaliyan/event/v3/store/base"
 	"github.com/rbaliyan/event/v3/transport/codec"
 )
 
@@ -19,9 +20,10 @@ type postgresStoreOptions struct {
 }
 
 // WithTable sets a custom table name for the PostgreSQL outbox store.
+// The name must be a valid SQL identifier (alphanumeric and underscores only).
 func WithTable(table string) PostgresStoreOption {
 	return func(o *postgresStoreOptions) {
-		if table != "" {
+		if table != "" && base.ValidIdentifier(table) {
 			o.table = table
 		}
 	}

--- a/outbox/redis.go
+++ b/outbox/redis.go
@@ -3,6 +3,7 @@ package outbox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -223,7 +224,7 @@ func (s *RedisStore) GetPending(ctx context.Context, count int64) ([]*RedisMessa
 	}).Result()
 
 	if err != nil {
-		if err == redis.Nil {
+		if errors.Is(err, redis.Nil) {
 			return pendingMsgs, nil // No new messages
 		}
 		return pendingMsgs, fmt.Errorf("xreadgroup: %w", err)
@@ -257,7 +258,7 @@ func (s *RedisStore) claimPendingMessages(ctx context.Context, count int64) ([]*
 	}).Result()
 
 	if err != nil {
-		if err == redis.Nil {
+		if errors.Is(err, redis.Nil) {
 			return nil, nil
 		}
 		return nil, err
@@ -393,7 +394,7 @@ func (s *RedisStore) RecoverStuck(ctx context.Context, stuckDuration time.Durati
 	}).Result()
 
 	if err != nil {
-		if err == redis.Nil {
+		if errors.Is(err, redis.Nil) {
 			return 0, nil
 		}
 		return 0, fmt.Errorf("xpending: %w", err)

--- a/outbox/relay_mongo_changestream.go
+++ b/outbox/relay_mongo_changestream.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -60,7 +61,7 @@ func (s *MongoResumeTokenStore) Load(ctx context.Context) (bson.Raw, error) {
 		Token bson.Raw `bson:"token"`
 	}
 	err := s.collection.FindOne(ctx, filter).Decode(&result)
-	if err == mongo.ErrNoDocuments {
+	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, nil
 	}
 	if err != nil {

--- a/poison/postgres.go
+++ b/poison/postgres.go
@@ -3,6 +3,7 @@ package poison
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -75,7 +76,9 @@ type PostgresStoreOption func(*PostgresStore)
 //	)
 func WithPostgresFailuresTable(table string) PostgresStoreOption {
 	return func(s *PostgresStore) {
-		s.failuresTable = table
+		if base.ValidIdentifier(table) {
+			s.failuresTable = table
+		}
 	}
 }
 
@@ -90,7 +93,9 @@ func WithPostgresFailuresTable(table string) PostgresStoreOption {
 //	)
 func WithPostgresQuarantineTable(table string) PostgresStoreOption {
 	return func(s *PostgresStore) {
-		s.quarantineTable = table
+		if base.ValidIdentifier(table) {
+			s.quarantineTable = table
+		}
 	}
 }
 
@@ -237,7 +242,7 @@ func (s *PostgresStore) GetFailureCount(ctx context.Context, messageID string) (
 
 	var count int
 	err := s.db.QueryRowContext(ctx, query, messageID).Scan(&count)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
 	if err != nil {

--- a/poison/redis.go
+++ b/poison/redis.go
@@ -2,6 +2,7 @@ package poison
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -136,7 +137,7 @@ func (s *RedisStore) GetFailureCount(ctx context.Context, messageID string) (int
 	key := s.failurePrefix + messageID
 
 	val, err := s.client.Get(ctx, key).Result()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return 0, nil
 	}
 	if err != nil {

--- a/schema/mongodb.go
+++ b/schema/mongodb.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -168,7 +169,7 @@ func (p *MongoProvider) Get(ctx context.Context, eventName string) (*EventSchema
 
 	var m mongoSchema
 	err := p.collection.FindOne(ctx, bson.M{"_id": eventName}).Decode(&m)
-	if err == mongo.ErrNoDocuments {
+	if errors.Is(err, mongo.ErrNoDocuments) {
 		return nil, nil
 	}
 	if err != nil {

--- a/schema/postgres.go
+++ b/schema/postgres.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/rbaliyan/event/v3/store/base"
 )
 
 // PostgresProvider implements SchemaProvider using PostgreSQL.
@@ -49,7 +52,9 @@ type PostgresOption func(*PostgresProvider)
 // WithTableName sets a custom table name (default: "event_schemas").
 func WithTableName(name string) PostgresOption {
 	return func(p *PostgresProvider) {
-		p.tableName = name
+		if base.ValidIdentifier(name) {
+			p.tableName = name
+		}
 	}
 }
 
@@ -89,7 +94,7 @@ func (p *PostgresProvider) Get(ctx context.Context, eventName string) (*EventSch
 
 	row := p.db.QueryRowContext(ctx, query, eventName)
 	schema, err := p.scanRow(row)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/schema/redis.go
+++ b/schema/redis.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -69,7 +70,7 @@ func (p *RedisProvider) Get(ctx context.Context, eventName string) (*EventSchema
 	p.mu.RUnlock()
 
 	data, err := p.client.HGet(ctx, p.key, eventName).Bytes()
-	if err == redis.Nil {
+	if errors.Is(err, redis.Nil) {
 		return nil, nil
 	}
 	if err != nil {

--- a/store/base/sql.go
+++ b/store/base/sql.go
@@ -3,9 +3,18 @@ package base
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// validIdentifier matches safe SQL identifiers (alphanumeric and underscores).
+var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// ValidIdentifier returns true if name is a safe SQL identifier.
+func ValidIdentifier(name string) bool {
+	return validIdentifier.MatchString(name)
+}
 
 // QueryBuilder helps construct SQL queries with dynamic conditions.
 // It handles parameter numbering automatically for PostgreSQL-style placeholders ($1, $2, etc.).


### PR DESCRIPTION
## Summary
- Replace bare `==` comparisons with `errors.Is()` for `redis.Nil`, `mongo.ErrNoDocuments`, and `sql.ErrNoRows` across checkpoint, idempotency, monitor, outbox, poison, and schema packages (16 sites)
- Add `ValidIdentifier()` helper to `store/base` and validate table names in all PostgreSQL option functions to prevent SQL injection via `fmt.Sprintf`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes