### PR TITLE
ci: add dependabot grouping to combine dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     commit-message:
       prefix: "deps"
     open-pull-requests-limit: 5
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
@@ -15,3 +19,7 @@ updates:
     commit-message:
       prefix: "ci"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add dependency grouping to dependabot config so all Go module updates are combined into a single PR
- Add grouping for GitHub Actions updates as well
- Reduces PR noise from individual patch bumps