### PR TITLE
feat: add circuit breaker for transport Publish calls

### DIFF
--- a/transport/circuit_breaker.go
+++ b/transport/circuit_breaker.go
@@ -1,0 +1,134 @@
+package transport
+
+import (
+	"errors"
+	"sync/atomic"
+	"time"
+)
+
+// ErrCircuitOpen is returned when the circuit breaker is open and rejecting calls.
+var ErrCircuitOpen = errors.New("circuit breaker is open")
+
+// Circuit breaker states.
+const (
+	cbClosed   int32 = 0
+	cbOpen     int32 = 1
+	cbHalfOpen int32 = 2
+)
+
+// CircuitBreaker implements a thread-safe circuit breaker using atomic operations.
+// It transitions through three states: Closed → Open → Half-Open.
+//
+// When disabled (zero value or nil), all methods are no-ops with zero overhead.
+type CircuitBreaker struct {
+	enabled   bool
+	threshold int32
+	cooldown  time.Duration
+
+	state    atomic.Int32
+	failures atomic.Int32
+	openedAt atomic.Int64 // UnixNano when breaker opened
+	probing  atomic.Int32 // CAS gate: 1 if a half-open probe is in-flight
+}
+
+// NewCircuitBreaker creates a circuit breaker that opens after threshold consecutive
+// failures and transitions to half-open after cooldown elapses.
+// Returns nil if threshold <= 0.
+func NewCircuitBreaker(threshold int, cooldown time.Duration) *CircuitBreaker {
+	if threshold <= 0 {
+		return nil
+	}
+	return &CircuitBreaker{
+		enabled:   true,
+		threshold: int32(threshold),
+		cooldown:  cooldown,
+	}
+}
+
+// Allow checks whether a call is permitted. Returns nil if allowed,
+// ErrCircuitOpen if the breaker is open and rejecting calls.
+func (cb *CircuitBreaker) Allow() error {
+	if cb == nil || !cb.enabled {
+		return nil
+	}
+
+	switch cb.state.Load() {
+	case cbClosed:
+		return nil
+
+	case cbOpen:
+		// Check if cooldown has elapsed
+		opened := cb.openedAt.Load()
+		if time.Since(time.Unix(0, opened)) < cb.cooldown {
+			return ErrCircuitOpen
+		}
+		// Cooldown elapsed — try to become the probe caller
+		if !cb.probing.CompareAndSwap(0, 1) {
+			return ErrCircuitOpen
+		}
+		cb.state.Store(cbHalfOpen)
+		return nil
+
+	case cbHalfOpen:
+		// Only the probe caller is allowed through
+		return ErrCircuitOpen
+	}
+
+	return nil
+}
+
+// RecordSuccess records a successful call. Resets failures and closes the breaker
+// if it was in half-open state.
+func (cb *CircuitBreaker) RecordSuccess() {
+	if cb == nil || !cb.enabled {
+		return
+	}
+	cb.failures.Store(0)
+	if cb.state.CompareAndSwap(cbHalfOpen, cbClosed) {
+		cb.probing.Store(0)
+	}
+}
+
+// RecordFailure records a failed call. If consecutive failures reach the threshold,
+// the breaker opens. If the breaker was in half-open state, it re-opens.
+func (cb *CircuitBreaker) RecordFailure() {
+	if cb == nil || !cb.enabled {
+		return
+	}
+
+	// Half-open probe failed — re-open immediately
+	if cb.state.CompareAndSwap(cbHalfOpen, cbOpen) {
+		cb.openedAt.Store(time.Now().UnixNano())
+		cb.failures.Store(0)
+		cb.probing.Store(0)
+		return
+	}
+
+	n := cb.failures.Add(1)
+	if n >= cb.threshold {
+		if cb.state.CompareAndSwap(cbClosed, cbOpen) {
+			cb.openedAt.Store(time.Now().UnixNano())
+			cb.failures.Store(0)
+		}
+	}
+}
+
+// State returns the current state as a string: "closed", "open", or "half-open".
+func (cb *CircuitBreaker) State() string {
+	if cb == nil || !cb.enabled {
+		return "closed"
+	}
+	switch cb.state.Load() {
+	case cbOpen:
+		return "open"
+	case cbHalfOpen:
+		return "half-open"
+	default:
+		return "closed"
+	}
+}
+
+// IsEnabled reports whether the circuit breaker is active.
+func (cb *CircuitBreaker) IsEnabled() bool {
+	return cb != nil && cb.enabled
+}

--- a/transport/circuit_breaker_test.go
+++ b/transport/circuit_breaker_test.go
@@ -1,0 +1,202 @@
+package transport
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_DisabledByDefault(t *testing.T) {
+	// nil circuit breaker should be a no-op
+	var cb *CircuitBreaker
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("nil cb.Allow() = %v, want nil", err)
+	}
+	cb.RecordSuccess()
+	cb.RecordFailure()
+	if cb.IsEnabled() {
+		t.Fatal("nil cb.IsEnabled() = true, want false")
+	}
+	if s := cb.State(); s != "closed" {
+		t.Fatalf("nil cb.State() = %q, want %q", s, "closed")
+	}
+
+	// threshold <= 0 returns nil
+	cb = NewCircuitBreaker(0, time.Second)
+	if cb != nil {
+		t.Fatal("NewCircuitBreaker(0, ...) should return nil")
+	}
+	cb = NewCircuitBreaker(-1, time.Second)
+	if cb != nil {
+		t.Fatal("NewCircuitBreaker(-1, ...) should return nil")
+	}
+}
+
+func TestCircuitBreaker_StaysClosedOnSuccess(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+
+	for i := 0; i < 100; i++ {
+		if err := cb.Allow(); err != nil {
+			t.Fatalf("Allow() failed on call %d: %v", i, err)
+		}
+		cb.RecordSuccess()
+	}
+
+	if s := cb.State(); s != "closed" {
+		t.Fatalf("State() = %q, want %q", s, "closed")
+	}
+}
+
+func TestCircuitBreaker_OpensAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+
+	// 3 consecutive failures should trip the breaker
+	for i := 0; i < 3; i++ {
+		if err := cb.Allow(); err != nil {
+			t.Fatalf("Allow() failed on failure %d: %v", i, err)
+		}
+		cb.RecordFailure()
+	}
+
+	if s := cb.State(); s != "open" {
+		t.Fatalf("State() = %q, want %q", s, "open")
+	}
+
+	// Subsequent calls should be rejected
+	err := cb.Allow()
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Allow() = %v, want ErrCircuitOpen", err)
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Second)
+
+	// 2 failures, then a success
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordSuccess()
+
+	// 2 more failures — should NOT trip (count was reset)
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if s := cb.State(); s != "closed" {
+		t.Fatalf("State() = %q, want %q after reset", s, "closed")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
+	cb := NewCircuitBreaker(1, 20*time.Millisecond)
+
+	// Trip the breaker
+	cb.Allow()
+	cb.RecordFailure()
+	if s := cb.State(); s != "open" {
+		t.Fatalf("State() = %q, want %q", s, "open")
+	}
+
+	// Before cooldown — rejected
+	err := cb.Allow()
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Allow() before cooldown = %v, want ErrCircuitOpen", err)
+	}
+
+	// Wait for cooldown
+	time.Sleep(30 * time.Millisecond)
+
+	// First call should be allowed (probe)
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("Allow() after cooldown = %v, want nil (probe)", err)
+	}
+	if s := cb.State(); s != "half-open" {
+		t.Fatalf("State() = %q, want %q", s, "half-open")
+	}
+
+	// Concurrent calls during probe should be rejected
+	err = cb.Allow()
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Allow() during probe = %v, want ErrCircuitOpen", err)
+	}
+}
+
+func TestCircuitBreaker_ProbeSuccessCloses(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Millisecond)
+
+	// Trip and wait for cooldown
+	cb.Allow()
+	cb.RecordFailure()
+	time.Sleep(15 * time.Millisecond)
+
+	// Probe
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("probe Allow() = %v, want nil", err)
+	}
+	cb.RecordSuccess()
+
+	if s := cb.State(); s != "closed" {
+		t.Fatalf("State() after probe success = %q, want %q", s, "closed")
+	}
+
+	// All calls should be allowed now
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("Allow() after close = %v, want nil", err)
+	}
+}
+
+func TestCircuitBreaker_ProbeFailureReopens(t *testing.T) {
+	cb := NewCircuitBreaker(1, 10*time.Millisecond)
+
+	// Trip and wait for cooldown
+	cb.Allow()
+	cb.RecordFailure()
+	time.Sleep(15 * time.Millisecond)
+
+	// Probe
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("probe Allow() = %v, want nil", err)
+	}
+	cb.RecordFailure()
+
+	if s := cb.State(); s != "open" {
+		t.Fatalf("State() after probe failure = %q, want %q", s, "open")
+	}
+
+	// Should be rejected again (cooldown restarted)
+	err := cb.Allow()
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("Allow() after reopen = %v, want ErrCircuitOpen", err)
+	}
+}
+
+func TestCircuitBreaker_ConcurrentSafety(t *testing.T) {
+	cb := NewCircuitBreaker(5, 10*time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				err := cb.Allow()
+				if err == nil {
+					if j%3 == 0 {
+						cb.RecordFailure()
+					} else {
+						cb.RecordSuccess()
+					}
+				}
+				_ = cb.State()
+				_ = cb.IsEnabled()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Just verify it didn't panic or deadlock; state is non-deterministic
+	s := cb.State()
+	if s != "closed" && s != "open" && s != "half-open" {
+		t.Fatalf("unexpected state: %q", s)
+	}
+}

--- a/transport/redis/options.go
+++ b/transport/redis/options.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/rbaliyan/event/v3/transport"
 	"github.com/rbaliyan/event/v3/transport/codec"
 )
 
@@ -120,6 +121,20 @@ func WithClaimBatchSize(n int64) Option {
 	return func(t *Transport) {
 		if n > 0 {
 			t.claimBatchSize = n
+		}
+	}
+}
+
+// WithCircuitBreaker enables a circuit breaker on Publish (XAdd) calls.
+// After threshold consecutive failures, the breaker opens and Publish returns
+// transport.ErrCircuitOpen immediately. After cooldown elapses, one probe call
+// is allowed through: success closes the breaker, failure re-opens it.
+//
+// Disabled by default (zero overhead when not configured).
+func WithCircuitBreaker(threshold int, cooldown time.Duration) Option {
+	return func(t *Transport) {
+		if threshold > 0 {
+			t.cb = transport.NewCircuitBreaker(threshold, cooldown)
 		}
 	}
 }

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -70,6 +70,7 @@ type Transport struct {
 	claimInterval  time.Duration // Interval for claiming orphaned messages (0 = disabled)
 	claimMinIdle   time.Duration // Minimum idle time before claiming a message
 	claimBatchSize int64         // Max messages to claim per cycle (default 100)
+	cb             *transport.CircuitBreaker // Publish circuit breaker (nil = disabled)
 
 }
 
@@ -222,11 +223,18 @@ func (t *Transport) Publish(ctx context.Context, name string, msg transport.Mess
 		args.Approx = true
 	}
 
+	if err := t.cb.Allow(); err != nil {
+		return err
+	}
+
 	_, err = t.client.XAdd(ctx, args).Result()
 	if err != nil {
+		t.cb.RecordFailure()
 		t.onError(err)
 		return err
 	}
+
+	t.cb.RecordSuccess()
 
 	t.logger.Debug("published message", "event", name, "msg_id", msg.ID())
 	return nil
@@ -393,6 +401,14 @@ func (t *Transport) Health(ctx context.Context) *transport.HealthCheckResult {
 	result.Details["ping_latency_ms"] = pingLatency.Milliseconds()
 	result.Details["events"] = eventCount
 	result.Details["consumer_group"] = t.groupID
+	if t.cb.IsEnabled() {
+		cbState := t.cb.State()
+		result.Details["circuit_breaker"] = cbState
+		if cbState == "open" {
+			result.Status = transport.HealthStatusDegraded
+			result.Message = "redis transport circuit breaker is open"
+		}
+	}
 
 	return result
 }


### PR DESCRIPTION
## Summary
- Add reusable `CircuitBreaker` struct in `transport/` package (lock-free, `sync/atomic` only)
- States: Closed → Open (after N consecutive failures) → Half-Open (after cooldown) → probe one call → Close on success or re-Open on failure
- Nil-safe: all methods are no-ops when circuit breaker is not configured (zero overhead by default)
- Integrate into Redis transport's `Publish` (XAdd) path via `WithCircuitBreaker(threshold, cooldown)` option
- Report circuit breaker state in Health endpoint; status degrades to `degraded` when open
- New sentinel error: `transport.ErrCircuitOpen`

## Files
- `transport/circuit_breaker.go` — reusable struct, any transport can embed
- `transport/circuit_breaker_test.go` — 8 tests covering all state transitions + concurrent safety
- `transport/redis/redis.go` — integration into Publish and Health
- `transport/redis/options.go` — `WithCircuitBreaker` option

## Test plan
- [x] `go test -race ./transport/...` — all pass
- [x] `go test -race ./transport/redis/...` — all pass
- [x] `go test ./...` — full suite green (34 packages)
- [x] Circuit breaker tests: disabled default, stays closed, opens after threshold, resets on success, half-open after cooldown, probe success closes, probe failure reopens, concurrent safety