### PR TITLE
fix(monitor): decode summary facet result as single document

### DIFF
--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -642,7 +642,7 @@ func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, erro
 	}
 	defer func() { _ = cursor.Close(ctx) }()
 
-	var results []struct {
+	var r struct {
 		ByStatus []struct {
 			ID    string `bson:"_id"`
 			Count int64  `bson:"count"`
@@ -679,19 +679,9 @@ func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, erro
 			ByEventName: make(map[string]*EventStats),
 		}, nil
 	}
-	if err := cursor.Decode(&results); err != nil {
+	if err := cursor.Decode(&r); err != nil {
 		return nil, fmt.Errorf("decode summary: %w", err)
 	}
-
-	// This should not happen but guard anyway
-	if len(results) == 0 {
-		return &Summary{
-			ByStatus:    make(map[Status]int64),
-			ByEventName: make(map[string]*EventStats),
-		}, nil
-	}
-
-	r := results[0]
 	summary := &Summary{
 		ByStatus:    make(map[Status]int64, len(r.ByStatus)),
 		ByEventName: make(map[string]*EventStats, len(r.ByEvent)),


### PR DESCRIPTION
## Summary
- MongoDB `$facet` always returns exactly one document, but `cursor.Decode` was called with a slice target (`[]struct{...}`), causing a BSON decode error at runtime
- Changed to decode into a single struct and removed the redundant empty-slice guard

## Test plan
- [x] All 84 monitor tests pass (`go test ./monitor/...`)
- [ ] Manual verification against a live MongoDB instance with the summary endpoint