### PR TITLE
docs: fix remaining README inaccuracies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Bus-level outbox support for atomic database writes with event publishing:
 
 **Configuration:**
 ```go
-store := outbox.NewMongoStore(db)
+store, _ := outbox.NewMongoStore(db)
 bus, _ := event.NewBus("mybus",
     event.WithTransport(transport),
     event.WithOutbox(store),  // Enables outbox routing

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -104,6 +104,7 @@ All store implementations follow the same interface patterns:
 | Monitor | Yes | Yes | No | Yes |
 | Schema | Yes | Yes | Yes | Yes |
 | Idempotency | Yes | Yes | Yes | Yes |
+| Poison | Yes | No | Yes | Yes |
 
 ## Middleware Chain Order
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ func main() {
     nc, _ := natsgo.Connect("nats://localhost:4222")
 
     transport, _ := nats.NewJetStream(nc,
-        nats.WithStreamName("ORDERS"),
         nats.WithDeduplication(time.Hour),
         nats.WithMaxDeliver(5),
         nats.WithAckWait(30*time.Second),
@@ -486,7 +485,7 @@ Prevent duplicate message processing:
 ```go
 import "github.com/rbaliyan/event/v3/idempotency"
 
-store := idempotency.NewRedisStore(redisClient, time.Hour)
+store, _ := idempotency.NewRedisStore(redisClient, time.Hour)
 
 bus, _ := event.NewBus("order-service",
     event.WithTransport(transport),
@@ -506,7 +505,7 @@ Auto-quarantine messages that keep failing:
 ```go
 import "github.com/rbaliyan/event/v3/poison"
 
-store := poison.NewRedisStore(redisClient)
+store, _ := poison.NewRedisStore(redisClient)
 detector := poison.NewDetector(store,
     poison.WithThreshold(5),
     poison.WithQuarantineTime(time.Hour),
@@ -531,7 +530,7 @@ Track event processing status, duration, and errors:
 ```go
 import "github.com/rbaliyan/event/v3/monitor"
 
-store := monitor.NewPostgresStore(db)
+store, _ := monitor.NewPostgresStore(db)
 
 bus, _ := event.NewBus("order-service",
     event.WithTransport(transport),
@@ -539,13 +538,13 @@ bus, _ := event.NewBus("order-service",
 )
 
 // Query monitoring data
-entries, _ := store.List(ctx, monitor.Filter{
+page, _ := store.List(ctx, monitor.Filter{
     Status:    []monitor.Status{monitor.StatusFailed},
     StartTime: time.Now().Add(-time.Hour),
     Limit:     100,
 })
 
-for _, entry := range entries {
+for _, entry := range page.Entries {
     fmt.Printf("Event %s: %s (duration: %v)\n",
         entry.EventID, entry.Status, entry.Duration)
 }
@@ -587,7 +586,7 @@ Define event configuration centrally:
 ```go
 import "github.com/rbaliyan/event/v3/schema"
 
-provider := schema.NewPostgresProvider(db, nil)
+provider, _ := schema.NewPostgresProvider(db, nil)
 defer provider.Close()
 
 bus, _ := event.NewBus("order-service",
@@ -634,7 +633,7 @@ orderEvent.Subscribe(ctx, func(ctx context.Context, e event.Event[Order], order 
         return event.ErrReject // ACK + send to DLQ
 
     default:
-        return event.ErrDefer.Wrap(err) // Default: retry with backoff
+        return event.Defer(err) // Default: retry with backoff
     }
 })
 ```
@@ -741,8 +740,8 @@ if err := orderSaga.Execute(ctx, sagaID, order); err != nil {
 | Component | PostgreSQL | MongoDB | Redis | In-Memory |
 |-----------|:----------:|:-------:|:-----:|:---------:|
 | Outbox | ✅ | ✅ | ✅ | - |
-| Idempotency | ✅ | - | ✅ | ✅ |
-| Poison | ✅ | - | ✅ | - |
+| Idempotency | ✅ | ✅ | ✅ | ✅ |
+| Poison | ✅ | - | ✅ | ✅ |
 | Monitor | ✅ | ✅ | - | ✅ |
 | Schema Registry | ✅ | ✅ | ✅ | ✅ |
 | DLQ | ✅ | ✅ | ✅ | ✅ |
@@ -774,8 +773,8 @@ func TestOrderHandler(t *testing.T) {
         t.Error("handler not called")
     }
 
-    orders := handler.Received()
-    if orders[0].ID != "test" {
+    calls := handler.Received()
+    if calls[0].Data.ID != "test" {
         t.Error("wrong order ID")
     }
 }

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ The `distributed` package enables WorkerPool semantics on Broadcast-only transpo
 import "github.com/rbaliyan/event/v3/distributed"
 
 // Create a coordinator (Redis for distributed deployments)
-coord := distributed.NewRedisStateManager(redisClient,
+coord, _ := distributed.NewRedisStateManager(redisClient,
     distributed.WithCompletedTTL(48*time.Hour),
 )
 
@@ -377,10 +377,10 @@ mongoEvent.Subscribe(ctx, handler,
 For transports without re-delivery (e.g., MongoDB Change Streams), the middleware automatically stores message payload so the RecoveryRunner can re-publish stale events if a worker crashes:
 
 ```go
-coord := distributed.NewMongoStateManager(db)
+coord, _ := distributed.NewMongoStateManager(db)
 
 // RecoveryRunner detects PayloadStore capability automatically
-runner := distributed.NewRecoveryRunner(coord,
+runner, _ := distributed.NewRecoveryRunner(coord,
     distributed.WithPublisher(bus),     // enables re-publishing
     distributed.WithStaleTimeout(2*time.Minute),
     distributed.WithCheckInterval(30*time.Second),
@@ -398,8 +398,8 @@ Recovery is two-phase:
 Use separate coordinators with different prefixes per group:
 
 ```go
-smA := distributed.NewRedisStateManager(redis, distributed.WithPrefix("processors:"))
-smB := distributed.NewRedisStateManager(redis, distributed.WithPrefix("analytics:"))
+smA, _ := distributed.NewRedisStateManager(redis, distributed.WithPrefix("processors:"))
+smB, _ := distributed.NewRedisStateManager(redis, distributed.WithPrefix("analytics:"))
 
 orderEvent.Subscribe(ctx, processOrder,
     event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smA, ttl)))
@@ -449,7 +449,7 @@ import (
 func main() {
     ctx := context.Background()
 
-    store := outbox.NewMongoStore(mongoClient.Database("myapp"))
+    store, _ := outbox.NewMongoStore(mongoClient.Database("myapp"))
 
     bus, _ := event.NewBus("order-service",
         event.WithTransport(transport),


### PR DESCRIPTION
## Summary
Fixes 7 remaining documentation issues found in follow-up review:

- Remove nonexistent `nats.WithStreamName` from NATS example
- Fix `event.ErrDefer.Wrap(err)` to `event.Defer(err)` (`.Wrap()` doesn't exist)
- Fix `monitor.List()` example: returns `*Page`, iterate `page.Entries`
- Fix `monitor.NewPostgresStore(db)` to include error return
- Fix database support table: add MongoDB for idempotency, in-memory for poison
- Fix testing example: `handler.Received()` returns `[]TestHandlerCall[T]`, use `.Data.ID`
- Fix missing error returns on `idempotency.NewRedisStore`, `poison.NewRedisStore`, `schema.NewPostgresProvider`
- Add poison row to COMPATIBILITY.md store table

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all 35 packages pass
- [x] `go vet ./...` — clean