### PR TITLE
refactor: improve robustness and clean architecture

### DIFF
--- a/bus_health.go
+++ b/bus_health.go
@@ -3,7 +3,6 @@ package event
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/rbaliyan/event/v3/health"
@@ -102,9 +101,8 @@ func (b *Bus) checkComponentHealth(ctx context.Context, result *Status, name str
 
 // aggregateComponentStatus updates the result status based on component status.
 // Uses the worst status: unhealthy > degraded > healthy.
-// Accepts health.Status or transport.HealthStatus (both are string types with identical values).
-func aggregateComponentStatus(result *Status, name string, status any) {
-	code := StatusCode(fmt.Sprint(status))
+func aggregateComponentStatus(result *Status, name string, status StatusCode) {
+	code := status
 
 	switch code {
 	case StatusUnhealthy:
@@ -149,7 +147,7 @@ func convertTransportStatus(th *transport.HealthCheckResult) *Status {
 	}
 
 	result := &Status{
-		Code:      StatusCode(th.Status),
+		Code:      th.Status,
 		Message:   th.Message,
 		Latency:   th.Latency,
 		Details:   th.Details,

--- a/event.go
+++ b/event.go
@@ -578,32 +578,9 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 					continue
 				}
 
-				// Decode payload.
+				// Decode payload
 				var typedData T
-				contentType := msg.Metadata()[MetadataContentType]
-				if contentType == "" {
-					contentType = "application/json"
-				}
-
-				codec, codecOk := payload.Get(contentType)
-				if !codecOk {
-					contentErr := fmt.Errorf("unknown content type: %s", contentType)
-					logger.Error("unknown content type, routing to DLQ",
-						"event", e.Name(), "msg_id", msg.ID(), "content_type", contentType)
-					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, contentErr); dlqErr != nil {
-						bus.logFallbackDLQ(logger, e.name, msg, contentErr, dlqErr)
-					}
-					_ = msg.Ack(nil)
-					continue
-				}
-
-				if err := codec.Decode(msg.Payload(), &typedData); err != nil {
-					logger.Error("decode error, routing to DLQ",
-						"event", e.Name(), "msg_id", msg.ID(), "error", err)
-					if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, err); dlqErr != nil {
-						bus.logFallbackDLQ(logger, e.name, msg, err, dlqErr)
-					}
-					_ = msg.Ack(nil)
+				if !e.decodePayload(msg, bus, logger, &typedData) {
 					continue
 				}
 
@@ -699,6 +676,39 @@ func (e *eventImpl[T]) filterMessage(msg transport.Message, bus *Bus, subOpts *s
 
 	// Apply route filters (transport-agnostic fallback for non-channel transports)
 	if !matchesSubscriptionRoute(msg.Metadata(), subOpts) {
+		_ = msg.Ack(nil)
+		return false
+	}
+
+	return true
+}
+
+// decodePayload resolves the content-type codec and decodes msg.Payload into *out.
+// On failure it routes to DLQ, acks the message, and returns false.
+func (e *eventImpl[T]) decodePayload(msg transport.Message, bus *Bus, logger *slog.Logger, out *T) bool {
+	contentType := msg.Metadata()[MetadataContentType]
+	if contentType == "" {
+		contentType = "application/json"
+	}
+
+	c, ok := payload.Get(contentType)
+	if !ok {
+		contentErr := fmt.Errorf("unknown content type: %s", contentType)
+		logger.Error("unknown content type, routing to DLQ",
+			"event", e.Name(), "msg_id", msg.ID(), "content_type", contentType)
+		if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, contentErr); dlqErr != nil {
+			bus.logFallbackDLQ(logger, e.name, msg, contentErr, dlqErr)
+		}
+		_ = msg.Ack(nil)
+		return false
+	}
+
+	if err := c.Decode(msg.Payload(), out); err != nil {
+		logger.Error("decode error, routing to DLQ",
+			"event", e.Name(), "msg_id", msg.ID(), "error", err)
+		if dlqErr := bus.sendToDLQ(context.Background(), e.name, msg, err); dlqErr != nil {
+			bus.logFallbackDLQ(logger, e.name, msg, err, dlqErr)
+		}
 		_ = msg.Ack(nil)
 		return false
 	}

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -140,23 +140,24 @@ func NewRelay(store Store, t transport.Transport, opts ...RelayOption) *Relay {
 		opt(o)
 	}
 
+	logger := o.logger
+	if logger == nil {
+		logger = slog.Default().With("component", "outbox.relay")
+	}
+
 	return &Relay{
 		store:      store,
 		transport:  t,
 		pollDelay:  o.pollDelay,
 		batchSize:  o.batchSize,
-		logger:     o.logger,
+		logger:     logger,
 		cleanupAge: o.cleanupAge,
 		metrics:    o.metrics,
 	}
 }
 
-// log returns the configured logger, falling back to slog.Default().
+// log returns the configured logger.
 func (r *Relay) log() *slog.Logger {
-	if r.logger != nil {
-		return r.logger
-	}
-	r.logger = slog.Default().With("component", "outbox.relay")
 	return r.logger
 }
 

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -210,16 +210,14 @@ func (t *Transport) Publish(ctx context.Context, name string, msg transport.Mess
 		},
 	}
 
-	// Apply count-based trimming (MAXLEN)
-	if t.maxLen > 0 {
-		args.MaxLen = t.maxLen
-		args.Approx = true // Use ~ for better performance
-	}
-
-	// Apply time-based trimming (MINID)
+	// Apply trimming: MINID takes precedence over MAXLEN when both are set,
+	// since combining them in a single XADD is only supported in Redis 7+.
 	if t.maxAge > 0 {
 		minTime := time.Now().Add(-t.maxAge).UnixMilli()
 		args.MinID = fmt.Sprintf("%d-0", minTime)
+		args.Approx = true
+	} else if t.maxLen > 0 {
+		args.MaxLen = t.maxLen
 		args.Approx = true
 	}
 
@@ -508,6 +506,13 @@ func (s *subscription) Close(ctx context.Context) error {
 	})
 }
 
+// ack acknowledges a message in the consumer group with a bounded timeout.
+func (s *subscription) ack(msgID string) *redis.IntCmd {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return s.client.XAck(ctx, s.stream, s.group, msgID)
+}
+
 // sendWithRetry sends a message to the channel with exponential backoff on timeout.
 // This is a convenience wrapper around SendWithRetry with Redis-specific logging.
 func (s *subscription) sendWithRetry(msg transport.Message, msgID string, logger *slog.Logger) bool {
@@ -527,7 +532,7 @@ func (s *subscription) processRedisMessage(xmsg redis.XMessage, retryCount int, 
 			msgID, nil, transport.ErrDecodeFailure,
 			func(err error) error {
 				if err == nil {
-					return s.client.XAck(context.Background(), s.stream, s.group, msgID).Err()
+					return s.ack(msgID).Err()
 				}
 				return nil
 			},
@@ -542,7 +547,7 @@ func (s *subscription) processRedisMessage(xmsg redis.XMessage, retryCount int, 
 			msgID, []byte(data), err,
 			func(ackErr error) error {
 				if ackErr == nil {
-					return s.client.XAck(context.Background(), s.stream, s.group, msgID).Err()
+					return s.ack(msgID).Err()
 				}
 				return nil
 			},
@@ -563,7 +568,7 @@ func (s *subscription) processRedisMessage(xmsg redis.XMessage, retryCount int, 
 		rc,
 		func(err error) error {
 			if err == nil {
-				return s.client.XAck(context.Background(), s.stream, s.group, msgID).Err()
+				return s.ack(msgID).Err()
 			}
 			return nil
 		},

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rbaliyan/event/v3/health"
 	"github.com/rbaliyan/event/v3/transport/codec"
 	"github.com/rbaliyan/event/v3/transport/message"
 	"go.opentelemetry.io/otel/trace"
@@ -103,16 +104,13 @@ func MatchesRouteFilters(metadata, filters map[string]string) bool {
 	return true
 }
 
-// HealthStatus represents the health state of a component
-type HealthStatus string
+// HealthStatus is an alias for health.Status to avoid type duplication.
+type HealthStatus = health.Status
 
 const (
-	// HealthStatusHealthy indicates the component is functioning normally
-	HealthStatusHealthy HealthStatus = "healthy"
-	// HealthStatusDegraded indicates the component is functioning but with issues
-	HealthStatusDegraded HealthStatus = "degraded"
-	// HealthStatusUnhealthy indicates the component is not functioning
-	HealthStatusUnhealthy HealthStatus = "unhealthy"
+	HealthStatusHealthy   = health.StatusHealthy
+	HealthStatusDegraded  = health.StatusDegraded
+	HealthStatusUnhealthy = health.StatusUnhealthy
 )
 
 // HealthCheckResult contains detailed health information


### PR DESCRIPTION
## Summary
- Fix Redis XAdd trimming: MinID takes precedence over MaxLen when both configured (Redis 6.x compat)
- Fix Redis ack closures: 5s deadline instead of `context.Background()` to prevent indefinite hangs
- Fix outbox Relay logger: initialize in `NewRelay` instead of thread-unsafe lazy init
- Unify `transport.HealthStatus` as alias for `health.Status`, removing duplicated constants and `fmt.Sprint` bridging
- Extract `decodePayload` method to deduplicate codec/DLQ logic between coalesce and standard subscribe paths

## Test plan
- [x] `go test -race -count=1 ./...` — all 34 packages pass
- [x] No new dependencies added
- [x] All changes are backwards compatible