### PR TITLE
ci: reduce fuzz test frequency to conserve Actions minutes

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,10 +1,9 @@
 name: ClusterFuzzLite Batch
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1' # Monday 06:00 UTC
+    - cron: '0 0 28 * *' # 28th of every month, 00:00 UTC
 
 permissions: read-all
 

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -3,6 +3,11 @@ name: ClusterFuzzLite PR
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '**_test.go'
+      - '**/fuzz_*.go'
+      - '**/testdata/**'
+      - '.github/workflows/cflite_pr.yml'
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

- **Batch fuzz**: remove push-to-main trigger, schedule monthly (28th), add `workflow_dispatch` for manual runs
- **PR fuzz**: only run when test files, fuzz files, or testdata change

Saves ~60 min of Actions minutes per merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)