### PR TITLE
feat: system-wide observability with topology, worker groups, and federation

### DIFF
--- a/context.go
+++ b/context.go
@@ -26,6 +26,7 @@ type eventContextData struct {
 	subscriberName        string
 	subscriberDescription string
 	coalescedCount        int
+	workerGroup           string
 }
 
 // contextKey
@@ -150,6 +151,16 @@ func ContextCoalescedCount(ctx context.Context) int {
 	return 0
 }
 
+// ContextWorkerGroup returns the worker group name stored in context.
+// Returns empty string if not set or not in WorkerPool mode.
+func ContextWorkerGroup(ctx context.Context) string {
+	s, ok := ctx.Value(eventcontextKey).(*eventContextData)
+	if ok {
+		return s.workerGroup
+	}
+	return ""
+}
+
 // ContextWithMetadata generate a context with event metadata
 func ContextWithMetadata(ctx context.Context, m map[string]string) context.Context {
 	if m == nil {
@@ -206,6 +217,7 @@ type contextInfo struct {
 	subscriberName        string
 	subscriberDescription string
 	coalescedCount        int
+	workerGroup           string
 }
 
 func contextWithInfo(ctx context.Context, info contextInfo) context.Context {
@@ -222,6 +234,7 @@ func contextWithInfo(ctx context.Context, info contextInfo) context.Context {
 		subscriberName:        info.subscriberName,
 		subscriberDescription: info.subscriberDescription,
 		coalescedCount:        info.coalescedCount,
+		workerGroup:           info.workerGroup,
 	})
 }
 

--- a/event.go
+++ b/event.go
@@ -102,11 +102,17 @@ type eventImpl[T any] struct {
 	messageFilter      func(map[string]string) bool                                    // pre-decode message filter (nil = accept all)
 	decodeErrorHandler func(ctx context.Context, msg message.Message, err error) error // decode error handler (nil = default DLQ+ack)
 	schema             schemaFlags                                                     // schema-based configuration
+	subscriptions      subscriptionRegistry                                            // active subscription metadata for topology
 }
 
 func (e *eventImpl[T]) String() string {
 	return e.name
 }
+
+// eventTopology interface implementation for generic-free topology access.
+func (e *eventImpl[T]) eventName() string                  { return e.name }
+func (e *eventImpl[T]) subscriberCount() int64             { return atomic.LoadInt64(&e.size) }
+func (e *eventImpl[T]) subscriptionInfos() []SubscriptionInfo { return e.subscriptions.all() }
 
 // Name event name
 func (e *eventImpl[T]) Name() string {
@@ -344,6 +350,16 @@ func (e *eventImpl[T]) Subscribe(ctx context.Context, handler Handler[T], opts .
 	atomic.AddInt64(&e.size, 1)
 	subID := sub.ID()
 
+	// Track subscription metadata for topology reporting
+	e.subscriptions.add(&SubscriptionInfo{
+		SubscriptionID:        subID,
+		DeliveryMode:          subOpts.mode,
+		WorkerGroup:           subOpts.workerGroup,
+		SubscriberName:        subOpts.subscriberName,
+		SubscriberDescription: subOpts.subscriberDescription,
+		StartedAt:             time.Now(),
+	})
+
 	// Apply middleware chain (innermost to outermost):
 	// 1. Recovery (innermost) - catch panics
 	// 2. Timeout - enforce handler timeout
@@ -411,6 +427,7 @@ func (e *eventImpl[T]) subscribeLoop(
 ) {
 	subID := sub.ID()
 	defer func() {
+		e.subscriptions.remove(subID)
 		atomic.AddInt64(&e.size, -1)
 		_ = sub.Close(context.Background())
 	}()
@@ -455,6 +472,7 @@ func (e *eventImpl[T]) subscribeWithRawCoalesce(
 
 	defer func() {
 		coal.Close()
+		e.subscriptions.remove(subID)
 		atomic.AddInt64(&e.size, -1)
 		_ = sub.Close(context.Background())
 	}()
@@ -546,6 +564,7 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 
 	defer func() {
 		coal.Close()
+		e.subscriptions.remove(subID)
 		atomic.AddInt64(&e.size, -1)
 		_ = sub.Close(context.Background())
 	}()
@@ -650,6 +669,7 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 					logger: logger, bus: bus, mode: subOpts.mode,
 					subscriberName: subOpts.subscriberName, subscriberDescription: subOpts.subscriberDescription,
 					coalescedCount: out.count,
+					workerGroup: subOpts.workerGroup,
 				})
 				handlerCtx = ContextWithRawPayload(handlerCtx, out.msg.Payload())
 
@@ -766,6 +786,7 @@ func (e *eventImpl[T]) processMessage(
 			metadata: msg.Metadata(), msgTime: msg.Timestamp(),
 			logger: logger, bus: bus, mode: subOpts.mode,
 			subscriberName: subOpts.subscriberName, subscriberDescription: subOpts.subscriberDescription,
+			workerGroup: subOpts.workerGroup,
 		})
 		decodeResult := e.decodeErrorHandler(decodeCtx, msg, err)
 
@@ -809,6 +830,7 @@ func (e *eventImpl[T]) processMessage(
 		logger: logger, bus: bus, mode: subOpts.mode,
 		subscriberName: subOpts.subscriberName, subscriberDescription: subOpts.subscriberDescription,
 		coalescedCount: coalescedCount,
+		workerGroup: subOpts.workerGroup,
 	})
 	handlerCtx = ContextWithRawPayload(handlerCtx, msg.Payload())
 	handlerErr := wrappedHandler(handlerCtx, e, typedData)

--- a/event_test.go
+++ b/event_test.go
@@ -2777,7 +2777,7 @@ func newMockMonitorStore() *mockMonitorStore {
 	}
 }
 
-func (s *mockMonitorStore) RecordStart(ctx context.Context, eventID, subscriptionID, eventName, busID string, workerPool bool, metadata map[string]string, traceID, spanID string, subscriberName, subscriberDescription string) error {
+func (s *mockMonitorStore) RecordStart(ctx context.Context, eventID, subscriptionID, eventName, busID string, workerPool bool, metadata map[string]string, traceID, spanID string, subscriberName, subscriberDescription, workerGroup string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.started[eventID] = true

--- a/middleware.go
+++ b/middleware.go
@@ -482,9 +482,10 @@ type MonitorStore interface {
 	// RecordStart records when event processing begins.
 	// workerPool indicates the delivery mode (true = WorkerPool, false = Broadcast)
 	// subscriberName and subscriberDescription are optional human-readable identifiers
+	// workerGroup is the worker group name (empty for broadcast or default group)
 	RecordStart(ctx context.Context, eventID, subscriptionID, eventName, busID string,
 		workerPool bool, metadata map[string]string, traceID, spanID string,
-		subscriberName, subscriberDescription string) error
+		subscriberName, subscriberDescription, workerGroup string) error
 
 	// RecordComplete updates the entry with the final result.
 	// status: "completed" (success), "failed" (rejected), "retrying" (will retry)
@@ -552,8 +553,9 @@ func MonitorMiddleware[T any](store MonitorStore) Middleware[T] {
 			}
 
 			// Record start (best effort)
+			workerGroup := ContextWorkerGroup(ctx)
 			if err := store.RecordStart(ctx, eventID, subIDForEntry, eventName, busID,
-				workerPool, metadata, traceID, spanID, subscriberName, subscriberDescription); err != nil {
+				workerPool, metadata, traceID, spanID, subscriberName, subscriberDescription, workerGroup); err != nil {
 				logger := ContextLogger(ctx)
 				if logger != nil {
 					logger.Warn("monitor record start failed", "error", err)

--- a/monitor/http/federation.go
+++ b/monitor/http/federation.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"context"
+	"time"
+
+	"github.com/rbaliyan/event/v3/health"
+)
+
+// DLQProvider supplies DLQ summary and health.
+// Satisfied by event-dlq Manager.
+type DLQProvider interface {
+	DLQStats(ctx context.Context) (*DLQStats, error)
+	health.Checker
+}
+
+// DLQStats contains summary statistics for the dead letter queue.
+type DLQStats struct {
+	TotalMessages   int64            `json:"total_messages"`
+	PendingMessages int64            `json:"pending_messages"`
+	MessagesByEvent map[string]int64 `json:"messages_by_event,omitempty"`
+	MessagesByError map[string]int64 `json:"messages_by_error,omitempty"`
+	OldestMessage   *time.Time       `json:"oldest_message,omitempty"`
+	NewestMessage   *time.Time       `json:"newest_message,omitempty"`
+}
+
+// SchedulerProvider supplies scheduler summary and health.
+// Satisfied by scheduler implementations.
+type SchedulerProvider interface {
+	SchedulerStats(ctx context.Context) (*SchedulerStats, error)
+	health.Checker
+}
+
+// SchedulerStats contains summary statistics for the scheduler.
+type SchedulerStats struct {
+	PendingMessages int64      `json:"pending_messages"`
+	StuckMessages   int64      `json:"stuck_messages,omitempty"`
+	NextDue         *time.Time `json:"next_due,omitempty"`
+}

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -17,7 +17,9 @@ import (
 
 // handlerOptions holds configuration for the Handler.
 type handlerOptions struct {
-	workerStore distributed.WorkerStore
+	workerStore   distributed.WorkerStore
+	dlqProvider   DLQProvider
+	schedProvider SchedulerProvider
 }
 
 // Option configures the Handler.
@@ -30,13 +32,29 @@ func WithWorkerStore(ws distributed.WorkerStore) Option {
 	}
 }
 
+// WithDLQProvider enables the /v1/system endpoints with DLQ statistics and health.
+func WithDLQProvider(p DLQProvider) Option {
+	return func(o *handlerOptions) {
+		o.dlqProvider = p
+	}
+}
+
+// WithSchedulerProvider enables the /v1/system endpoints with scheduler statistics and health.
+func WithSchedulerProvider(p SchedulerProvider) Option {
+	return func(o *handlerOptions) {
+		o.schedProvider = p
+	}
+}
+
 // Handler implements http.Handler for the monitor service using protoJSON.
 type Handler struct {
-	store       monitor.Store
-	workerStore distributed.WorkerStore
-	mux         *http.ServeMux
-	marshaler   protojson.MarshalOptions
-	unmarshaler protojson.UnmarshalOptions
+	store         monitor.Store
+	workerStore   distributed.WorkerStore
+	dlqProvider   DLQProvider
+	schedProvider SchedulerProvider
+	mux           *http.ServeMux
+	marshaler     protojson.MarshalOptions
+	unmarshaler   protojson.UnmarshalOptions
 }
 
 // New creates a new HTTP handler for the monitor service.
@@ -47,9 +65,11 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	}
 
 	h := &Handler{
-		store:       store,
-		workerStore: o.workerStore,
-		mux:         http.NewServeMux(),
+		store:         store,
+		workerStore:   o.workerStore,
+		dlqProvider:   o.dlqProvider,
+		schedProvider: o.schedProvider,
+		mux:           http.NewServeMux(),
 		marshaler: protojson.MarshalOptions{
 			EmitUnpopulated: true,
 			UseProtoNames:   true,
@@ -68,6 +88,14 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	h.mux.HandleFunc("/v1/monitor/entries", h.handleEntries)
 	h.mux.HandleFunc("/v1/monitor/entries/", h.handleEntriesWithPath)
 	h.mux.HandleFunc("/v1/monitor/entries/count", h.handleCount)
+
+	// Register topology endpoints
+	h.mux.HandleFunc("/v1/topology", h.handleTopology)
+	h.mux.HandleFunc("/v1/topology/", h.handleTopologyWithPath)
+
+	// Register system view endpoints
+	h.mux.HandleFunc("/v1/system", h.handleSystemView)
+	h.mux.HandleFunc("/v1/system/health", h.handleSystemHealth)
 
 	// Register worker pool state endpoints if worker store is configured
 	if h.workerStore != nil {
@@ -245,6 +273,9 @@ func (h *Handler) parseFilterFromQuery(r *http.Request) monitor.Filter {
 	}
 	if v := q.Get("instance_id"); v != "" {
 		filter.InstanceID = v
+	}
+	if v := q.Get("worker_group"); v != "" {
+		filter.WorkerGroup = v
 	}
 	if v := q.Get("delivery_mode"); v != "" {
 		dm := monitor.ParseDeliveryMode(v)

--- a/monitor/http/system.go
+++ b/monitor/http/system.go
@@ -1,0 +1,85 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/health"
+)
+
+// SystemView is the unified response for GET /v1/system.
+type SystemView struct {
+	Topology  []event.BusInfo        `json:"topology"`
+	DLQ       *DLQStats              `json:"dlq,omitempty"`
+	Scheduler *SchedulerStats        `json:"scheduler,omitempty"`
+	Health    *health.AggregateResult `json:"health"`
+}
+
+// handleSystemView handles GET /v1/system — aggregates topology, DLQ, scheduler, and health.
+func (h *Handler) handleSystemView(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	ctx := r.Context()
+	view := SystemView{
+		Topology: event.Topology(),
+	}
+
+	components := make(map[string]*health.Result)
+
+	if h.dlqProvider != nil {
+		stats, err := h.dlqProvider.DLQStats(ctx)
+		if err == nil {
+			view.DLQ = stats
+		}
+		components["dlq"] = h.dlqProvider.Health(ctx)
+	}
+
+	if h.schedProvider != nil {
+		stats, err := h.schedProvider.SchedulerStats(ctx)
+		if err == nil {
+			view.Scheduler = stats
+		}
+		components["scheduler"] = h.schedProvider.Health(ctx)
+	}
+
+	view.Health = health.Aggregate(components)
+
+	h.writeJSON(w, view)
+}
+
+// handleSystemHealth handles GET /v1/system/health — returns aggregated health status.
+// Returns 200 for healthy/degraded, 503 for unhealthy.
+func (h *Handler) handleSystemHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	ctx := r.Context()
+	components := make(map[string]*health.Result)
+
+	if h.dlqProvider != nil {
+		components["dlq"] = h.dlqProvider.Health(ctx)
+	}
+	if h.schedProvider != nil {
+		components["scheduler"] = h.schedProvider.Health(ctx)
+	}
+
+	result := health.Aggregate(components)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if result.Status == health.StatusUnhealthy {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	_, _ = w.Write(data)
+}

--- a/monitor/http/topology.go
+++ b/monitor/http/topology.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/rbaliyan/event/v3"
+)
+
+// handleTopology handles GET /v1/topology — returns all bus topologies.
+func (h *Handler) handleTopology(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	h.writeJSON(w, event.Topology())
+}
+
+// handleTopologyWithPath handles GET /v1/topology/{bus_name}.
+func (h *Handler) handleTopologyWithPath(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	name := strings.TrimPrefix(r.URL.Path, "/v1/topology/")
+	if name == "" {
+		h.writeError(w, http.StatusBadRequest, "bus name is required")
+		return
+	}
+
+	bus := event.GetBus(name)
+	if bus == nil {
+		h.writeError(w, http.StatusNotFound, "bus not found")
+		return
+	}
+
+	h.writeJSON(w, bus.Topology())
+}

--- a/monitor/memory.go
+++ b/monitor/memory.go
@@ -236,6 +236,9 @@ func (s *MemoryStore) matchesFilter(entry *Entry, filter Filter) bool {
 	if filter.SubscriberName != "" && entry.SubscriberName != filter.SubscriberName {
 		return false
 	}
+	if filter.WorkerGroup != "" && entry.WorkerGroup != filter.WorkerGroup {
+		return false
+	}
 	if filter.EventName != "" && entry.EventName != filter.EventName {
 		return false
 	}
@@ -373,7 +376,7 @@ func (s *MemoryStore) Len() int {
 // Implements event.MonitorStore interface.
 func (s *MemoryStore) RecordStart(ctx context.Context, eventID, subscriptionID, eventName, busID string,
 	workerPool bool, metadata map[string]string, traceID, spanID string,
-	subscriberName, subscriberDescription string) error {
+	subscriberName, subscriberDescription, workerGroup string) error {
 
 	mode := Broadcast
 	if workerPool {
@@ -393,6 +396,7 @@ func (s *MemoryStore) RecordStart(ctx context.Context, eventID, subscriptionID, 
 		StartedAt:             time.Now(),
 		TraceID:               traceID,
 		SpanID:                spanID,
+		WorkerGroup:           workerGroup,
 	}
 
 	return s.Record(ctx, entry)

--- a/monitor/middleware.go
+++ b/monitor/middleware.go
@@ -71,6 +71,7 @@ func NewMiddleware[T any](store Store, opts ...MiddlewareOption) event.Middlewar
 			metadata := event.ContextMetadata(ctx)
 			subscriberName := event.ContextSubscriberName(ctx)
 			subscriberDescription := event.ContextSubscriberDescription(ctx)
+			workerGroup := event.ContextWorkerGroup(ctx)
 
 			// Determine delivery mode
 			deliveryMode := detectDeliveryMode(ctx, o.mode)
@@ -94,6 +95,7 @@ func NewMiddleware[T any](store Store, opts ...MiddlewareOption) event.Middlewar
 				Metadata:              metadata,
 				Status:                StatusPending,
 				StartedAt:             time.Now(),
+				WorkerGroup:           workerGroup,
 			}
 
 			// Extract trace context if available

--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -36,7 +36,8 @@ Document structure:
     "completed_at": ISODate,
     "duration_ms": int64,
     "trace_id": string,
-    "span_id": string
+    "span_id": string,
+    "worker_group": string
 }
 
 Indexes:
@@ -67,6 +68,7 @@ type MongoEntry struct {
 	DurationMs            *int64            `bson:"duration_ms,omitempty"`
 	TraceID               string            `bson:"trace_id,omitempty"`
 	SpanID                string            `bson:"span_id,omitempty"`
+	WorkerGroup           string            `bson:"worker_group,omitempty"`
 }
 
 // ToEntry converts MongoEntry to Entry.
@@ -88,6 +90,7 @@ func (m *MongoEntry) ToEntry() *Entry {
 		CompletedAt:           m.CompletedAt,
 		TraceID:               m.TraceID,
 		SpanID:                m.SpanID,
+		WorkerGroup:           m.WorkerGroup,
 	}
 	if m.DurationMs != nil {
 		entry.Duration = time.Duration(*m.DurationMs) * time.Millisecond
@@ -126,6 +129,7 @@ func FromEntry(e *Entry) *MongoEntry {
 		DurationMs:            durationMs,
 		TraceID:               e.TraceID,
 		SpanID:                e.SpanID,
+		WorkerGroup:           e.WorkerGroup,
 	}
 }
 
@@ -225,6 +229,7 @@ func (s *MongoStore) Record(ctx context.Context, entry *Entry) error {
 			"duration_ms":            mongoEntry.DurationMs,
 			"trace_id":               mongoEntry.TraceID,
 			"span_id":                mongoEntry.SpanID,
+			"worker_group":           mongoEntry.WorkerGroup,
 		},
 		"$setOnInsert": bson.M{
 			"event_id":        mongoEntry.EventID,
@@ -462,6 +467,9 @@ func (s *MongoStore) buildFilter(filter Filter) bson.M {
 	if filter.MinRetries > 0 {
 		mongoFilter["retry_count"] = bson.M{"$gte": filter.MinRetries}
 	}
+	if filter.WorkerGroup != "" {
+		mongoFilter["worker_group"] = filter.WorkerGroup
+	}
 
 	return mongoFilter
 }
@@ -537,7 +545,7 @@ func decodeMongoCursor(str string) (mongoCursor, error) {
 // Implements event.MonitorStore interface.
 func (s *MongoStore) RecordStart(ctx context.Context, eventID, subscriptionID, eventName, busID string,
 	workerPool bool, metadata map[string]string, traceID, spanID string,
-	subscriberName, subscriberDescription string) error {
+	subscriberName, subscriberDescription, workerGroup string) error {
 
 	mode := Broadcast
 	if workerPool {
@@ -557,6 +565,7 @@ func (s *MongoStore) RecordStart(ctx context.Context, eventID, subscriptionID, e
 		StartedAt:             time.Now(),
 		TraceID:               traceID,
 		SpanID:                spanID,
+		WorkerGroup:           workerGroup,
 	}
 
 	return s.Record(ctx, entry)

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -120,6 +120,9 @@ type Entry struct {
 	// Tracing correlation (OpenTelemetry)
 	TraceID string `json:"trace_id,omitempty"`
 	SpanID  string `json:"span_id,omitempty"`
+
+	// Worker group name (for WorkerPool mode with named groups)
+	WorkerGroup string `json:"worker_group,omitempty"`
 }
 
 // IsComplete returns true if the entry represents a completed processing attempt.

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -392,7 +392,7 @@ func TestMemoryStore(t *testing.T) {
 		store := NewMemoryStore()
 		defer store.Close()
 
-		err := store.RecordStart(ctx, "event-1", "sub-1", "order.created", "bus-1", false, map[string]string{"key": "value"}, "trace-1", "span-1", "test-subscriber", "Test subscriber description")
+		err := store.RecordStart(ctx, "event-1", "sub-1", "order.created", "bus-1", false, map[string]string{"key": "value"}, "trace-1", "span-1", "test-subscriber", "Test subscriber description", "")
 		if err != nil {
 			t.Fatalf("RecordStart failed: %v", err)
 		}

--- a/monitor/postgres.go
+++ b/monitor/postgres.go
@@ -134,8 +134,8 @@ func (s *PostgresStore) Record(ctx context.Context, entry *Entry) error {
 			event_id, subscription_id, subscriber_name, subscriber_description,
 			event_name, bus_id, instance_id, delivery_mode,
 			metadata, status, error, retry_count, started_at, completed_at,
-			duration_ms, trace_id, span_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+			duration_ms, trace_id, span_id, worker_group
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 		ON CONFLICT (event_id, subscription_id) DO UPDATE SET
 			status = EXCLUDED.status,
 			error = EXCLUDED.error,
@@ -168,6 +168,7 @@ func (s *PostgresStore) Record(ctx context.Context, entry *Entry) error {
 		durationMs,
 		base.StringPtr(entry.TraceID),
 		base.StringPtr(entry.SpanID),
+		base.StringPtr(entry.WorkerGroup),
 	)
 	if err != nil {
 		return fmt.Errorf("record monitor: %w", err)
@@ -182,7 +183,7 @@ func (s *PostgresStore) Get(ctx context.Context, eventID, subscriptionID string)
 		SELECT event_id, subscription_id, subscriber_name, subscriber_description,
 		       event_name, bus_id, instance_id, delivery_mode,
 		       metadata, status, error, retry_count, started_at, completed_at,
-		       duration_ms, trace_id, span_id
+		       duration_ms, trace_id, span_id, worker_group
 		FROM %s
 		WHERE event_id = $1 AND subscription_id = $2
 	`, s.opts.tableName)
@@ -204,7 +205,7 @@ func (s *PostgresStore) GetByEventID(ctx context.Context, eventID string) ([]*En
 		SELECT event_id, subscription_id, subscriber_name, subscriber_description,
 		       event_name, bus_id, instance_id, delivery_mode,
 		       metadata, status, error, retry_count, started_at, completed_at,
-		       duration_ms, trace_id, span_id
+		       duration_ms, trace_id, span_id, worker_group
 		FROM %s
 		WHERE event_id = $1
 		ORDER BY started_at ASC
@@ -242,6 +243,7 @@ func (s *PostgresStore) buildFilterQuery(filter Filter) (*base.QueryBuilder, err
 	qb.AddIfNotEmpty("event_id = $%d", filter.EventID)
 	qb.AddIfNotEmpty("subscription_id = $%d", filter.SubscriptionID)
 	qb.AddIfNotEmpty("subscriber_name = $%d", filter.SubscriberName)
+	qb.AddIfNotEmpty("worker_group = $%d", filter.WorkerGroup)
 	qb.AddIfNotEmpty("event_name = $%d", filter.EventName)
 	qb.AddIfNotEmpty("bus_id = $%d", filter.BusID)
 	qb.AddIfNotEmpty("instance_id = $%d", filter.InstanceID)
@@ -331,7 +333,7 @@ func (s *PostgresStore) List(ctx context.Context, filter Filter) (*Page, error) 
 		SELECT event_id, subscription_id, subscriber_name, subscriber_description,
 		       event_name, bus_id, instance_id, delivery_mode,
 		       metadata, status, error, retry_count, started_at, completed_at,
-		       duration_ms, trace_id, span_id
+		       duration_ms, trace_id, span_id, worker_group
 		FROM %s
 		%s
 		%s
@@ -460,6 +462,7 @@ func (s *PostgresStore) CreateTable(ctx context.Context) error {
 			duration_ms BIGINT,
 			trace_id TEXT,
 			span_id TEXT,
+			worker_group TEXT,
 			PRIMARY KEY (event_id, subscription_id)
 		);
 		CREATE INDEX IF NOT EXISTS idx_%s_event_name ON %s(event_name);
@@ -495,7 +498,7 @@ func (s *PostgresStore) scanEntry(row *sql.Row) (*Entry, error) {
 	var durationMs sql.NullInt64
 	var traceID, spanID sql.NullString
 	var subscriberName, subscriberDescription sql.NullString
-	var instanceID sql.NullString
+	var instanceID, workerGroup sql.NullString
 
 	err := row.Scan(
 		&entry.EventID,
@@ -515,6 +518,7 @@ func (s *PostgresStore) scanEntry(row *sql.Row) (*Entry, error) {
 		&durationMs,
 		&traceID,
 		&spanID,
+		&workerGroup,
 	)
 	if err != nil {
 		return nil, err
@@ -530,6 +534,7 @@ func (s *PostgresStore) scanEntry(row *sql.Row) (*Entry, error) {
 	entry.SubscriberName = base.NullString(subscriberName)
 	entry.SubscriberDescription = base.NullString(subscriberDescription)
 	entry.InstanceID = base.NullString(instanceID)
+	entry.WorkerGroup = base.NullString(workerGroup)
 
 	if len(metadataJSON) > 0 {
 		metadata, err := base.UnmarshalMetadata(metadataJSON)
@@ -553,7 +558,7 @@ func (s *PostgresStore) scanEntryRows(rows *sql.Rows) (*Entry, error) {
 	var durationMs sql.NullInt64
 	var traceID, spanID sql.NullString
 	var subscriberName, subscriberDescription sql.NullString
-	var instanceID sql.NullString
+	var instanceID, workerGroup sql.NullString
 
 	err := rows.Scan(
 		&entry.EventID,
@@ -573,6 +578,7 @@ func (s *PostgresStore) scanEntryRows(rows *sql.Rows) (*Entry, error) {
 		&durationMs,
 		&traceID,
 		&spanID,
+		&workerGroup,
 	)
 	if err != nil {
 		return nil, err
@@ -588,6 +594,7 @@ func (s *PostgresStore) scanEntryRows(rows *sql.Rows) (*Entry, error) {
 	entry.SubscriberName = base.NullString(subscriberName)
 	entry.SubscriberDescription = base.NullString(subscriberDescription)
 	entry.InstanceID = base.NullString(instanceID)
+	entry.WorkerGroup = base.NullString(workerGroup)
 
 	if len(metadataJSON) > 0 {
 		metadata, err := base.UnmarshalMetadata(metadataJSON)
@@ -604,7 +611,7 @@ func (s *PostgresStore) scanEntryRows(rows *sql.Rows) (*Entry, error) {
 // Implements event.MonitorStore interface.
 func (s *PostgresStore) RecordStart(ctx context.Context, eventID, subscriptionID, eventName, busID string,
 	workerPool bool, metadata map[string]string, traceID, spanID string,
-	subscriberName, subscriberDescription string) error {
+	subscriberName, subscriberDescription, workerGroup string) error {
 
 	mode := Broadcast
 	if workerPool {
@@ -624,6 +631,7 @@ func (s *PostgresStore) RecordStart(ctx context.Context, eventID, subscriptionID
 		StartedAt:             time.Now(),
 		TraceID:               traceID,
 		SpanID:                spanID,
+		WorkerGroup:           workerGroup,
 	}
 
 	return s.Record(ctx, entry)

--- a/monitor/proto/convert.go
+++ b/monitor/proto/convert.go
@@ -29,6 +29,7 @@ func EntryToProto(e *monitor.Entry) *Entry {
 		Duration:       durationpb.New(e.Duration),
 		TraceId:        e.TraceID,
 		SpanId:         e.SpanID,
+		WorkerGroup:    e.WorkerGroup,
 	}
 
 	if e.CompletedAt != nil {
@@ -57,6 +58,7 @@ func ProtoToEntry(pb *Entry) *monitor.Entry {
 		RetryCount:     int(pb.RetryCount),
 		TraceID:        pb.TraceId,
 		SpanID:         pb.SpanId,
+		WorkerGroup:    pb.WorkerGroup,
 	}
 
 	if pb.StartedAt != nil {
@@ -85,6 +87,7 @@ func ProtoToFilter(pb *Filter) monitor.Filter {
 		EventName:      pb.EventName,
 		BusID:          pb.BusId,
 		InstanceID:     pb.InstanceId,
+		WorkerGroup:    pb.WorkerGroup,
 		MinRetries:     int(pb.MinRetries),
 		Cursor:         pb.Cursor,
 		Limit:          int(pb.Limit),
@@ -128,6 +131,7 @@ func FilterToProto(f monitor.Filter) *Filter {
 		EventName:      f.EventName,
 		BusId:          f.BusID,
 		InstanceId:     f.InstanceID,
+		WorkerGroup:    f.WorkerGroup,
 		MinRetries:     int32(f.MinRetries),
 		Cursor:         f.Cursor,
 		Limit:          int32(f.Limit),

--- a/monitor/proto/monitor.pb.go
+++ b/monitor/proto/monitor.pb.go
@@ -147,6 +147,7 @@ type Entry struct {
 	TraceId        string                 `protobuf:"bytes,13,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
 	SpanId         string                 `protobuf:"bytes,14,opt,name=span_id,json=spanId,proto3" json:"span_id,omitempty"`
 	InstanceId     string                 `protobuf:"bytes,15,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	WorkerGroup    string                 `protobuf:"bytes,16,opt,name=worker_group,json=workerGroup,proto3" json:"worker_group,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -286,6 +287,13 @@ func (x *Entry) GetInstanceId() string {
 	return ""
 }
 
+func (x *Entry) GetWorkerGroup() string {
+	if x != nil {
+		return x.WorkerGroup
+	}
+	return ""
+}
+
 // Filter specifies criteria for listing monitor entries.
 type Filter struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
@@ -304,6 +312,7 @@ type Filter struct {
 	Limit          int32                  `protobuf:"varint,13,opt,name=limit,proto3" json:"limit,omitempty"`
 	OrderDesc      bool                   `protobuf:"varint,14,opt,name=order_desc,json=orderDesc,proto3" json:"order_desc,omitempty"`
 	InstanceId     string                 `protobuf:"bytes,15,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	WorkerGroup    string                 `protobuf:"bytes,16,opt,name=worker_group,json=workerGroup,proto3" json:"worker_group,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -439,6 +448,13 @@ func (x *Filter) GetOrderDesc() bool {
 func (x *Filter) GetInstanceId() string {
 	if x != nil {
 		return x.InstanceId
+	}
+	return ""
+}
+
+func (x *Filter) GetWorkerGroup() string {
+	if x != nil {
+		return x.WorkerGroup
 	}
 	return ""
 }

--- a/monitor/proto/monitor.proto
+++ b/monitor/proto/monitor.proto
@@ -61,6 +61,7 @@ message Entry {
   string trace_id = 13;
   string span_id = 14;
   string instance_id = 15;
+  string worker_group = 16;
 }
 
 // Filter specifies criteria for listing monitor entries.
@@ -80,6 +81,7 @@ message Filter {
   int32 limit = 13;
   bool order_desc = 14;
   string instance_id = 15;
+  string worker_group = 16;
 }
 
 // ListRequest is the request for List RPC.

--- a/monitor/store.go
+++ b/monitor/store.go
@@ -53,6 +53,7 @@ type Filter struct {
 	BusID          string // Filter by bus ID
 	InstanceID     string // Filter by instance ID (pod/hostname)
 	SubscriberName string // Exact match on subscriber name (human-readable identifier)
+	WorkerGroup    string // Exact match on worker group name
 
 	// Mode filter
 	DeliveryMode *DeliveryMode // Filter by delivery mode (nil = all modes)

--- a/topology.go
+++ b/topology.go
@@ -1,0 +1,135 @@
+package event
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// SubscriptionInfo describes a live subscription on an event.
+type SubscriptionInfo struct {
+	SubscriptionID        string       `json:"subscription_id"`
+	DeliveryMode          DeliveryMode `json:"delivery_mode"`
+	WorkerGroup           string       `json:"worker_group,omitempty"`
+	SubscriberName        string       `json:"subscriber_name,omitempty"`
+	SubscriberDescription string       `json:"subscriber_description,omitempty"`
+	StartedAt             time.Time    `json:"started_at"`
+}
+
+// EventInfo describes a registered event and its active subscriptions.
+type EventInfo struct {
+	Name            string             `json:"name"`
+	SubscriberCount int                `json:"subscriber_count"`
+	Subscriptions   []SubscriptionInfo `json:"subscriptions"`
+}
+
+// BusInfo describes a registered bus, its transport, and its events.
+type BusInfo struct {
+	ID            string      `json:"id"`
+	Name          string      `json:"name"`
+	Running       bool        `json:"running"`
+	TransportName string      `json:"transport_name"`
+	Events        []EventInfo `json:"events"`
+	HasMonitor    bool        `json:"has_monitor"`
+	HasDLQ        bool        `json:"has_dlq"`
+	HasOutbox     bool        `json:"has_outbox"`
+}
+
+// eventTopology is implemented by eventImpl[T] for generic-free topology access.
+type eventTopology interface {
+	eventName() string
+	subscriberCount() int64
+	subscriptionInfos() []SubscriptionInfo
+}
+
+// Topology returns a snapshot of all registered buses, their events, and subscriptions.
+func Topology() []BusInfo {
+	var infos []BusInfo
+	busRegistry.Range(func(key, value any) bool {
+		bus := value.(*Bus)
+		infos = append(infos, bus.Topology())
+		return true
+	})
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].Name < infos[j].Name
+	})
+	return infos
+}
+
+// Topology returns a snapshot of this bus, its events, and their subscriptions.
+func (b *Bus) Topology() BusInfo {
+	info := BusInfo{
+		ID:            b.id,
+		Name:          b.name,
+		Running:       b.Running(),
+		TransportName: transportName(b.transport),
+		HasMonitor:    b.monitorStore != nil,
+		HasDLQ:        b.dlqStore != nil,
+		HasOutbox:     b.outboxStore != nil,
+	}
+
+	b.eventMutex.RLock()
+	for _, ev := range b.events {
+		if topo, ok := ev.(eventTopology); ok {
+			subs := topo.subscriptionInfos()
+			info.Events = append(info.Events, EventInfo{
+				Name:            topo.eventName(),
+				SubscriberCount: int(topo.subscriberCount()),
+				Subscriptions:   subs,
+			})
+		}
+	}
+	b.eventMutex.RUnlock()
+
+	sort.Slice(info.Events, func(i, j int) bool {
+		return info.Events[i].Name < info.Events[j].Name
+	})
+
+	return info
+}
+
+// transportName returns a human-readable name for the transport.
+func transportName(t transport.Transport) string {
+	if t == nil {
+		return ""
+	}
+	if named, ok := t.(transport.Named); ok {
+		return named.Name()
+	}
+	// Fallback to reflected type name
+	rt := reflect.TypeOf(t)
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	return rt.Name()
+}
+
+// subscriptions tracks active subscription metadata on an eventImpl.
+// Access must be guarded by the embedded sync.Map.
+type subscriptionRegistry struct {
+	m sync.Map // map[subscriptionID]*SubscriptionInfo
+}
+
+func (r *subscriptionRegistry) add(info *SubscriptionInfo) {
+	r.m.Store(info.SubscriptionID, info)
+}
+
+func (r *subscriptionRegistry) remove(subscriptionID string) {
+	r.m.Delete(subscriptionID)
+}
+
+func (r *subscriptionRegistry) all() []SubscriptionInfo {
+	var infos []SubscriptionInfo
+	r.m.Range(func(key, value any) bool {
+		info := value.(*SubscriptionInfo)
+		infos = append(infos, *info)
+		return true
+	})
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].StartedAt.Before(infos[j].StartedAt)
+	})
+	return infos
+}

--- a/transport/channel/channel.go
+++ b/transport/channel/channel.go
@@ -432,4 +432,8 @@ func (t *Transport) SupportsRedelivery() bool { return false }
 var _ transport.Transport = (*Transport)(nil)
 var _ transport.HealthChecker = (*Transport)(nil)
 var _ transport.Redeliverable = (*Transport)(nil)
+var _ transport.Named = (*Transport)(nil)
+
+// Name returns the transport name.
+func (t *Transport) Name() string { return "channel" }
 var _ transport.Subscription = (*subscription)(nil)

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -648,9 +648,13 @@ func (h *consumerHandler) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 // re-delivery of uncommitted messages via consumer group offset management.
 func (t *Transport) SupportsRedelivery() bool { return true }
 
+// Name returns the transport name.
+func (t *Transport) Name() string { return "kafka" }
+
 // Compile-time checks
 var _ transport.Transport = (*Transport)(nil)
 var _ transport.HealthChecker = (*Transport)(nil)
+var _ transport.Named = (*Transport)(nil)
 var _ transport.LagMonitor = (*Transport)(nil)
 var _ transport.Redeliverable = (*Transport)(nil)
 var _ transport.Subscription = (*subscription)(nil)

--- a/transport/nats/core.go
+++ b/transport/nats/core.go
@@ -399,8 +399,12 @@ func (s *coreSubscription) handleMessage(msg *nats.Msg) {
 	}
 }
 
+// Name returns the transport name.
+func (t *CoreTransport) Name() string { return "nats" }
+
 // Compile-time checks
 var (
 	_ transport.Transport     = (*CoreTransport)(nil)
 	_ transport.HealthChecker = (*CoreTransport)(nil)
+	_ transport.Named         = (*CoreTransport)(nil)
 )

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -605,9 +605,13 @@ func (s *jsSubscription) consumeLoop(ctx context.Context, logger *slog.Logger) {
 // re-delivery of unacknowledged messages.
 func (t *JetStreamTransport) SupportsRedelivery() bool { return true }
 
+// Name returns the transport name.
+func (t *JetStreamTransport) Name() string { return "nats-jetstream" }
+
 // Compile-time checks
 var _ transport.Transport = (*JetStreamTransport)(nil)
 var _ transport.HealthChecker = (*JetStreamTransport)(nil)
+var _ transport.Named = (*JetStreamTransport)(nil)
 var _ transport.LagMonitor = (*JetStreamTransport)(nil)
 var _ transport.Redeliverable = (*JetStreamTransport)(nil)
 var _ transport.Subscription = (*jsSubscription)(nil)

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -748,9 +748,13 @@ func (s *subscription) claimOnce(ctx context.Context, logger *slog.Logger) {
 // re-delivery of unacknowledged messages via consumer group pending entries.
 func (t *Transport) SupportsRedelivery() bool { return true }
 
+// Name returns the transport name.
+func (t *Transport) Name() string { return "redis" }
+
 // Compile-time checks
 var _ transport.Transport = (*Transport)(nil)
 var _ transport.HealthChecker = (*Transport)(nil)
+var _ transport.Named = (*Transport)(nil)
 var _ transport.LagMonitor = (*Transport)(nil)
 var _ transport.Redeliverable = (*Transport)(nil)
 var _ transport.Subscription = (*subscription)(nil)

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -113,6 +113,13 @@ type ConsumerLag struct {
 	PendingMessages int64         `json:"pending_messages"` // Messages delivered but not yet acked
 }
 
+// Named is an optional interface that transports can implement
+// to identify themselves with a human-readable name.
+// Used by topology reporting to label transport types.
+type Named interface {
+	Name() string
+}
+
 // Redeliverable is an optional interface that transports can implement
 // to indicate they support automatic re-delivery of unacknowledged messages.
 // Transports that do NOT implement this interface are assumed to NOT support


### PR DESCRIPTION
## Summary

- Add bus topology registry for live introspection of buses, events, and subscriptions
- Thread `workerGroup` through context and monitor entries (breaking change to `MonitorStore.RecordStart`)
- Add federated HTTP endpoints for unified system view with DLQ/scheduler provider interfaces

## Changes

### Phase 1: Bus Topology Registry
- New `topology.go` with `BusInfo`, `EventInfo`, `SubscriptionInfo` snapshot types
- `Topology()` and `Bus.Topology()` for live bus/event/subscription introspection
- `transport.Named` optional interface — implemented by all transports (channel, redis, kafka, nats)
- `subscriptionRegistry` on `eventImpl` tracks active subscriptions via `sync.Map`

### Phase 2: WorkerGroup in Context & Monitor
- `workerGroup` added to `contextInfo`/`eventContextData` with `ContextWorkerGroup()` accessor
- **Breaking:** `MonitorStore.RecordStart` extended with `workerGroup string` parameter
- `WorkerGroup` added to `monitor.Entry`, `monitor.Filter`, protobuf definitions, and all store backends (memory, PostgreSQL, MongoDB)
- PostgreSQL `CreateTable` schema includes `worker_group TEXT` column

### Phase 3: Federated HTTP Endpoints
- `DLQProvider` and `SchedulerProvider` interfaces in `monitor/http/federation.go`
- `GET /v1/topology` and `GET /v1/topology/{bus_name}` — bus topology
- `GET /v1/system` — aggregated topology + DLQ + scheduler + health
- `GET /v1/system/health` — aggregated health (returns 503 when unhealthy)
- `WithDLQProvider()` and `WithSchedulerProvider()` handler options

## Breaking Changes

| Interface | Change |
|-----------|--------|
| `event.MonitorStore.RecordStart` | Added `workerGroup string` as final parameter |

All in-tree implementations (memory, PostgreSQL, MongoDB) are updated.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (902 tests, 28 packages)
- [ ] Verify topology snapshot accuracy with channel transport integration test
- [ ] Verify worker group appears in monitor entries when subscribed with `WithWorkerGroup`
- [ ] Verify `/v1/topology`, `/v1/system`, `/v1/system/health` HTTP endpoints