### PR TITLE
docs: fix documentation inaccuracies and add missing feature docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,14 +139,15 @@ Bus (transport, tracing, metrics, recovery)
 
 ### Middleware Chain Execution Order
 
-When a handler is subscribed, it's wrapped in this chain (innermost to outermost):
+When a handler is subscribed, it's wrapped in this chain. Execution flows from outermost to handler:
 ```
-Recovery (panic handling)
-  → Timeout (context deadline)
-    → Custom middleware (via WithMiddleware)
-      → Idempotency (bus-level, controlled by schema if loaded)
-        → Poison detection (bus-level, controlled by schema if loaded)
-          → Monitor (bus-level, controlled by schema if loaded)
+Monitor (bus-level, controlled by schema if loaded)
+  → Poison detection (bus-level, controlled by schema if loaded)
+    → Idempotency (bus-level, controlled by schema if loaded)
+      → Custom middleware (via WithMiddleware)
+        → Timeout (context deadline)
+          → Recovery (panic handling)
+            → Handler
 ```
 
 **Schema-Controlled Middleware:**
@@ -243,8 +244,7 @@ type OutboxStore interface {
 **Outbox Metrics** (`outbox.Metrics`):
 ```go
 metrics, _ := outbox.NewMetrics()
-relay := outbox.NewRelay(store, transport).
-    WithMetrics(metrics)
+relay := outbox.NewRelay(store, transport, outbox.WithMetrics(metrics))
 ```
 
 Metrics recorded:

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,7 @@ This document describes version compatibility between the event library and its 
 
 | Package | Current | Go Version | Dependencies |
 |---------|---------|------------|--------------|
-| event/v3 | 3.x | 1.25+ | otel 1.40+ |
+| event/v3 | 3.x | 1.25.8+ | otel 1.40+ |
 | event-scheduler | 1.x | 1.25+ | event/v3, go-redis/v9 |
 | event-dlq | 1.x | 1.25+ | event/v3, go-redis/v9 |
 | event-extras | 1.x | 1.25+ | event/v3, go-redis/v9 |
@@ -97,14 +97,14 @@ No breaking changes planned. All v3.x APIs will remain stable.
 All store implementations follow the same interface patterns:
 
 | Store Type | PostgreSQL | MongoDB | Redis | Memory |
-|------------|------------|---------|-------|--------|
-| Scheduler | Yes | Yes | Yes | Test only |
-| DLQ | Yes | Yes | Yes | Yes |
-| Saga | Yes | Yes | Yes | Yes |
-| Monitor | Yes | Yes | No | Yes |
-| Schema | Yes | Yes | Yes | Yes |
-| Idempotency | Yes | Yes | Yes | Yes |
-| Poison | Yes | No | Yes | Yes |
+|------------|:----------:|:-------:|:-----:|:------:|
+| Scheduler | ✅ | ✅ | ✅ | - |
+| DLQ | ✅ | ✅ | ✅ | ✅ |
+| Saga | ✅ | ✅ | ✅ | ✅ |
+| Monitor | ✅ | ✅ | - | ✅ |
+| Schema | ✅ | ✅ | ✅ | ✅ |
+| Idempotency | ✅ | ✅ | ✅ | ✅ |
+| Poison | ✅ | - | ✅ | ✅ |
 
 ## Middleware Chain Order
 
@@ -123,9 +123,9 @@ Outermost (first added)
 Example:
 ```go
 chain := event.NewChain[Order]().
-    Use(LoggingMiddleware).    // 1. Outermost - logs before/after
-    Use(MetricsMiddleware).    // 2. Records timing
-    Use(ValidationMiddleware)  // 3. Innermost - validates data
+    Use(myLoggingMiddleware).    // 1. Outermost - logs before/after (user-defined)
+    Use(myMetricsMiddleware).    // 2. Records timing (user-defined)
+    Use(myValidationMiddleware)  // 3. Innermost - validates data (user-defined)
 ```
 
 ## Backoff Strategy Compatibility

--- a/README.md
+++ b/README.md
@@ -249,24 +249,55 @@ func main() {
 
 \* MongoDB CDC supports WorkerPool mode through the `distributed` package, which emulates worker semantics using database atomic state transitions. See [Distributed WorkerPool](#distributed-workerpool).
 
-## Health Checks
+### Circuit Breaker
 
-All transports and stores implement the `health.Checker` interface:
+Protect publish calls from cascading failures when a transport backend is temporarily unavailable. Currently supported on Redis transport:
 
 ```go
-import "github.com/rbaliyan/event/v3/health"
+transport, _ := redis.New(rdb,
+    redis.WithCircuitBreaker(5, 30*time.Second), // open after 5 failures, cooldown 30s
+)
+```
 
-// Check transport health
-result := transport.Health(ctx)
-fmt.Printf("Status: %s, Latency: %v\n", result.Status, result.Latency)
+When open, `Publish` returns `transport.ErrCircuitOpen` immediately instead of blocking until timeout. After the cooldown period, one probe call is allowed through — success closes the breaker, failure re-opens it.
 
-// Check all components
+The `CircuitBreaker` struct in the `transport` package is reusable and can be embedded by any transport implementation.
+
+### Transport Migration
+
+Bridge an old and new transport during a migration with zero message loss:
+
+```go
+import "github.com/rbaliyan/event/v3/transport/migration"
+
+mt, _ := migration.New(oldRedisTransport, newKafkaTransport,
+    migration.WithMergedBufferSize(128),
+)
+bus, _ := event.NewBus("mybus", event.WithTransport(mt))
+```
+
+- **Publish** routes to the new transport only
+- **Subscribe** fans-in messages from both transports into a single subscription
+- Falls back to new-only if the old transport fails to subscribe
+- Health reports degraded when old is down, unhealthy when new is down
+- Consumer lag is prefixed with `old:`/`new:` for dashboard disambiguation
+
+Once the old transport is fully drained, replace the migration transport with the new one directly.
+
+## Health Checks
+
+Stores implement `health.Checker`; transports implement `transport.HealthChecker`. The bus aggregates both:
+
+```go
+// Check bus health (aggregates transport + all configured stores)
+status := bus.Status(ctx)
+fmt.Printf("Status: %s, Latency: %v\n", status.Code, status.Latency)
+
+// Check individual stores via health.CheckAll
 results := health.CheckAll(ctx, map[string]health.Checker{
-    "transport":   transport,
     "idempotency": idempStore,
     "monitor":     monitorStore,
 })
-
 for name, result := range results.Components {
     fmt.Printf("%s: %s\n", name, result.Status)
 }


### PR DESCRIPTION
## Summary
- **HIGH**: Fix middleware chain execution order in CLAUDE.md (was inverted — showed innermost-to-outermost instead of actual execution order)
- **HIGH**: Fix health check example in README (transports implement `transport.HealthChecker`, not `health.Checker` — example wouldn't compile)
- **MEDIUM**: Add migration transport documentation to README with usage example
- **MEDIUM**: Add circuit breaker documentation to README with usage example
- **MEDIUM**: Fix outbox relay `WithMetrics` example in CLAUDE.md (is a constructor option, not a method chain)
- **LOW**: Align COMPATIBILITY.md store table notation with README (checkmarks/dashes)
- **LOW**: Annotate middleware example names as user-defined in COMPATIBILITY.md
- **LOW**: Fix Go version precision (`1.25+` → `1.25.8+`)

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all 35 packages pass
- [x] All code examples verified against actual function signatures