### PR TITLE
feat(monitor): add summary aggregation and enhance system view

### DIFF
--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -89,6 +89,9 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	h.mux.HandleFunc("/v1/monitor/entries/", h.handleEntriesWithPath)
 	h.mux.HandleFunc("/v1/monitor/entries/count", h.handleCount)
 
+	// Register summary endpoint
+	h.mux.HandleFunc("/v1/monitor/summary", h.handleSummary)
+
 	// Register topology endpoints
 	h.mux.HandleFunc("/v1/topology", h.handleTopology)
 	h.mux.HandleFunc("/v1/topology/", h.handleTopologyWithPath)

--- a/monitor/http/summary.go
+++ b/monitor/http/summary.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/rbaliyan/event/v3/monitor"
+)
+
+// handleSummary handles GET /v1/monitor/summary — returns aggregated statistics.
+func (h *Handler) handleSummary(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	sp, ok := h.store.(monitor.SummaryProvider)
+	if !ok {
+		h.writeError(w, http.StatusNotImplemented, "store does not support summary aggregation")
+		return
+	}
+
+	filter := h.parseFilterFromQuery(r)
+
+	// Default to last 24h if no time range specified
+	if filter.StartTime.IsZero() && filter.EndTime.IsZero() {
+		filter.StartTime = time.Now().Add(-24 * time.Hour)
+	}
+
+	summary, err := sp.Summary(r.Context(), filter)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	h.writeJSON(w, summary)
+}

--- a/monitor/http/summary_test.go
+++ b/monitor/http/summary_test.go
@@ -1,0 +1,110 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/monitor"
+)
+
+func TestHandlerSummary(t *testing.T) {
+	ctx := context.Background()
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	h := New(store)
+
+	// Seed some entries
+	now := time.Now()
+	entries := []*monitor.Entry{
+		{EventID: "1", EventName: "orders.created", BusID: "bus", Status: monitor.StatusCompleted, Duration: 100 * time.Millisecond, StartedAt: now.Add(-1 * time.Hour), DeliveryMode: monitor.Broadcast, InstanceID: "pod-1"},
+		{EventID: "2", EventName: "orders.created", BusID: "bus", Status: monitor.StatusFailed, Duration: 200 * time.Millisecond, StartedAt: now.Add(-30 * time.Minute), DeliveryMode: monitor.Broadcast, InstanceID: "pod-2"},
+		{EventID: "3", EventName: "orders.updated", BusID: "bus", Status: monitor.StatusCompleted, Duration: 50 * time.Millisecond, StartedAt: now, DeliveryMode: monitor.Broadcast, InstanceID: "pod-1"},
+	}
+	for _, e := range entries {
+		if err := store.Record(ctx, e); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+
+	t.Run("GET returns summary", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/monitor/summary", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var summary monitor.Summary
+		if err := json.Unmarshal(w.Body.Bytes(), &summary); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if summary.TotalEntries != 3 {
+			t.Errorf("expected 3 entries, got %d", summary.TotalEntries)
+		}
+		if summary.ByStatus[monitor.StatusCompleted] != 2 {
+			t.Errorf("expected 2 completed, got %d", summary.ByStatus[monitor.StatusCompleted])
+		}
+		if summary.ByStatus[monitor.StatusFailed] != 1 {
+			t.Errorf("expected 1 failed, got %d", summary.ByStatus[monitor.StatusFailed])
+		}
+		if len(summary.ByEventName) != 2 {
+			t.Errorf("expected 2 event names, got %d", len(summary.ByEventName))
+		}
+		if summary.ByInstance["pod-1"] != 2 {
+			t.Errorf("expected 2 for pod-1, got %d", summary.ByInstance["pod-1"])
+		}
+
+		// Verify avg_duration_ms is in milliseconds (not nanoseconds)
+		// Entries: 100ms + 200ms + 50ms = 350ms / 3 = 116ms
+		var raw map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+			t.Fatalf("unmarshal raw: %v", err)
+		}
+		avgMs, ok := raw["avg_duration_ms"].(float64)
+		if !ok {
+			t.Fatal("avg_duration_ms not a number in JSON")
+		}
+		if avgMs < 1 || avgMs > 1000 {
+			t.Errorf("expected avg_duration_ms in reasonable millisecond range, got %f", avgMs)
+		}
+	})
+
+	t.Run("GET with filter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/monitor/summary?event_name=orders.created", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var summary monitor.Summary
+		if err := json.Unmarshal(w.Body.Bytes(), &summary); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if summary.TotalEntries != 2 {
+			t.Errorf("expected 2 entries, got %d", summary.TotalEntries)
+		}
+	})
+
+	t.Run("POST not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/monitor/summary", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}

--- a/monitor/http/system.go
+++ b/monitor/http/system.go
@@ -1,19 +1,26 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/rbaliyan/event/v3"
 	"github.com/rbaliyan/event/v3/health"
+	"github.com/rbaliyan/event/v3/monitor"
 )
 
 // SystemView is the unified response for GET /v1/system.
 type SystemView struct {
-	Topology  []event.BusInfo        `json:"topology"`
-	DLQ       *DLQStats              `json:"dlq,omitempty"`
-	Scheduler *SchedulerStats        `json:"scheduler,omitempty"`
-	Health    *health.AggregateResult `json:"health"`
+	Topology    []event.BusInfo         `json:"topology"`
+	DLQ         *DLQStats               `json:"dlq,omitempty"`
+	Scheduler   *SchedulerStats         `json:"scheduler,omitempty"`
+	Health      *health.AggregateResult `json:"health"`
+	BusHealth   map[string]*event.Status `json:"bus_health,omitempty"`
+	ConsumerLag []event.ConsumerLag      `json:"consumer_lag,omitempty"`
+	Summary     *monitor.Summary         `json:"summary,omitempty"`
 }
 
 // handleSystemView handles GET /v1/system — aggregates topology, DLQ, scheduler, and health.
@@ -24,8 +31,9 @@ func (h *Handler) handleSystemView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+	topology := event.Topology()
 	view := SystemView{
-		Topology: event.Topology(),
+		Topology: topology,
 	}
 
 	components := make(map[string]*health.Result)
@@ -34,6 +42,8 @@ func (h *Handler) handleSystemView(w http.ResponseWriter, r *http.Request) {
 		stats, err := h.dlqProvider.DLQStats(ctx)
 		if err == nil {
 			view.DLQ = stats
+		} else {
+			slog.WarnContext(ctx, "dlq stats query failed", "error", err)
 		}
 		components["dlq"] = h.dlqProvider.Health(ctx)
 	}
@@ -42,8 +52,32 @@ func (h *Handler) handleSystemView(w http.ResponseWriter, r *http.Request) {
 		stats, err := h.schedProvider.SchedulerStats(ctx)
 		if err == nil {
 			view.Scheduler = stats
+		} else {
+			slog.WarnContext(ctx, "scheduler stats query failed", "error", err)
 		}
 		components["scheduler"] = h.schedProvider.Health(ctx)
+	}
+
+	// Collect bus health and consumer lag from registered buses
+	busHealth, consumerLag := h.collectBusHealth(ctx, topology, components)
+	if len(busHealth) > 0 {
+		view.BusHealth = busHealth
+	}
+	if len(consumerLag) > 0 {
+		view.ConsumerLag = consumerLag
+	}
+
+	// Include summary if store supports it
+	if sp, ok := h.store.(monitor.SummaryProvider); ok {
+		filter := monitor.Filter{
+			StartTime: time.Now().Add(-24 * time.Hour),
+		}
+		summary, err := sp.Summary(ctx, filter)
+		if err == nil {
+			view.Summary = summary
+		} else {
+			slog.WarnContext(ctx, "summary query failed", "error", err)
+		}
 	}
 
 	view.Health = health.Aggregate(components)
@@ -69,6 +103,9 @@ func (h *Handler) handleSystemHealth(w http.ResponseWriter, r *http.Request) {
 		components["scheduler"] = h.schedProvider.Health(ctx)
 	}
 
+	// Include bus health in the health check
+	h.collectBusHealth(ctx, event.Topology(), components)
+
 	result := health.Aggregate(components)
 
 	data, err := json.Marshal(result)
@@ -82,4 +119,35 @@ func (h *Handler) handleSystemHealth(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}
 	_, _ = w.Write(data)
+}
+
+// collectBusHealth collects health status and consumer lag from all registered buses.
+// It populates the components map with per-bus health results for aggregation.
+func (h *Handler) collectBusHealth(ctx context.Context, topology []event.BusInfo, components map[string]*health.Result) (map[string]*event.Status, []event.ConsumerLag) {
+	busHealth := make(map[string]*event.Status)
+	var consumerLag []event.ConsumerLag
+
+	for _, info := range topology {
+		bus := event.GetBus(info.Name)
+		if bus == nil {
+			continue
+		}
+
+		status := bus.Status(ctx)
+		busHealth[info.Name] = status
+
+		components["bus:"+info.Name] = &health.Result{
+			Status:    health.Status(status.Code),
+			Message:   status.Message,
+			Latency:   status.Latency,
+			CheckedAt: status.CheckedAt,
+		}
+
+		lag, err := bus.ConsumerLag(ctx)
+		if err == nil && len(lag) > 0 {
+			consumerLag = append(consumerLag, lag...)
+		}
+	}
+
+	return busHealth, consumerLag
 }

--- a/monitor/http/system_test.go
+++ b/monitor/http/system_test.go
@@ -1,0 +1,179 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/health"
+	"github.com/rbaliyan/event/v3/monitor"
+)
+
+// mockDLQProvider implements DLQProvider for testing.
+type mockDLQProvider struct {
+	stats  *DLQStats
+	health *health.Result
+}
+
+func (m *mockDLQProvider) DLQStats(ctx context.Context) (*DLQStats, error) {
+	return m.stats, nil
+}
+
+func (m *mockDLQProvider) Health(ctx context.Context) *health.Result {
+	return m.health
+}
+
+func TestHandleSystemView(t *testing.T) {
+	ctx := context.Background()
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	// Seed entries for summary
+	now := time.Now()
+	store.Record(ctx, &monitor.Entry{
+		EventID: "1", EventName: "orders.created", BusID: "bus",
+		Status: monitor.StatusCompleted, Duration: 100 * time.Millisecond,
+		StartedAt: now, DeliveryMode: monitor.Broadcast,
+	})
+
+	t.Run("basic system view without providers", func(t *testing.T) {
+		h := New(store)
+		req := httptest.NewRequest(http.MethodGet, "/v1/system", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var view SystemView
+		if err := json.Unmarshal(w.Body.Bytes(), &view); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if view.Health == nil {
+			t.Error("expected health to be present")
+		}
+		// Summary should be populated since MemoryStore implements SummaryProvider
+		if view.Summary == nil {
+			t.Error("expected summary to be present")
+		}
+		if view.Summary != nil && view.Summary.TotalEntries != 1 {
+			t.Errorf("expected 1 entry in summary, got %d", view.Summary.TotalEntries)
+		}
+	})
+
+	t.Run("system view with DLQ provider", func(t *testing.T) {
+		dlq := &mockDLQProvider{
+			stats: &DLQStats{
+				TotalMessages:   42,
+				PendingMessages: 5,
+			},
+			health: &health.Result{
+				Status:    health.StatusDegraded,
+				Message:   "5 messages pending in DLQ",
+				CheckedAt: now,
+			},
+		}
+
+		h := New(store, WithDLQProvider(dlq))
+		req := httptest.NewRequest(http.MethodGet, "/v1/system", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var view SystemView
+		if err := json.Unmarshal(w.Body.Bytes(), &view); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if view.DLQ == nil {
+			t.Fatal("expected DLQ stats")
+		}
+		if view.DLQ.TotalMessages != 42 {
+			t.Errorf("expected 42 total messages, got %d", view.DLQ.TotalMessages)
+		}
+		if view.Health.Status != health.StatusDegraded {
+			t.Errorf("expected degraded health, got %s", view.Health.Status)
+		}
+		if view.Health.Components["dlq"] == nil {
+			t.Error("expected dlq component in health")
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		h := New(store)
+		req := httptest.NewRequest(http.MethodPost, "/v1/system", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+func TestHandleSystemHealth(t *testing.T) {
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	t.Run("healthy when no providers", func(t *testing.T) {
+		h := New(store)
+		req := httptest.NewRequest(http.MethodGet, "/v1/system/health", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		var result health.AggregateResult
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if result.Status != health.StatusHealthy {
+			t.Errorf("expected healthy, got %s", result.Status)
+		}
+	})
+
+	t.Run("unhealthy returns 503", func(t *testing.T) {
+		dlq := &mockDLQProvider{
+			stats: &DLQStats{},
+			health: &health.Result{
+				Status:    health.StatusUnhealthy,
+				Message:   "store connectivity failed",
+				CheckedAt: time.Now(),
+			},
+		}
+
+		h := New(store, WithDLQProvider(dlq))
+		req := httptest.NewRequest(http.MethodGet, "/v1/system/health", nil)
+		w := httptest.NewRecorder()
+
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("expected 503, got %d", w.Code)
+		}
+
+		var result health.AggregateResult
+		if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if result.Status != health.StatusUnhealthy {
+			t.Errorf("expected unhealthy, got %s", result.Status)
+		}
+	})
+}

--- a/monitor/memory.go
+++ b/monitor/memory.go
@@ -410,5 +410,104 @@ func (s *MemoryStore) RecordComplete(ctx context.Context, eventID, subscriptionI
 	return s.UpdateStatus(ctx, eventID, subscriptionID, Status(status), handlerErr, duration)
 }
 
+// Summary returns aggregated statistics for entries matching the filter.
+func (s *MemoryStore) Summary(ctx context.Context, filter Filter) (*Summary, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, fmt.Errorf("store is closed")
+	}
+
+	summary := &Summary{
+		ByStatus:    make(map[Status]int64),
+		ByEventName: make(map[string]*EventStats),
+		ByInstance:  make(map[string]int64),
+	}
+
+	type durationAcc struct {
+		totalMs int64
+		count   int64
+	}
+	var globalDur durationAcc
+	eventDurations := make(map[string]*durationAcc)
+
+	for _, entry := range s.entries {
+		if !s.matchesFilter(entry, filter) {
+			continue
+		}
+
+		summary.TotalEntries++
+		summary.ByStatus[entry.Status]++
+
+		// Per-event stats
+		es, ok := summary.ByEventName[entry.EventName]
+		if !ok {
+			es = &EventStats{}
+			summary.ByEventName[entry.EventName] = es
+			eventDurations[entry.EventName] = &durationAcc{}
+		}
+		es.Total++
+		switch entry.Status {
+		case StatusCompleted:
+			es.Completed++
+		case StatusFailed:
+			es.Failed++
+		case StatusRetrying:
+			es.Retrying++
+		case StatusPending:
+			es.Pending++
+		}
+
+		if entry.Duration > 0 {
+			ms := entry.Duration.Milliseconds()
+			globalDur.totalMs += ms
+			globalDur.count++
+			ed := eventDurations[entry.EventName]
+			ed.totalMs += ms
+			ed.count++
+		}
+
+		if entry.InstanceID != "" {
+			summary.ByInstance[entry.InstanceID]++
+		}
+
+		t := entry.StartedAt
+		if summary.TimeRange.Oldest == nil || t.Before(*summary.TimeRange.Oldest) {
+			cp := t
+			summary.TimeRange.Oldest = &cp
+		}
+		if summary.TimeRange.Newest == nil || t.After(*summary.TimeRange.Newest) {
+			cp := t
+			summary.TimeRange.Newest = &cp
+		}
+	}
+
+	// Compute global averages and rates
+	if globalDur.count > 0 {
+		summary.AvgDurationMs = globalDur.totalMs / globalDur.count
+	}
+	if summary.TotalEntries > 0 {
+		summary.ErrorRate = float64(summary.ByStatus[StatusFailed]) / float64(summary.TotalEntries)
+	}
+
+	// Compute per-event averages and error rates
+	for name, es := range summary.ByEventName {
+		if ed := eventDurations[name]; ed.count > 0 {
+			es.AvgDurationMs = ed.totalMs / ed.count
+		}
+		if es.Total > 0 {
+			es.ErrorRate = float64(es.Failed) / float64(es.Total)
+		}
+	}
+
+	if len(summary.ByInstance) == 0 {
+		summary.ByInstance = nil
+	}
+
+	return summary, nil
+}
+
 // Compile-time check that MemoryStore implements Store.
 var _ Store = (*MemoryStore)(nil)
+var _ SummaryProvider = (*MemoryStore)(nil)

--- a/monitor/memory_summary_test.go
+++ b/monitor/memory_summary_test.go
@@ -1,0 +1,161 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreSummary(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	t.Run("empty store", func(t *testing.T) {
+		store := NewMemoryStore()
+		defer store.Close()
+
+		summary, err := store.Summary(ctx, Filter{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if summary.TotalEntries != 0 {
+			t.Errorf("expected 0 entries, got %d", summary.TotalEntries)
+		}
+		if len(summary.ByStatus) != 0 {
+			t.Errorf("expected empty ByStatus, got %v", summary.ByStatus)
+		}
+		if summary.ErrorRate != 0 {
+			t.Errorf("expected 0 error rate, got %f", summary.ErrorRate)
+		}
+	})
+
+	t.Run("aggregates correctly", func(t *testing.T) {
+		store := NewMemoryStore()
+		defer store.Close()
+
+		entries := []*Entry{
+			{EventID: "1", EventName: "orders.created", BusID: "bus", Status: StatusCompleted, Duration: 100 * time.Millisecond, StartedAt: now.Add(-3 * time.Hour), InstanceID: "pod-1", DeliveryMode: Broadcast},
+			{EventID: "2", EventName: "orders.created", BusID: "bus", Status: StatusFailed, Duration: 200 * time.Millisecond, StartedAt: now.Add(-2 * time.Hour), InstanceID: "pod-1", DeliveryMode: Broadcast},
+			{EventID: "3", EventName: "orders.updated", BusID: "bus", Status: StatusCompleted, Duration: 50 * time.Millisecond, StartedAt: now.Add(-1 * time.Hour), InstanceID: "pod-2", DeliveryMode: Broadcast},
+			{EventID: "4", EventName: "orders.created", BusID: "bus", Status: StatusRetrying, Duration: 300 * time.Millisecond, StartedAt: now, InstanceID: "pod-2", DeliveryMode: Broadcast},
+			{EventID: "5", EventName: "orders.created", BusID: "bus", Status: StatusPending, StartedAt: now.Add(time.Second), InstanceID: "pod-1", DeliveryMode: Broadcast},
+		}
+		for _, e := range entries {
+			if err := store.Record(ctx, e); err != nil {
+				t.Fatalf("Record: %v", err)
+			}
+		}
+
+		summary, err := store.Summary(ctx, Filter{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if summary.TotalEntries != 5 {
+			t.Errorf("expected 5 entries, got %d", summary.TotalEntries)
+		}
+
+		// Status counts
+		if summary.ByStatus[StatusCompleted] != 2 {
+			t.Errorf("expected 2 completed, got %d", summary.ByStatus[StatusCompleted])
+		}
+		if summary.ByStatus[StatusFailed] != 1 {
+			t.Errorf("expected 1 failed, got %d", summary.ByStatus[StatusFailed])
+		}
+		if summary.ByStatus[StatusRetrying] != 1 {
+			t.Errorf("expected 1 retrying, got %d", summary.ByStatus[StatusRetrying])
+		}
+		if summary.ByStatus[StatusPending] != 1 {
+			t.Errorf("expected 1 pending, got %d", summary.ByStatus[StatusPending])
+		}
+
+		// Per-event stats
+		ordersCreated := summary.ByEventName["orders.created"]
+		if ordersCreated == nil {
+			t.Fatal("expected orders.created stats")
+		}
+		if ordersCreated.Total != 4 {
+			t.Errorf("expected 4 orders.created total, got %d", ordersCreated.Total)
+		}
+		if ordersCreated.Failed != 1 {
+			t.Errorf("expected 1 orders.created failed, got %d", ordersCreated.Failed)
+		}
+		if ordersCreated.ErrorRate != 0.25 {
+			t.Errorf("expected 0.25 error rate, got %f", ordersCreated.ErrorRate)
+		}
+
+		ordersUpdated := summary.ByEventName["orders.updated"]
+		if ordersUpdated == nil {
+			t.Fatal("expected orders.updated stats")
+		}
+		if ordersUpdated.Total != 1 {
+			t.Errorf("expected 1 orders.updated total, got %d", ordersUpdated.Total)
+		}
+
+		// Instance counts
+		if summary.ByInstance["pod-1"] != 3 {
+			t.Errorf("expected 3 for pod-1, got %d", summary.ByInstance["pod-1"])
+		}
+		if summary.ByInstance["pod-2"] != 2 {
+			t.Errorf("expected 2 for pod-2, got %d", summary.ByInstance["pod-2"])
+		}
+
+		// Error rate
+		if summary.ErrorRate != 0.2 {
+			t.Errorf("expected 0.2 error rate, got %f", summary.ErrorRate)
+		}
+
+		// Time range
+		if summary.TimeRange.Oldest == nil || !summary.TimeRange.Oldest.Equal(now.Add(-3*time.Hour)) {
+			t.Errorf("unexpected oldest: %v", summary.TimeRange.Oldest)
+		}
+		if summary.TimeRange.Newest == nil || !summary.TimeRange.Newest.Equal(now.Add(time.Second)) {
+			t.Errorf("unexpected newest: %v", summary.TimeRange.Newest)
+		}
+
+		// Avg duration in ms (only 4 entries have duration > 0: 100+200+50+300 = 650/4 = 162ms)
+		if summary.AvgDurationMs != 162 {
+			t.Errorf("expected 162 avg duration ms, got %d", summary.AvgDurationMs)
+		}
+	})
+
+	t.Run("respects filter", func(t *testing.T) {
+		store := NewMemoryStore()
+		defer store.Close()
+
+		entries := []*Entry{
+			{EventID: "1", EventName: "orders.created", BusID: "bus", Status: StatusCompleted, StartedAt: now, DeliveryMode: Broadcast},
+			{EventID: "2", EventName: "orders.updated", BusID: "bus", Status: StatusFailed, StartedAt: now, DeliveryMode: Broadcast},
+		}
+		for _, e := range entries {
+			store.Record(ctx, e)
+		}
+
+		summary, err := store.Summary(ctx, Filter{EventName: "orders.created"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if summary.TotalEntries != 1 {
+			t.Errorf("expected 1 entry, got %d", summary.TotalEntries)
+		}
+		if summary.ErrorRate != 0 {
+			t.Errorf("expected 0 error rate, got %f", summary.ErrorRate)
+		}
+	})
+
+	t.Run("closed store returns error", func(t *testing.T) {
+		store := NewMemoryStore()
+		store.Close()
+
+		_, err := store.Summary(ctx, Filter{})
+		if err == nil {
+			t.Error("expected error for closed store")
+		}
+	})
+
+	t.Run("implements SummaryProvider", func(t *testing.T) {
+		store := NewMemoryStore()
+		var _ SummaryProvider = store
+	})
+}

--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -579,5 +579,179 @@ func (s *MongoStore) RecordComplete(ctx context.Context, eventID, subscriptionID
 	return s.UpdateStatus(ctx, eventID, subscriptionID, Status(status), handlerErr, duration)
 }
 
+// Summary returns aggregated statistics using a MongoDB $facet aggregation pipeline.
+func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, error) {
+	matchStage := s.buildFilter(filter)
+
+	// Default to last 24h if no time range specified to avoid full collection scan
+	if filter.StartTime.IsZero() && filter.EndTime.IsZero() {
+		if existing, ok := matchStage["started_at"].(bson.M); ok {
+			existing["$gte"] = time.Now().Add(-24 * time.Hour)
+		} else {
+			matchStage["started_at"] = bson.M{"$gte": time.Now().Add(-24 * time.Hour)}
+		}
+	}
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: matchStage}},
+		{{Key: "$facet", Value: bson.M{
+			"by_status": mongo.Pipeline{
+				{{Key: "$group", Value: bson.M{
+					"_id":   "$status",
+					"count": bson.M{"$sum": 1},
+				}}},
+			},
+			"by_event": mongo.Pipeline{
+				{{Key: "$group", Value: bson.M{
+					"_id":       "$event_name",
+					"total":     bson.M{"$sum": 1},
+					"completed": bson.M{"$sum": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{"$status", "completed"}}, 1, 0}}},
+					"failed":    bson.M{"$sum": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{"$status", "failed"}}, 1, 0}}},
+					"retrying":  bson.M{"$sum": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{"$status", "retrying"}}, 1, 0}}},
+					"pending":   bson.M{"$sum": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{"$status", "pending"}}, 1, 0}}},
+					"avg_dur":   bson.M{"$avg": "$duration_ms"},
+				}}},
+			},
+			"by_instance": mongo.Pipeline{
+				{{Key: "$match", Value: bson.M{"instance_id": bson.M{"$ne": ""}}}},
+				{{Key: "$group", Value: bson.M{
+					"_id":   "$instance_id",
+					"count": bson.M{"$sum": 1},
+				}}},
+			},
+			"global": mongo.Pipeline{
+				{{Key: "$group", Value: bson.M{
+					"_id":     nil,
+					"total":   bson.M{"$sum": 1},
+					"avg_dur": bson.M{"$avg": "$duration_ms"},
+					"failed":  bson.M{"$sum": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{"$status", "failed"}}, 1, 0}}},
+				}}},
+			},
+			"oldest": mongo.Pipeline{
+				{{Key: "$sort", Value: bson.M{"started_at": 1}}},
+				{{Key: "$limit", Value: 1}},
+				{{Key: "$project", Value: bson.M{"started_at": 1}}},
+			},
+			"newest": mongo.Pipeline{
+				{{Key: "$sort", Value: bson.M{"started_at": -1}}},
+				{{Key: "$limit", Value: 1}},
+				{{Key: "$project", Value: bson.M{"started_at": 1}}},
+			},
+		}}},
+	}
+
+	cursor, err := s.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("summary aggregate: %w", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var results []struct {
+		ByStatus []struct {
+			ID    string `bson:"_id"`
+			Count int64  `bson:"count"`
+		} `bson:"by_status"`
+		ByEvent []struct {
+			ID        string   `bson:"_id"`
+			Total     int64    `bson:"total"`
+			Completed int64    `bson:"completed"`
+			Failed    int64    `bson:"failed"`
+			Retrying  int64    `bson:"retrying"`
+			Pending   int64    `bson:"pending"`
+			AvgDur    *float64 `bson:"avg_dur"`
+		} `bson:"by_event"`
+		ByInstance []struct {
+			ID    string `bson:"_id"`
+			Count int64  `bson:"count"`
+		} `bson:"by_instance"`
+		Global []struct {
+			Total  int64    `bson:"total"`
+			AvgDur *float64 `bson:"avg_dur"`
+			Failed int64    `bson:"failed"`
+		} `bson:"global"`
+		Oldest []struct {
+			StartedAt time.Time `bson:"started_at"`
+		} `bson:"oldest"`
+		Newest []struct {
+			StartedAt time.Time `bson:"started_at"`
+		} `bson:"newest"`
+	}
+
+	if !cursor.Next(ctx) {
+		return &Summary{
+			ByStatus:    make(map[Status]int64),
+			ByEventName: make(map[string]*EventStats),
+		}, nil
+	}
+	if err := cursor.Decode(&results); err != nil {
+		return nil, fmt.Errorf("decode summary: %w", err)
+	}
+
+	// This should not happen but guard anyway
+	if len(results) == 0 {
+		return &Summary{
+			ByStatus:    make(map[Status]int64),
+			ByEventName: make(map[string]*EventStats),
+		}, nil
+	}
+
+	r := results[0]
+	summary := &Summary{
+		ByStatus:    make(map[Status]int64, len(r.ByStatus)),
+		ByEventName: make(map[string]*EventStats, len(r.ByEvent)),
+	}
+
+	for _, s := range r.ByStatus {
+		summary.ByStatus[Status(s.ID)] = s.Count
+	}
+
+	for _, e := range r.ByEvent {
+		es := &EventStats{
+			Total:     e.Total,
+			Completed: e.Completed,
+			Failed:    e.Failed,
+			Retrying:  e.Retrying,
+			Pending:   e.Pending,
+		}
+		if e.AvgDur != nil {
+			es.AvgDurationMs = int64(*e.AvgDur)
+		}
+		if es.Total > 0 {
+			es.ErrorRate = float64(es.Failed) / float64(es.Total)
+		}
+		summary.ByEventName[e.ID] = es
+	}
+
+	if len(r.ByInstance) > 0 {
+		summary.ByInstance = make(map[string]int64, len(r.ByInstance))
+		for _, inst := range r.ByInstance {
+			summary.ByInstance[inst.ID] = inst.Count
+		}
+	}
+
+	if len(r.Global) > 0 {
+		g := r.Global[0]
+		summary.TotalEntries = g.Total
+		if g.AvgDur != nil {
+			summary.AvgDurationMs = int64(*g.AvgDur)
+		}
+		if g.Total > 0 {
+			summary.ErrorRate = float64(g.Failed) / float64(g.Total)
+		}
+	}
+
+	if len(r.Oldest) > 0 {
+		t := r.Oldest[0].StartedAt
+		summary.TimeRange.Oldest = &t
+	}
+	if len(r.Newest) > 0 {
+		t := r.Newest[0].StartedAt
+		summary.TimeRange.Newest = &t
+	}
+
+	return summary, nil
+}
+
 // Compile-time check that MongoStore implements Store.
 var _ Store = (*MongoStore)(nil)
+var _ SummaryProvider = (*MongoStore)(nil)

--- a/monitor/postgres.go
+++ b/monitor/postgres.go
@@ -645,5 +645,154 @@ func (s *PostgresStore) RecordComplete(ctx context.Context, eventID, subscriptio
 	return s.UpdateStatus(ctx, eventID, subscriptionID, Status(status), handlerErr, duration)
 }
 
+// Summary returns aggregated statistics using SQL GROUP BY queries.
+func (s *PostgresStore) Summary(ctx context.Context, filter Filter) (*Summary, error) {
+	qb, err := s.buildFilterQuery(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Default to last 24h if no time range specified
+	if filter.StartTime.IsZero() && filter.EndTime.IsZero() {
+		qb.Add("started_at >= $%d", time.Now().Add(-24*time.Hour))
+	}
+
+	where := qb.WhereClause()
+	args := qb.Args()
+
+	query := fmt.Sprintf(`
+		SELECT
+			COUNT(*) AS total,
+			COALESCE(AVG(duration_ms), 0) AS avg_duration_ms,
+			COUNT(*) FILTER (WHERE status = 'failed') AS failed_count,
+			COUNT(*) FILTER (WHERE status = 'completed') AS completed_count,
+			COUNT(*) FILTER (WHERE status = 'retrying') AS retrying_count,
+			COUNT(*) FILTER (WHERE status = 'pending') AS pending_count,
+			MIN(started_at) AS oldest,
+			MAX(started_at) AS newest
+		FROM %s
+		%s
+	`, s.opts.tableName, where)
+
+	var total, failedCount, completedCount, retryingCount, pendingCount int64
+	var avgDurMs float64
+	var oldest, newest sql.NullTime
+
+	err = s.db.QueryRowContext(ctx, query, args...).Scan(
+		&total, &avgDurMs, &failedCount, &completedCount, &retryingCount, &pendingCount,
+		&oldest, &newest,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("summary global: %w", err)
+	}
+
+	summary := &Summary{
+		TotalEntries: total,
+		AvgDurationMs: int64(avgDurMs),
+		ByStatus:     make(map[Status]int64),
+		ByEventName:  make(map[string]*EventStats),
+	}
+
+	if total > 0 {
+		summary.ErrorRate = float64(failedCount) / float64(total)
+	}
+	if completedCount > 0 {
+		summary.ByStatus[StatusCompleted] = completedCount
+	}
+	if failedCount > 0 {
+		summary.ByStatus[StatusFailed] = failedCount
+	}
+	if retryingCount > 0 {
+		summary.ByStatus[StatusRetrying] = retryingCount
+	}
+	if pendingCount > 0 {
+		summary.ByStatus[StatusPending] = pendingCount
+	}
+	if oldest.Valid {
+		t := oldest.Time
+		summary.TimeRange.Oldest = &t
+	}
+	if newest.Valid {
+		t := newest.Time
+		summary.TimeRange.Newest = &t
+	}
+
+	// Per-event stats
+	eventQuery := fmt.Sprintf(`
+		SELECT
+			event_name,
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE status = 'completed') AS completed,
+			COUNT(*) FILTER (WHERE status = 'failed') AS failed,
+			COUNT(*) FILTER (WHERE status = 'retrying') AS retrying,
+			COUNT(*) FILTER (WHERE status = 'pending') AS pending,
+			COALESCE(AVG(duration_ms), 0) AS avg_duration_ms
+		FROM %s
+		%s
+		GROUP BY event_name
+	`, s.opts.tableName, where)
+
+	rows, err := s.db.QueryContext(ctx, eventQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("summary by event: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var name string
+		var es EventStats
+		var avgDur float64
+		if err := rows.Scan(&name, &es.Total, &es.Completed, &es.Failed, &es.Retrying, &es.Pending, &avgDur); err != nil {
+			return nil, fmt.Errorf("scan event stats: %w", err)
+		}
+		es.AvgDurationMs = int64(avgDur)
+		if es.Total > 0 {
+			es.ErrorRate = float64(es.Failed) / float64(es.Total)
+		}
+		summary.ByEventName[name] = &es
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("event rows: %w", err)
+	}
+
+	// Per-instance counts — use WHERE TRUE as baseline when where is empty
+	// to safely append AND conditions
+	instanceWhere := where
+	if instanceWhere == "" {
+		instanceWhere = "WHERE TRUE"
+	}
+	instanceQuery := fmt.Sprintf(`
+		SELECT instance_id, COUNT(*) AS count
+		FROM %s
+		%s AND instance_id IS NOT NULL AND instance_id != ''
+		GROUP BY instance_id
+	`, s.opts.tableName, instanceWhere)
+
+	instRows, err := s.db.QueryContext(ctx, instanceQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("summary by instance: %w", err)
+	}
+	defer func() { _ = instRows.Close() }()
+
+	byInstance := make(map[string]int64)
+	for instRows.Next() {
+		var id string
+		var count int64
+		if err := instRows.Scan(&id, &count); err != nil {
+			return nil, fmt.Errorf("scan instance: %w", err)
+		}
+		byInstance[id] = count
+	}
+	if err := instRows.Err(); err != nil {
+		return nil, fmt.Errorf("instance rows: %w", err)
+	}
+	if len(byInstance) > 0 {
+		summary.ByInstance = byInstance
+	}
+
+	return summary, nil
+}
+
 // Compile-time check that PostgresStore implements Store.
 var _ Store = (*PostgresStore)(nil)
+var _ SummaryProvider = (*PostgresStore)(nil)

--- a/monitor/store.go
+++ b/monitor/store.go
@@ -107,3 +107,37 @@ func (f *Filter) EffectiveLimit() int {
 	}
 	return f.Limit
 }
+
+// SummaryProvider is an optional interface for stores that support aggregated summary queries.
+// Implementations should use database-level aggregation (e.g., $facet, GROUP BY) for efficiency.
+type SummaryProvider interface {
+	Summary(ctx context.Context, filter Filter) (*Summary, error)
+}
+
+// Summary contains aggregated statistics for monitor entries matching a filter.
+type Summary struct {
+	TotalEntries  int64                  `json:"total_entries"`
+	ByStatus      map[Status]int64       `json:"by_status"`
+	ByEventName   map[string]*EventStats `json:"by_event_name"`
+	ByInstance    map[string]int64       `json:"by_instance,omitempty"`
+	AvgDurationMs int64                  `json:"avg_duration_ms"`
+	ErrorRate     float64                `json:"error_rate"`
+	TimeRange     TimeRange              `json:"time_range"`
+}
+
+// EventStats contains per-event aggregated statistics.
+type EventStats struct {
+	Total         int64   `json:"total"`
+	Completed     int64   `json:"completed"`
+	Failed        int64   `json:"failed"`
+	Retrying      int64   `json:"retrying"`
+	Pending       int64   `json:"pending"`
+	AvgDurationMs int64   `json:"avg_duration_ms"`
+	ErrorRate     float64 `json:"error_rate"`
+}
+
+// TimeRange contains the oldest and newest timestamps in a result set.
+type TimeRange struct {
+	Oldest *time.Time `json:"oldest,omitempty"`
+	Newest *time.Time `json:"newest,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Add `SummaryProvider` optional interface with implementations for Memory, MongoDB ($facet pipeline), and PostgreSQL (GROUP BY with FILTER) stores
- Add `GET /v1/monitor/summary` endpoint for aggregated per-event stats, error rates, and duration breakdowns
- Enhance `GET /v1/system` with bus health, consumer lag, and summary fields
- Extract `collectBusHealth` helper eliminating duplication between system view and health endpoints
- Add structured logging (`slog.WarnContext`) for silenced provider errors in system view
- Use `int64` milliseconds for `AvgDurationMs` instead of `time.Duration` for correct JSON serialization
- Guard Postgres instance query with `WHERE TRUE` fallback for empty WHERE clauses
- Use comma-ok assertion for MongoDB `bson.M` type check in Summary default time window

## Test plan

- [x] 5 MemoryStore summary tests (empty, aggregation, filter, closed, interface check)
- [x] 3 HTTP summary handler tests (GET, filter, method not allowed) with JSON round-trip assertion for duration
- [x] 5 system view/health tests (basic, DLQ provider, method not allowed, healthy, unhealthy)
- [x] All 73 monitor tests pass (23 core + 18 gRPC + 32 HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)