### PR TITLE
fix(monitor): prevent race condition in WorkerPool mode

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -287,4 +288,50 @@ func detachedContext(ctx context.Context) context.Context {
 		bg = oteltrace.ContextWithSpanContext(bg, spanCtx)
 	}
 	return bg
+}
+
+// AcquisitionResult represents the outcome of a WorkerPool acquisition attempt.
+type AcquisitionResult int32
+
+const (
+	// AcquisitionPending indicates the acquisition attempt has not yet completed.
+	AcquisitionPending AcquisitionResult = iota
+	// AcquisitionAcquired indicates this worker won the acquisition.
+	AcquisitionAcquired
+	// AcquisitionSkipped indicates another worker acquired the message.
+	AcquisitionSkipped
+)
+
+// AcquisitionSignal is an atomic signal that communicates the result of a
+// WorkerPool acquisition attempt from the WorkerPoolMiddleware back to the
+// monitor middleware. This prevents the monitor from recording false "completed"
+// entries for workers that did not actually process the message.
+type AcquisitionSignal struct {
+	result atomic.Int32
+}
+
+// Set stores the acquisition result.
+func (s *AcquisitionSignal) Set(r AcquisitionResult) {
+	s.result.Store(int32(r))
+}
+
+// Result returns the current acquisition result.
+func (s *AcquisitionSignal) Result() AcquisitionResult {
+	return AcquisitionResult(s.result.Load())
+}
+
+type acquisitionSignalKey struct{}
+
+// ContextWithAcquisitionSignal stores an AcquisitionSignal in the context.
+// The monitor middleware injects this before calling the next handler, and
+// the WorkerPoolMiddleware writes the result after Acquire().
+func ContextWithAcquisitionSignal(ctx context.Context, signal *AcquisitionSignal) context.Context {
+	return context.WithValue(ctx, acquisitionSignalKey{}, signal)
+}
+
+// ContextAcquisitionSignal retrieves the AcquisitionSignal from the context.
+// Returns nil if no signal is present (non-WorkerPool mode).
+func ContextAcquisitionSignal(ctx context.Context) *AcquisitionSignal {
+	s, _ := ctx.Value(acquisitionSignalKey{}).(*AcquisitionSignal)
+	return s
 }

--- a/distributed/middleware.go
+++ b/distributed/middleware.go
@@ -167,17 +167,29 @@ func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts
 						"message_id", messageID,
 						"error", err)
 				}
+				// Signal acquired on error (fail open = treat as acquired)
+				if sig := event.ContextAcquisitionSignal(ctx); sig != nil {
+					sig.Set(event.AcquisitionAcquired)
+				}
 				return next(ctx, ev, data)
 			}
 
 			if !acquired {
 				// Another worker already acquired this message - skip silently
+				if sig := event.ContextAcquisitionSignal(ctx); sig != nil {
+					sig.Set(event.AcquisitionSkipped)
+				}
 				logger := event.ContextLogger(ctx)
 				if logger != nil {
 					logger.Debug("message acquired by another worker, skipping",
 						"message_id", messageID)
 				}
 				return nil
+			}
+
+			// Signal successful acquisition
+			if sig := event.ContextAcquisitionSignal(ctx); sig != nil {
+				sig.Set(event.AcquisitionAcquired)
 			}
 
 			// Store payload for recovery if needed (after successful acquire)

--- a/middleware.go
+++ b/middleware.go
@@ -414,10 +414,25 @@ func MonitorMiddleware[T any](store MonitorStore) Middleware[T] {
 				}
 			}
 
+			// For WorkerPool mode, inject an acquisition signal so the
+			// WorkerPoolMiddleware can communicate whether this worker
+			// actually acquired the message.
+			var signal *AcquisitionSignal
+			if workerPool {
+				signal = &AcquisitionSignal{}
+				ctx = ContextWithAcquisitionSignal(ctx, signal)
+			}
+
 			// Execute handler
 			start := time.Now()
 			handlerErr := next(ctx, ev, data)
 			duration := time.Since(start)
+
+			// In WorkerPool mode, skip recording if this worker didn't acquire the message.
+			// The winning worker will record the actual result.
+			if signal != nil && signal.Result() == AcquisitionSkipped {
+				return handlerErr
+			}
 
 			// Determine status
 			status := "completed"

--- a/monitor/memory.go
+++ b/monitor/memory.go
@@ -45,6 +45,9 @@ func makeKey(eventID, subscriptionID string, mode DeliveryMode) string {
 }
 
 // Record creates or updates a monitor entry.
+//
+// In WorkerPool mode, if an entry already exists it is not overwritten.
+// This prevents losing workers from replacing the winning worker's data.
 func (s *MemoryStore) Record(ctx context.Context, entry *Entry) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -54,6 +57,13 @@ func (s *MemoryStore) Record(ctx context.Context, entry *Entry) error {
 	}
 
 	key := makeKey(entry.EventID, entry.SubscriptionID, entry.DeliveryMode)
+
+	// In WorkerPool mode, don't overwrite an existing entry
+	if entry.DeliveryMode == WorkerPool {
+		if _, exists := s.entries[key]; exists {
+			return nil
+		}
+	}
 
 	// Create a copy to avoid mutation
 	entryCopy := *entry

--- a/monitor/middleware.go
+++ b/monitor/middleware.go
@@ -112,10 +112,25 @@ func NewMiddleware[T any](store Store, opts ...MiddlewareOption) event.Middlewar
 				}
 			}
 
+			// For WorkerPool mode, inject an acquisition signal so the
+			// WorkerPoolMiddleware (which runs after us) can communicate
+			// whether this worker actually acquired the message.
+			var signal *event.AcquisitionSignal
+			if deliveryMode == WorkerPool {
+				signal = &event.AcquisitionSignal{}
+				ctx = event.ContextWithAcquisitionSignal(ctx, signal)
+			}
+
 			// Execute handler
 			start := time.Now()
 			handlerErr := next(ctx, ev, data)
 			duration := time.Since(start)
+
+			// In WorkerPool mode, skip recording if this worker didn't acquire the message.
+			// The winning worker will record the actual result.
+			if signal != nil && signal.Result() == event.AcquisitionSkipped {
+				return handlerErr
+			}
 
 			// Determine final status based on error classification
 			status := StatusCompleted

--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -205,6 +205,11 @@ func (s *MongoStore) EnsureIndexes(ctx context.Context) error {
 }
 
 // Record creates or updates a monitor entry.
+//
+// In WorkerPool mode, fields are written with $setOnInsert so that only the
+// first pod to call Record() (the one most likely to win acquisition) populates
+// the entry. Subsequent pods that lose the worker pool race will not overwrite
+// instance_id, started_at, trace_id, or span_id of the winning pod.
 func (s *MongoStore) Record(ctx context.Context, entry *Entry) error {
 	mongoEntry := fromEntry(entry)
 
@@ -213,29 +218,60 @@ func (s *MongoStore) Record(ctx context.Context, entry *Entry) error {
 		"subscription_id": mongoEntry.SubscriptionID,
 	}
 
-	update := bson.M{
-		"$set": bson.M{
-			"subscriber_name":        mongoEntry.SubscriberName,
-			"subscriber_description": mongoEntry.SubscriberDescription,
-			"event_name":             mongoEntry.EventName,
-			"bus_id":                 mongoEntry.BusID,
-			"instance_id":            mongoEntry.InstanceID,
-			"delivery_mode":          mongoEntry.DeliveryMode,
-			"metadata":               mongoEntry.Metadata,
-			"status":                 mongoEntry.Status,
-			"error":                  mongoEntry.Error,
-			"retry_count":            mongoEntry.RetryCount,
-			"started_at":             mongoEntry.StartedAt,
-			"completed_at":           mongoEntry.CompletedAt,
-			"duration_ms":            mongoEntry.DurationMs,
-			"trace_id":               mongoEntry.TraceID,
-			"span_id":                mongoEntry.SpanID,
-			"worker_group":           mongoEntry.WorkerGroup,
-		},
-		"$setOnInsert": bson.M{
-			"event_id":        mongoEntry.EventID,
-			"subscription_id": mongoEntry.SubscriptionID,
-		},
+	var update bson.M
+
+	if entry.DeliveryMode == WorkerPool {
+		// WorkerPool mode: use $setOnInsert for all fields so only the first
+		// writer populates the entry. This prevents losing pods from overwriting
+		// the winning pod's instance_id, started_at, and trace context.
+		update = bson.M{
+			"$setOnInsert": bson.M{
+				"event_id":               mongoEntry.EventID,
+				"subscription_id":        mongoEntry.SubscriptionID,
+				"subscriber_name":        mongoEntry.SubscriberName,
+				"subscriber_description": mongoEntry.SubscriberDescription,
+				"event_name":             mongoEntry.EventName,
+				"bus_id":                 mongoEntry.BusID,
+				"instance_id":            mongoEntry.InstanceID,
+				"delivery_mode":          mongoEntry.DeliveryMode,
+				"metadata":               mongoEntry.Metadata,
+				"status":                 mongoEntry.Status,
+				"error":                  mongoEntry.Error,
+				"retry_count":            mongoEntry.RetryCount,
+				"started_at":             mongoEntry.StartedAt,
+				"completed_at":           mongoEntry.CompletedAt,
+				"duration_ms":            mongoEntry.DurationMs,
+				"trace_id":               mongoEntry.TraceID,
+				"span_id":                mongoEntry.SpanID,
+				"worker_group":           mongoEntry.WorkerGroup,
+			},
+		}
+	} else {
+		// Broadcast mode: each subscription has its own entry, so $set is safe.
+		update = bson.M{
+			"$set": bson.M{
+				"subscriber_name":        mongoEntry.SubscriberName,
+				"subscriber_description": mongoEntry.SubscriberDescription,
+				"event_name":             mongoEntry.EventName,
+				"bus_id":                 mongoEntry.BusID,
+				"instance_id":            mongoEntry.InstanceID,
+				"delivery_mode":          mongoEntry.DeliveryMode,
+				"metadata":               mongoEntry.Metadata,
+				"status":                 mongoEntry.Status,
+				"error":                  mongoEntry.Error,
+				"retry_count":            mongoEntry.RetryCount,
+				"started_at":             mongoEntry.StartedAt,
+				"completed_at":           mongoEntry.CompletedAt,
+				"duration_ms":            mongoEntry.DurationMs,
+				"trace_id":               mongoEntry.TraceID,
+				"span_id":                mongoEntry.SpanID,
+				"worker_group":           mongoEntry.WorkerGroup,
+			},
+			"$setOnInsert": bson.M{
+				"event_id":        mongoEntry.EventID,
+				"subscription_id": mongoEntry.SubscriptionID,
+			},
+		}
 	}
 
 	opts := options.UpdateOne().SetUpsert(true)

--- a/monitor/postgres.go
+++ b/monitor/postgres.go
@@ -130,6 +130,21 @@ func (s *PostgresStore) Record(ctx context.Context, entry *Entry) error {
 		subscriptionID = ""
 	}
 
+	// In WorkerPool mode, use DO NOTHING so the first writer (the likely winner)
+	// keeps its data. In Broadcast mode, each subscription has its own row so
+	// updating on conflict is safe.
+	var conflictClause string
+	if entry.DeliveryMode == WorkerPool {
+		conflictClause = "ON CONFLICT (event_id, subscription_id) DO NOTHING"
+	} else {
+		conflictClause = `ON CONFLICT (event_id, subscription_id) DO UPDATE SET
+			status = EXCLUDED.status,
+			error = EXCLUDED.error,
+			retry_count = EXCLUDED.retry_count,
+			completed_at = EXCLUDED.completed_at,
+			duration_ms = EXCLUDED.duration_ms`
+	}
+
 	query := fmt.Sprintf(`
 		INSERT INTO %s (
 			event_id, subscription_id, subscriber_name, subscriber_description,
@@ -137,13 +152,8 @@ func (s *PostgresStore) Record(ctx context.Context, entry *Entry) error {
 			metadata, status, error, retry_count, started_at, completed_at,
 			duration_ms, trace_id, span_id, worker_group
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-		ON CONFLICT (event_id, subscription_id) DO UPDATE SET
-			status = EXCLUDED.status,
-			error = EXCLUDED.error,
-			retry_count = EXCLUDED.retry_count,
-			completed_at = EXCLUDED.completed_at,
-			duration_ms = EXCLUDED.duration_ms
-	`, s.opts.tableName)
+		%s
+	`, s.opts.tableName, conflictClause)
 
 	var durationMs *int64
 	if entry.Duration > 0 {


### PR DESCRIPTION
## Summary

- Fixes a race condition where monitor middleware records false "completed" entries for workers that lose the WorkerPool acquisition
- Adds `AcquisitionSignal` — an atomic signal passed via context from monitor middleware to `WorkerPoolMiddleware`, communicating whether this worker acquired the message or was skipped
- Monitor middleware now skips `UpdateStatus` when the signal indicates the message was not acquired by this worker
- Store-level `Record()` protection ensures losing pods cannot overwrite the winning pod's initial entry:
  - MongoDB: `$setOnInsert` for all fields in WorkerPool mode
  - Memory: skip overwrite if entry exists
  - Postgres: `ON CONFLICT DO NOTHING`

## Root Cause

The monitor middleware runs **before** `WorkerPoolMiddleware` in the chain. In WorkerPool mode, all pods share the same composite key `(event_id, "")`. When multiple pods call `Record()` and `UpdateStatus()` on the same key:

1. `Record()` uses `$set` — last writer overwrites `instance_id`, `started_at`, `trace_id`
2. Losing pods' `WorkerPoolMiddleware` returns `nil` (not acquired) — monitor sees this as success
3. `UpdateStatus()` records `status: "completed"` with the losing pod's duration

This produces unreliable monitor entries where instance_id is from one pod, duration from another, and events that were never actually processed show as "completed".

## Test plan

- [x] All 563 existing tests pass across 32 packages
- [ ] Integration test: deploy with multiple pods, verify only the acquiring pod's data appears in monitor entries
- [ ] Verify monitor entries show correct `instance_id` and `duration_ms` from the winning pod