### PR TITLE
ci: add build provenance attestation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,3 +35,15 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+
+      - name: Download source archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p dist
+          gh release download "${{ github.ref_name }}" --archive=tar.gz --dir=dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v2
+        with:
+          subject-path: dist/*.tar.gz


### PR DESCRIPTION
## Summary
- Add `id-token: write` and `attestations: write` permissions for OIDC-based attestation
- Download auto-generated source tarball after release creation
- Attest it with `actions/attest-build-provenance@v2` (pinned to SHA)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Create a test release tag to confirm attestation is generated