### PR TITLE
ci: use go-version-file for stable job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.25.8']
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download
@@ -49,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: '1.25.8'
+          go-version-file: go.mod
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9


### PR DESCRIPTION
## Summary
- Remove single-entry matrix strategy from test job
- Use `go-version-file: go.mod` instead of hardcoded version in both test and lint jobs
- Keeps job name as "Test" regardless of Go version, preventing branch protection check mismatches on dependabot version bumps

## Test plan
- [ ] Verify CI passes with `go-version-file: go.mod`
- [ ] Confirm job name appears as "Test" (not "Test (x.y.z)")