### PR TITLE
feat: add metadata-based routing for selective event delivery

### DIFF
--- a/context.go
+++ b/context.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rbaliyan/event/v3/transport"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -174,6 +175,24 @@ func ContextWithMetadata(ctx context.Context, m map[string]string) context.Conte
 		return context.WithValue(ctx, eventcontextKey, &newData)
 	}
 	return context.WithValue(ctx, eventcontextKey, &eventContextData{metadata: m})
+}
+
+// ContextWithRoutingKey adds a routing key to the context metadata.
+// The key is automatically prefixed with X-Route-.
+// Multiple calls accumulate routing keys.
+//
+// Example:
+//
+//	ctx = event.ContextWithRoutingKey(ctx, "region", "us-east")
+//	ctx = event.ContextWithRoutingKey(ctx, "priority", "high")
+//	orderEvent.Publish(ctx, order)
+func ContextWithRoutingKey(ctx context.Context, key, value string) context.Context {
+	meta := ContextMetadata(ctx)
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	meta[transport.RoutingKeyPrefix+key] = value
+	return ContextWithMetadata(ctx, meta)
 }
 
 // ContextWithEventID generate a context with event id

--- a/event.go
+++ b/event.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
@@ -357,6 +358,8 @@ func (e *eventImpl[T]) Subscribe(ctx context.Context, handler Handler[T], opts .
 		WorkerGroup:           subOpts.workerGroup,
 		SubscriberName:        subOpts.subscriberName,
 		SubscriberDescription: subOpts.subscriberDescription,
+		RouteFilters:          maps.Clone(subOpts.routeFilters),
+		HasRouteMatch:         subOpts.routeMatch != nil,
 		StartedAt:             time.Now(),
 	})
 
@@ -509,6 +512,12 @@ func (e *eventImpl[T]) subscribeWithRawCoalesce(
 					continue
 				}
 
+				// Apply route filters.
+				if !matchesSubscriptionRoute(msg.Metadata(), subOpts) {
+					_ = msg.Ack(nil)
+					continue
+				}
+
 				select {
 				case coal.incoming <- rawCoalesceInput{msg: msg}:
 				case <-bus.shutdownChan:
@@ -597,6 +606,12 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 
 				// Apply pre-decode message filter.
 				if e.messageFilter != nil && !e.messageFilter(msg.Metadata()) {
+					_ = msg.Ack(nil)
+					continue
+				}
+
+				// Apply route filters.
+				if !matchesSubscriptionRoute(msg.Metadata(), subOpts) {
 					_ = msg.Ack(nil)
 					continue
 				}
@@ -730,6 +745,12 @@ func (e *eventImpl[T]) processMessage(
 
 	// Apply pre-decode message filter
 	if e.messageFilter != nil && !e.messageFilter(msg.Metadata()) {
+		_ = msg.Ack(nil)
+		return
+	}
+
+	// Apply route filters (transport-agnostic fallback for non-channel transports)
+	if !matchesSubscriptionRoute(msg.Metadata(), subOpts) {
 		_ = msg.Ack(nil)
 		return
 	}

--- a/option.go
+++ b/option.go
@@ -332,6 +332,10 @@ type subscribeOptions[T any] struct {
 	coalesceKeyFunc func(T) string // key from decoded payload (nil = no coalescing)
 	coalesceMetaKey string         // key from message metadata (empty = no coalescing)
 	coalesceMaxKeys int            // max unique keys tracked (0 = defaultCoalesceMaxKeys)
+
+	// routing
+	routeFilters map[string]string            // exact-match route filters (prefixed keys)
+	routeMatch   func(map[string]string) bool // custom route predicate
 }
 
 // SubscribeOption configures subscription behavior
@@ -405,6 +409,14 @@ func (o *subscribeOptions[T]) transportOptions() []transport.SubscribeOption {
 
 	if o.ackPolicy != AckExplicit {
 		opts = append(opts, transport.WithAckPolicy(o.ackPolicy))
+	}
+
+	if len(o.routeFilters) > 0 {
+		opts = append(opts, transport.WithRouteFilters(o.routeFilters))
+	}
+
+	if o.routeMatch != nil {
+		opts = append(opts, transport.WithRouteMatch(o.routeMatch))
 	}
 
 	return opts
@@ -722,6 +734,61 @@ func WithCoalesceMaxKeys[T any](n int) SubscribeOption[T] {
 	return func(o *subscribeOptions[T]) {
 		if n > 0 {
 			o.coalesceMaxKeys = n
+		}
+	}
+}
+
+// WithRouteFilter adds an exact-match routing filter to the subscription.
+// Only messages whose metadata contains X-Route-{key} = value will be delivered.
+// Multiple WithRouteFilter calls use AND semantics: all must match.
+//
+// For the channel transport, filtering happens at dispatch time — non-matching
+// messages never enter the subscriber's buffer. For other transports, the filter
+// is checked after receiving from the transport.
+//
+// Example:
+//
+//	orderEvent.Subscribe(ctx, handler,
+//	    event.WithRouteFilter[Order]("region", "us-east"),
+//	    event.WithRouteFilter[Order]("priority", "high"),
+//	)
+func WithRouteFilter[T any](key, value string) SubscribeOption[T] {
+	return func(o *subscribeOptions[T]) {
+		if o.routeFilters == nil {
+			o.routeFilters = make(map[string]string)
+		}
+		o.routeFilters[transport.RoutingKeyPrefix+key] = value
+	}
+}
+
+// WithRouteMatch adds a custom routing predicate to the subscription.
+// Only messages for which fn returns true will be delivered.
+// This composes with WithRouteFilter (both must pass).
+//
+// Multiple calls compose with AND semantics: all predicates must return true.
+//
+// The function receives the full message metadata map, including routing keys
+// (prefixed with X-Route-) and other metadata like Content-Type.
+//
+// Example:
+//
+//	orderEvent.Subscribe(ctx, handler,
+//	    event.WithRouteMatch[Order](func(meta map[string]string) bool {
+//	        return meta["X-Route-region"] != "eu-west"
+//	    }),
+//	)
+func WithRouteMatch[T any](fn func(map[string]string) bool) SubscribeOption[T] {
+	return func(o *subscribeOptions[T]) {
+		if fn == nil {
+			return
+		}
+		if o.routeMatch == nil {
+			o.routeMatch = fn
+			return
+		}
+		prev := o.routeMatch
+		o.routeMatch = func(meta map[string]string) bool {
+			return prev(meta) && fn(meta)
 		}
 	}
 }

--- a/route.go
+++ b/route.go
@@ -1,0 +1,45 @@
+package event
+
+import (
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// RoutingKeyPrefix is the metadata key prefix for routing keys.
+// Publishers set routing keys via metadata entries like "X-Route-region" = "us-east".
+// Subscribers declare route filters to receive only matching messages.
+const RoutingKeyPrefix = transport.RoutingKeyPrefix
+
+// RoutingKey returns the full metadata key for a routing key name.
+// For example, RoutingKey("region") returns "X-Route-region".
+func RoutingKey(key string) string {
+	return RoutingKeyPrefix + key
+}
+
+// HasRoutingKeys returns true if the metadata contains any routing keys
+// (keys prefixed with X-Route-).
+func HasRoutingKeys(metadata map[string]string) bool {
+	return transport.HasRoutingKeys(metadata)
+}
+
+// MatchesRouteFilters checks whether message metadata satisfies all route filters.
+// This is re-exported from the transport package for use in custom WithRouteMatch predicates.
+func MatchesRouteFilters(metadata, filters map[string]string) bool {
+	return transport.MatchesRouteFilters(metadata, filters)
+}
+
+// matchesSubscriptionRoute checks whether a message satisfies the subscription's
+// route filters and route match predicate. Used as a transport-agnostic fallback
+// in the event layer's subscribe loops — ensures routing works across all transports,
+// not only the channel transport which filters at dispatch time.
+func matchesSubscriptionRoute[T any](metadata map[string]string, subOpts *subscribeOptions[T]) bool {
+	if len(subOpts.routeFilters) == 0 && subOpts.routeMatch == nil {
+		return true
+	}
+	if !transport.MatchesRouteFilters(metadata, subOpts.routeFilters) {
+		return false
+	}
+	if subOpts.routeMatch != nil && !subOpts.routeMatch(metadata) {
+		return false
+	}
+	return true
+}

--- a/route_test.go
+++ b/route_test.go
@@ -1,0 +1,143 @@
+package event
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+func TestRoutingKey(t *testing.T) {
+	got := RoutingKey("region")
+	want := "X-Route-region"
+	if got != want {
+		t.Errorf("RoutingKey(\"region\") = %q, want %q", got, want)
+	}
+}
+
+func TestHasRoutingKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     bool
+	}{
+		{"nil metadata", nil, false},
+		{"empty metadata", map[string]string{}, false},
+		{"no routing keys", map[string]string{"Content-Type": "application/json"}, false},
+		{"has routing key", map[string]string{"X-Route-region": "us-east"}, true},
+		{"mixed keys", map[string]string{"Content-Type": "json", "X-Route-priority": "high"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasRoutingKeys(tt.metadata)
+			if got != tt.want {
+				t.Errorf("HasRoutingKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesRouteFilters(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		filters  map[string]string
+		want     bool
+	}{
+		{"nil filters", map[string]string{"X-Route-region": "us-east"}, nil, true},
+		{"empty filters", map[string]string{"X-Route-region": "us-east"}, map[string]string{}, true},
+		{"exact match", map[string]string{"X-Route-region": "us-east"}, map[string]string{"X-Route-region": "us-east"}, true},
+		{"value mismatch", map[string]string{"X-Route-region": "eu-west"}, map[string]string{"X-Route-region": "us-east"}, false},
+		{"key missing", map[string]string{}, map[string]string{"X-Route-region": "us-east"}, false},
+		{"nil metadata", nil, map[string]string{"X-Route-region": "us-east"}, false},
+		{"multiple filters all match", map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}, map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}, true},
+		{"multiple filters partial match", map[string]string{"X-Route-region": "us-east"}, map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}, false},
+		{"extra metadata keys ok", map[string]string{"X-Route-region": "us-east", "Content-Type": "json"}, map[string]string{"X-Route-region": "us-east"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := transport.MatchesRouteFilters(tt.metadata, tt.filters)
+			if got != tt.want {
+				t.Errorf("MatchesRouteFilters() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContextWithRoutingKey(t *testing.T) {
+	ctx := context.Background()
+
+	// Add a routing key
+	ctx = ContextWithRoutingKey(ctx, "region", "us-east")
+	meta := ContextMetadata(ctx)
+
+	if meta == nil {
+		t.Fatal("expected metadata, got nil")
+	}
+	if v := meta["X-Route-region"]; v != "us-east" {
+		t.Errorf("expected X-Route-region=us-east, got %q", v)
+	}
+
+	// Add another routing key — should accumulate
+	ctx = ContextWithRoutingKey(ctx, "priority", "high")
+	meta = ContextMetadata(ctx)
+
+	if v := meta["X-Route-region"]; v != "us-east" {
+		t.Errorf("expected X-Route-region=us-east after second key, got %q", v)
+	}
+	if v := meta["X-Route-priority"]; v != "high" {
+		t.Errorf("expected X-Route-priority=high, got %q", v)
+	}
+}
+
+func TestContextWithRoutingKey_OverwriteExisting(t *testing.T) {
+	ctx := context.Background()
+	ctx = ContextWithRoutingKey(ctx, "region", "us-east")
+	ctx = ContextWithRoutingKey(ctx, "region", "eu-west")
+
+	meta := ContextMetadata(ctx)
+	if v := meta["X-Route-region"]; v != "eu-west" {
+		t.Errorf("expected overwritten value eu-west, got %q", v)
+	}
+}
+
+func TestMatchesRouteFilters_Reexport(t *testing.T) {
+	// Verify the re-exported function works identically
+	meta := map[string]string{"X-Route-region": "us-east"}
+	if !MatchesRouteFilters(meta, map[string]string{"X-Route-region": "us-east"}) {
+		t.Error("expected match")
+	}
+	if MatchesRouteFilters(meta, map[string]string{"X-Route-region": "eu-west"}) {
+		t.Error("expected no match")
+	}
+}
+
+func TestWithRouteMatch_Composition(t *testing.T) {
+	// Two predicates composed with AND semantics
+	var opts []SubscribeOption[string]
+	opts = append(opts,
+		WithRouteMatch[string](func(meta map[string]string) bool {
+			return meta["X-Route-region"] == "us-east"
+		}),
+		WithRouteMatch[string](func(meta map[string]string) bool {
+			return meta["X-Route-priority"] == "high"
+		}),
+	)
+
+	subOpts := newSubscribeOptions(opts...)
+
+	// Both match
+	if !subOpts.routeMatch(map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}) {
+		t.Error("expected match when both predicates satisfied")
+	}
+	// First fails
+	if subOpts.routeMatch(map[string]string{"X-Route-region": "eu-west", "X-Route-priority": "high"}) {
+		t.Error("expected no match when first predicate fails")
+	}
+	// Second fails
+	if subOpts.routeMatch(map[string]string{"X-Route-region": "us-east", "X-Route-priority": "low"}) {
+		t.Error("expected no match when second predicate fails")
+	}
+}

--- a/topology.go
+++ b/topology.go
@@ -11,12 +11,14 @@ import (
 
 // SubscriptionInfo describes a live subscription on an event.
 type SubscriptionInfo struct {
-	SubscriptionID        string       `json:"subscription_id"`
-	DeliveryMode          DeliveryMode `json:"delivery_mode"`
-	WorkerGroup           string       `json:"worker_group,omitempty"`
-	SubscriberName        string       `json:"subscriber_name,omitempty"`
-	SubscriberDescription string       `json:"subscriber_description,omitempty"`
-	StartedAt             time.Time    `json:"started_at"`
+	SubscriptionID        string            `json:"subscription_id"`
+	DeliveryMode          DeliveryMode      `json:"delivery_mode"`
+	WorkerGroup           string            `json:"worker_group,omitempty"`
+	SubscriberName        string            `json:"subscriber_name,omitempty"`
+	SubscriberDescription string            `json:"subscriber_description,omitempty"`
+	RouteFilters          map[string]string `json:"route_filters,omitempty"`
+	HasRouteMatch         bool              `json:"has_route_match,omitempty"`
+	StartedAt             time.Time         `json:"started_at"`
 }
 
 // EventInfo describes a registered event and its active subscriptions.

--- a/transport/channel/channel.go
+++ b/transport/channel/channel.go
@@ -57,10 +57,26 @@ type eventChannel struct {
 
 // subscription implements transport.Subscription
 type subscription struct {
-	*base.Subscription                        // Embedded base subscription
-	ev                 *eventChannel          // Parent event channel
-	mode               transport.DeliveryMode // Delivery mode
-	workerGroup        string                 // Worker group name for WorkerPool mode
+	*base.Subscription                              // Embedded base subscription
+	ev                 *eventChannel                // Parent event channel
+	mode               transport.DeliveryMode       // Delivery mode
+	workerGroup        string                       // Worker group name for WorkerPool mode
+	routeFilters       map[string]string            // Exact-match routing filters
+	routeMatch         func(map[string]string) bool // Custom routing predicate
+}
+
+// matchesRoute checks if a message's metadata satisfies this subscription's route filters.
+func (s *subscription) matchesRoute(metadata map[string]string) bool {
+	if len(s.routeFilters) == 0 && s.routeMatch == nil {
+		return true
+	}
+	if !transport.MatchesRouteFilters(metadata, s.routeFilters) {
+		return false
+	}
+	if s.routeMatch != nil && !s.routeMatch(metadata) {
+		return false
+	}
+	return true
 }
 
 func (s *subscription) Close(ctx context.Context) error {
@@ -181,15 +197,17 @@ func (t *Transport) Publish(ctx context.Context, name string, msg transport.Mess
 	var broadcastSubs []*subscription
 	workerGroups := make(map[string][]*subscription) // group name -> subscribers
 
+	msgMeta := msg.Metadata()
 	ec.subscribers.Range(func(key, value any) bool {
 		sub := value.(*subscription)
-		if !sub.IsClosed() {
-			if sub.mode == transport.WorkerPool {
-				// Group by worker group name (empty string = default group)
-				workerGroups[sub.workerGroup] = append(workerGroups[sub.workerGroup], sub)
-			} else {
-				broadcastSubs = append(broadcastSubs, sub)
-			}
+		if sub.IsClosed() || !sub.matchesRoute(msgMeta) {
+			return true
+		}
+		if sub.mode == transport.WorkerPool {
+			// Group by worker group name (empty string = default group)
+			workerGroups[sub.workerGroup] = append(workerGroups[sub.workerGroup], sub)
+		} else {
+			broadcastSubs = append(broadcastSubs, sub)
 		}
 		return true
 	})
@@ -353,6 +371,8 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 		ev:           ec,
 		mode:         subOpts.DeliveryMode,
 		workerGroup:  subOpts.WorkerGroup,
+		routeFilters: subOpts.RouteFilters,
+		routeMatch:   subOpts.RouteMatch,
 	}
 
 	ec.subscribers.Store(sub.ID(), sub)

--- a/transport/channel/route_test.go
+++ b/transport/channel/route_test.go
@@ -1,0 +1,299 @@
+package channel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+	"github.com/rbaliyan/event/v3/transport/message"
+)
+
+func testMessageWithMeta(id, payload string, metadata map[string]string) transport.Message {
+	return message.New(id, "test", []byte(payload), metadata)
+}
+
+func TestRouteFilter_BroadcastExactMatch(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "orders")
+
+	// Subscriber with route filter: only us-east
+	filtered, _ := tr.Subscribe(ctx, "orders",
+		transport.WithRouteFilters(map[string]string{"X-Route-region": "us-east"}),
+	)
+	defer filtered.Close(ctx)
+
+	// Subscriber without filter: receives all
+	unfiltered, _ := tr.Subscribe(ctx, "orders")
+	defer unfiltered.Close(ctx)
+
+	// Publish message with matching routing key
+	msg := testMessageWithMeta("1", "order1", map[string]string{"X-Route-region": "us-east"})
+	if err := tr.Publish(ctx, "orders", msg); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	// Both should receive
+	select {
+	case <-filtered.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("filtered subscriber should have received matching message")
+	}
+	select {
+	case <-unfiltered.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("unfiltered subscriber should have received message")
+	}
+
+	// Publish message with non-matching routing key
+	msg2 := testMessageWithMeta("2", "order2", map[string]string{"X-Route-region": "eu-west"})
+	if err := tr.Publish(ctx, "orders", msg2); err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+
+	// Only unfiltered should receive
+	select {
+	case <-unfiltered.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("unfiltered subscriber should have received message")
+	}
+	select {
+	case <-filtered.Messages():
+		t.Fatal("filtered subscriber should NOT have received non-matching message")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: filtered subscriber does not receive
+	}
+}
+
+func TestRouteFilter_MultipleKeys(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "orders")
+
+	// Subscriber requires both region AND priority
+	sub, _ := tr.Subscribe(ctx, "orders",
+		transport.WithRouteFilters(map[string]string{
+			"X-Route-region":   "us-east",
+			"X-Route-priority": "high",
+		}),
+	)
+	defer sub.Close(ctx)
+
+	// Message with only region — should NOT match
+	msg1 := testMessageWithMeta("1", "data", map[string]string{"X-Route-region": "us-east"})
+	tr.Publish(ctx, "orders", msg1)
+
+	select {
+	case <-sub.Messages():
+		t.Fatal("should not receive message with only partial routing keys")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Message with both keys — should match
+	msg2 := testMessageWithMeta("2", "data", map[string]string{
+		"X-Route-region":   "us-east",
+		"X-Route-priority": "high",
+	})
+	tr.Publish(ctx, "orders", msg2)
+
+	select {
+	case <-sub.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("should have received message matching all routing keys")
+	}
+}
+
+func TestRouteFilter_NoFilter(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "orders")
+
+	sub, _ := tr.Subscribe(ctx, "orders")
+	defer sub.Close(ctx)
+
+	// Message with routing keys — unfiltered subscriber should still receive
+	msg := testMessageWithMeta("1", "data", map[string]string{"X-Route-region": "us-east"})
+	tr.Publish(ctx, "orders", msg)
+
+	select {
+	case <-sub.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("unfiltered subscriber should receive all messages")
+	}
+
+	// Message without routing keys
+	msg2 := testMessageWithMeta("2", "data", nil)
+	tr.Publish(ctx, "orders", msg2)
+
+	select {
+	case <-sub.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("unfiltered subscriber should receive messages without routing keys")
+	}
+}
+
+func TestRouteFilter_WorkerPool(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "tasks")
+
+	// Two workers with same route filter
+	w1, _ := tr.Subscribe(ctx, "tasks",
+		transport.WithDeliveryMode(transport.WorkerPool),
+		transport.WithRouteFilters(map[string]string{"X-Route-region": "us-east"}),
+	)
+	defer w1.Close(ctx)
+
+	w2, _ := tr.Subscribe(ctx, "tasks",
+		transport.WithDeliveryMode(transport.WorkerPool),
+		transport.WithRouteFilters(map[string]string{"X-Route-region": "us-east"}),
+	)
+	defer w2.Close(ctx)
+
+	// Publish matching message — only ONE worker should receive (round-robin)
+	msg := testMessageWithMeta("1", "task", map[string]string{"X-Route-region": "us-east"})
+	tr.Publish(ctx, "tasks", msg)
+
+	received := 0
+	for i := 0; i < 2; i++ {
+		select {
+		case <-w1.Messages():
+			received++
+		case <-w2.Messages():
+			received++
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	if received != 1 {
+		t.Fatalf("expected exactly 1 worker to receive, got %d", received)
+	}
+
+	// Publish non-matching message — neither should receive
+	msg2 := testMessageWithMeta("2", "task", map[string]string{"X-Route-region": "eu-west"})
+	tr.Publish(ctx, "tasks", msg2)
+
+	select {
+	case <-w1.Messages():
+		t.Fatal("worker should not receive non-matching message")
+	case <-w2.Messages():
+		t.Fatal("worker should not receive non-matching message")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestRouteFilter_WorkerGroup(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "orders")
+
+	// Group A: filters for us-east
+	ga, _ := tr.Subscribe(ctx, "orders",
+		transport.WithDeliveryMode(transport.WorkerPool),
+		transport.WithWorkerGroup("group-a"),
+		transport.WithRouteFilters(map[string]string{"X-Route-region": "us-east"}),
+	)
+	defer ga.Close(ctx)
+
+	// Group B: filters for eu-west
+	gb, _ := tr.Subscribe(ctx, "orders",
+		transport.WithDeliveryMode(transport.WorkerPool),
+		transport.WithWorkerGroup("group-b"),
+		transport.WithRouteFilters(map[string]string{"X-Route-region": "eu-west"}),
+	)
+	defer gb.Close(ctx)
+
+	// Publish us-east message — only group A should receive
+	msg := testMessageWithMeta("1", "data", map[string]string{"X-Route-region": "us-east"})
+	tr.Publish(ctx, "orders", msg)
+
+	select {
+	case <-ga.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("group-a should receive us-east message")
+	}
+	select {
+	case <-gb.Messages():
+		t.Fatal("group-b should NOT receive us-east message")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestRouteFilter_CustomPredicate(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "orders")
+
+	// Custom predicate: exclude eu-west
+	sub, _ := tr.Subscribe(ctx, "orders",
+		transport.WithRouteMatch(func(meta map[string]string) bool {
+			return meta["X-Route-region"] != "eu-west"
+		}),
+	)
+	defer sub.Close(ctx)
+
+	// us-east should be received
+	msg1 := testMessageWithMeta("1", "data", map[string]string{"X-Route-region": "us-east"})
+	tr.Publish(ctx, "orders", msg1)
+
+	select {
+	case <-sub.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("should receive us-east message")
+	}
+
+	// eu-west should be filtered
+	msg2 := testMessageWithMeta("2", "data", map[string]string{"X-Route-region": "eu-west"})
+	tr.Publish(ctx, "orders", msg2)
+
+	select {
+	case <-sub.Messages():
+		t.Fatal("should NOT receive eu-west message")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestRouteFilter_NoRoutingKeys(t *testing.T) {
+	ctx := context.Background()
+	tr := New(WithBufferSize(10))
+	defer tr.Close(ctx)
+
+	tr.RegisterEvent(ctx, "orders")
+
+	// Subscriber with route filter
+	filtered, _ := tr.Subscribe(ctx, "orders",
+		transport.WithRouteFilters(map[string]string{"X-Route-region": "us-east"}),
+	)
+	defer filtered.Close(ctx)
+
+	// Subscriber without filter
+	unfiltered, _ := tr.Subscribe(ctx, "orders")
+	defer unfiltered.Close(ctx)
+
+	// Message without any routing keys — filtered subscriber should NOT receive
+	msg := testMessageWithMeta("1", "data", nil)
+	tr.Publish(ctx, "orders", msg)
+
+	select {
+	case <-unfiltered.Messages():
+	case <-time.After(time.Second):
+		t.Fatal("unfiltered subscriber should receive message")
+	}
+	select {
+	case <-filtered.Messages():
+		t.Fatal("filtered subscriber should NOT receive message without routing keys")
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -67,6 +68,39 @@ func NewDecodeErrorMessage(msgID string, rawData []byte, err error, ackFn func(e
 		MetadataDecodeError: err.Error(),
 	}
 	return NewMessageWithAck(msgID, "", rawData, metadata, 0, ackFn)
+}
+
+// RoutingKeyPrefix is the metadata key prefix for routing keys.
+// Publishers set routing keys via metadata entries like "X-Route-region" = "us-east".
+// Subscribers declare route filters to receive only matching messages.
+const RoutingKeyPrefix = "X-Route-"
+
+// HasRoutingKeys returns true if the metadata contains any routing keys.
+func HasRoutingKeys(metadata map[string]string) bool {
+	for k := range metadata {
+		if strings.HasPrefix(k, RoutingKeyPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesRouteFilters checks whether message metadata satisfies all route filters.
+// Returns true if:
+//   - filters is nil or empty (no filtering)
+//   - all filter key-value pairs exist and match in metadata
+//
+// Returns false if any filter key is missing or has a different value.
+func MatchesRouteFilters(metadata, filters map[string]string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+	for k, v := range filters {
+		if metadata[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // HealthStatus represents the health state of a component
@@ -212,6 +246,16 @@ type SubscribeOptions struct {
 	// Set to AckOnReceive for best-effort delivery where handler errors
 	// are logged but never cause redelivery.
 	AckPolicy AckPolicy
+
+	// RouteFilters specifies exact-match filters on message metadata routing keys.
+	// Keys should include the X-Route- prefix. All filters must match (AND semantics).
+	// Nil or empty means no filtering (accept all messages).
+	RouteFilters map[string]string
+
+	// RouteMatch is a custom predicate for routing decisions.
+	// Called with message metadata. Return true to accept, false to skip.
+	// Nil means no custom filtering. Composes with RouteFilters (both must pass).
+	RouteMatch func(map[string]string) bool
 }
 
 // SubscribeOption is a functional option for configuring subscriptions
@@ -338,6 +382,40 @@ func WithConsumerID(id string) SubscribeOption {
 func WithAckPolicy(policy AckPolicy) SubscribeOption {
 	return func(o *SubscribeOptions) {
 		o.AckPolicy = policy
+	}
+}
+
+// WithRouteFilters sets exact-match routing filters for the subscription.
+// Only messages whose metadata contains all specified key-value pairs will be delivered.
+// Keys should include the X-Route- prefix.
+//
+// Example:
+//
+//	sub, err := transport.Subscribe(ctx, "orders",
+//	    transport.WithRouteFilters(map[string]string{"X-Route-region": "us-east"}))
+func WithRouteFilters(filters map[string]string) SubscribeOption {
+	return func(o *SubscribeOptions) {
+		o.RouteFilters = filters
+	}
+}
+
+// WithRouteMatch sets a custom routing predicate for the subscription.
+// Only messages for which fn returns true will be delivered.
+// This composes with RouteFilters (both must pass).
+// Multiple calls compose with AND semantics: all predicates must return true.
+func WithRouteMatch(fn func(map[string]string) bool) SubscribeOption {
+	return func(o *SubscribeOptions) {
+		if fn == nil {
+			return
+		}
+		if o.RouteMatch == nil {
+			o.RouteMatch = fn
+			return
+		}
+		prev := o.RouteMatch
+		o.RouteMatch = func(meta map[string]string) bool {
+			return prev(meta) && fn(meta)
+		}
 	}
 }
 

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1,0 +1,100 @@
+package transport
+
+import "testing"
+
+func TestMatchesRouteFilters(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		filters  map[string]string
+		want     bool
+	}{
+		{"nil filters", map[string]string{"X-Route-region": "us-east"}, nil, true},
+		{"empty filters", map[string]string{}, map[string]string{}, true},
+		{"exact match", map[string]string{"X-Route-region": "us-east"}, map[string]string{"X-Route-region": "us-east"}, true},
+		{"value mismatch", map[string]string{"X-Route-region": "eu-west"}, map[string]string{"X-Route-region": "us-east"}, false},
+		{"key missing from metadata", map[string]string{}, map[string]string{"X-Route-region": "us-east"}, false},
+		{"nil metadata with filters", nil, map[string]string{"X-Route-region": "us-east"}, false},
+		{"nil metadata nil filters", nil, nil, true},
+		{"multiple filters all match", map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}, map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}, true},
+		{"multiple filters partial match", map[string]string{"X-Route-region": "us-east"}, map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}, false},
+		{"extra metadata ignored", map[string]string{"X-Route-region": "us-east", "Content-Type": "json"}, map[string]string{"X-Route-region": "us-east"}, true},
+		{"empty string value matches", map[string]string{"X-Route-tag": ""}, map[string]string{"X-Route-tag": ""}, true},
+		{"empty string vs missing", map[string]string{}, map[string]string{"X-Route-tag": ""}, true}, // Go map returns "" for missing key, which matches ""
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchesRouteFilters(tt.metadata, tt.filters)
+			if got != tt.want {
+				t.Errorf("MatchesRouteFilters() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasRoutingKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[string]string{}, false},
+		{"no routing keys", map[string]string{"Content-Type": "json"}, false},
+		{"has routing key", map[string]string{"X-Route-region": "us-east"}, true},
+		{"prefix only key", map[string]string{"X-Route-": ""}, true},
+		{"similar but wrong prefix", map[string]string{"X-Routeregion": "us-east"}, false},
+		{"mixed", map[string]string{"foo": "bar", "X-Route-x": "y"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasRoutingKeys(tt.metadata)
+			if got != tt.want {
+				t.Errorf("HasRoutingKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithRouteMatch_Composition(t *testing.T) {
+	opts := DefaultSubscribeOptions()
+
+	// First predicate: region must be us-east
+	WithRouteMatch(func(meta map[string]string) bool {
+		return meta["X-Route-region"] == "us-east"
+	})(opts)
+
+	// Second predicate: priority must be high (should AND with first)
+	WithRouteMatch(func(meta map[string]string) bool {
+		return meta["X-Route-priority"] == "high"
+	})(opts)
+
+	// Both match
+	if !opts.RouteMatch(map[string]string{"X-Route-region": "us-east", "X-Route-priority": "high"}) {
+		t.Error("expected match when both predicates satisfied")
+	}
+
+	// First fails
+	if opts.RouteMatch(map[string]string{"X-Route-region": "eu-west", "X-Route-priority": "high"}) {
+		t.Error("expected no match when first predicate fails")
+	}
+
+	// Second fails
+	if opts.RouteMatch(map[string]string{"X-Route-region": "us-east", "X-Route-priority": "low"}) {
+		t.Error("expected no match when second predicate fails")
+	}
+}
+
+func TestWithRouteFilters(t *testing.T) {
+	opts := DefaultSubscribeOptions()
+	WithRouteFilters(map[string]string{"X-Route-region": "us-east"})(opts)
+
+	if len(opts.RouteFilters) != 1 {
+		t.Fatalf("expected 1 filter, got %d", len(opts.RouteFilters))
+	}
+	if opts.RouteFilters["X-Route-region"] != "us-east" {
+		t.Errorf("expected us-east, got %s", opts.RouteFilters["X-Route-region"])
+	}
+}


### PR DESCRIPTION
## Summary
- Add publisher-side routing keys via `ContextWithRoutingKey(ctx, key, value)` using `X-Route-` metadata prefix
- Add subscriber-side route filters: `WithRouteFilter[T](key, value)` for exact match and `WithRouteMatch[T](fn)` for custom predicates
- Channel transport filters at dispatch time (before sending to subscriber buffer) for efficiency
- Event-layer fallback in all subscribe loops ensures routing works across all transports (Redis, NATS, Kafka)
- `WithRouteMatch` composes with AND semantics across multiple calls
- Topology reports route filters via `SubscriptionInfo`

## Test plan
- [x] `TestRouteFilter_BroadcastExactMatch` — filtered subscriber only receives matching messages
- [x] `TestRouteFilter_MultipleKeys` — AND semantics for multiple route filters
- [x] `TestRouteFilter_NoFilter` — unfiltered subscribers receive all messages
- [x] `TestRouteFilter_WorkerPool` — route filtering composes with worker round-robin
- [x] `TestRouteFilter_WorkerGroup` — different filters across worker groups
- [x] `TestRouteFilter_CustomPredicate` — `WithRouteMatch` custom function
- [x] `TestRouteFilter_NoRoutingKeys` — messages without routing keys skip filtered subscribers
- [x] `TestMatchesRouteFilters` — transport-level primitive edge cases
- [x] `TestWithRouteMatch_Composition` — AND composition of multiple predicates
- [x] `TestContextWithRoutingKey` — publisher context round-trip
- [x] Full test suite passes (`go test ./...` — 35 packages)
- [x] `go vet ./...` clean