### PR TITLE
feat: add outbox resilience, observability, and prioritization

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -63,8 +63,9 @@ type Bus struct {
 	// DLQ store for automatic dead letter routing
 	dlqStore DLQStore
 	// Cached OTel instruments (initialized once during construction)
-	publishedCounter  metric.Int64Counter
-	subscribedCounter metric.Int64Counter
+	publishedCounter   metric.Int64Counter
+	subscribedCounter  metric.Int64Counter
+	publishDuration    metric.Float64Histogram
 }
 
 // NewBus creates a new event bus and registers it in the global registry.
@@ -118,6 +119,8 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 			metric.WithDescription("Total number of events published"))
 		bus.subscribedCounter, _ = meter.Int64Counter("event.subscribed",
 			metric.WithDescription("Total number of subscriptions"))
+		bus.publishDuration, _ = meter.Float64Histogram("event.publish_duration_seconds",
+			metric.WithDescription("Time to publish a message to the transport"))
 	}
 
 	// Register in global registry (use LoadOrStore to handle race condition)
@@ -429,7 +432,13 @@ func (b *Bus) Send(ctx context.Context, eventName string, eventID string, payloa
 	msg := message.New(eventID, b.ID(), payload, meta, message.WithSpanContext(spanCtx))
 
 	// Send via transport
-	return b.transport.Publish(ctx, eventName, msg)
+	publishStart := time.Now()
+	err := b.transport.Publish(ctx, eventName, msg)
+	if b.metricsEnabled && b.publishDuration != nil {
+		b.publishDuration.Record(ctx, time.Since(publishStart).Seconds(),
+			metric.WithAttributes(attribute.String("event", eventName)))
+	}
+	return err
 }
 
 // Recv creates a subscription to receive messages for the specified event.

--- a/bus.go
+++ b/bus.go
@@ -120,7 +120,8 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 		bus.subscribedCounter, _ = meter.Int64Counter("event.subscribed",
 			metric.WithDescription("Total number of subscriptions"))
 		bus.publishDuration, _ = meter.Float64Histogram("event.publish_duration_seconds",
-			metric.WithDescription("Time to publish a message to the transport"))
+			metric.WithDescription("Time to publish a message to the transport"),
+			metric.WithUnit("s"))
 	}
 
 	// Register in global registry (use LoadOrStore to handle race condition)

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -21,12 +21,18 @@ import (
 // DefaultSystemRefreshInterval is the default interval for background system view refresh.
 const DefaultSystemRefreshInterval = 10 * time.Second
 
+// DLQAlertFunc is called when DLQ pending message count exceeds the configured threshold.
+// stats contains the current DLQ statistics at the time of the alert.
+type DLQAlertFunc func(stats *DLQStats)
+
 // handlerOptions holds configuration for the Handler.
 type handlerOptions struct {
 	workerStore           distributed.WorkerStore
 	dlqProvider           DLQProvider
 	schedProvider         SchedulerProvider
 	systemRefreshInterval time.Duration
+	dlqAlertFunc          DLQAlertFunc
+	dlqAlertThreshold     int64
 }
 
 // Option configures the Handler.
@@ -53,6 +59,19 @@ func WithSchedulerProvider(p SchedulerProvider) Option {
 	}
 }
 
+// WithDLQAlertHook registers a callback that is invoked during each system view refresh
+// when the DLQ pending message count exceeds the threshold. The hook runs in the
+// background refresh goroutine, so it should be non-blocking (e.g., send to a channel
+// or fire an HTTP webhook asynchronously).
+func WithDLQAlertHook(fn DLQAlertFunc, threshold int64) Option {
+	return func(o *handlerOptions) {
+		if fn != nil && threshold > 0 {
+			o.dlqAlertFunc = fn
+			o.dlqAlertThreshold = threshold
+		}
+	}
+}
+
 // WithSystemRefreshInterval sets the interval for background system view refresh.
 // The system view (/v1/system, /v1/system/health) is collected in the background
 // and cached, so API responses are instant regardless of how many buses or messages exist.
@@ -65,13 +84,15 @@ func WithSystemRefreshInterval(d time.Duration) Option {
 
 // Handler implements http.Handler for the monitor service using protoJSON.
 type Handler struct {
-	store         monitor.Store
-	workerStore   distributed.WorkerStore
-	dlqProvider   DLQProvider
-	schedProvider SchedulerProvider
-	mux           *http.ServeMux
-	marshaler     protojson.MarshalOptions
-	unmarshaler   protojson.UnmarshalOptions
+	store             monitor.Store
+	workerStore       distributed.WorkerStore
+	dlqProvider       DLQProvider
+	schedProvider     SchedulerProvider
+	dlqAlertFunc      DLQAlertFunc
+	dlqAlertThreshold int64
+	mux               *http.ServeMux
+	marshaler         protojson.MarshalOptions
+	unmarshaler       protojson.UnmarshalOptions
 
 	// Background system view cache
 	systemView    atomic.Pointer[SystemView]
@@ -91,10 +112,12 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	}
 
 	h := &Handler{
-		store:         store,
-		workerStore:   o.workerStore,
-		dlqProvider:   o.dlqProvider,
-		schedProvider: o.schedProvider,
+		store:             store,
+		workerStore:       o.workerStore,
+		dlqProvider:       o.dlqProvider,
+		schedProvider:     o.schedProvider,
+		dlqAlertFunc:      o.dlqAlertFunc,
+		dlqAlertThreshold: o.dlqAlertThreshold,
 		mux:           http.NewServeMux(),
 		done:          make(chan struct{}),
 		marshaler: protojson.MarshalOptions{

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -60,8 +60,10 @@ func WithSchedulerProvider(p SchedulerProvider) Option {
 }
 
 // WithDLQAlertHook registers a callback that is invoked during each system view refresh
-// when the DLQ pending message count exceeds the threshold. The hook runs in the
-// background refresh goroutine, so it should be non-blocking (e.g., send to a channel
+// when the DLQ pending message count exceeds the threshold. The hook is called on
+// EVERY refresh cycle where the threshold is exceeded (default: every 10s), so callers
+// are responsible for rate-limiting or deduplicating alerts. The hook runs in the
+// background refresh goroutine and should be non-blocking (e.g., send to a channel
 // or fire an HTTP webhook asynchronously).
 func WithDLQAlertHook(fn DLQAlertFunc, threshold int64) Option {
 	return func(o *handlerOptions) {

--- a/monitor/http/system.go
+++ b/monitor/http/system.go
@@ -71,6 +71,10 @@ func (h *Handler) refreshSystemView(ctx context.Context) {
 			mu.Lock()
 			if err == nil {
 				view.DLQ = stats
+				// Check DLQ alert threshold
+				if h.dlqAlertFunc != nil && stats.PendingMessages >= h.dlqAlertThreshold {
+					h.dlqAlertFunc(stats)
+				}
 			} else {
 				slog.WarnContext(ctx, "dlq stats query failed", "error", err)
 			}

--- a/outbox/mongodb.go
+++ b/outbox/mongodb.go
@@ -72,6 +72,7 @@ type mongoMessage struct {
 	Status      Status            `bson:"status"`
 	RetryCount  int               `bson:"retry_count"`
 	LastError   string            `bson:"last_error,omitempty"`
+	Priority    int               `bson:"priority"`
 }
 
 // toMessage converts mongoMessage to Message
@@ -87,6 +88,7 @@ func (m *mongoMessage) toMessage() *Message {
 		Status:      m.Status,
 		RetryCount:  m.RetryCount,
 		LastError:   m.LastError,
+		Priority:    m.Priority,
 	}
 }
 
@@ -376,7 +378,7 @@ func (s *MongoStore) claimNextPending(ctx context.Context) (*Message, error) {
 		},
 	}
 	opts := options.FindOneAndUpdate().
-		SetSort(bson.D{{Key: "created_at", Value: 1}}).
+		SetSort(bson.D{{Key: "priority", Value: -1}, {Key: "created_at", Value: 1}}).
 		SetReturnDocument(options.After)
 
 	var mongoMsg mongoMessage
@@ -418,7 +420,7 @@ func (s *MongoStore) claimNextPendingMongo(ctx context.Context) (*mongoMessage, 
 		},
 	}
 	opts := options.FindOneAndUpdate().
-		SetSort(bson.D{{Key: "created_at", Value: 1}}).
+		SetSort(bson.D{{Key: "priority", Value: -1}, {Key: "created_at", Value: 1}}).
 		SetReturnDocument(options.After)
 
 	var mongoMsg mongoMessage

--- a/outbox/mongodb.go
+++ b/outbox/mongodb.go
@@ -158,6 +158,7 @@ func (s *MongoStore) Indexes() []mongo.IndexModel {
 		{
 			Keys: bson.D{
 				{Key: "status", Value: 1},
+				{Key: "priority", Value: -1},
 				{Key: "created_at", Value: 1},
 			},
 		},
@@ -370,7 +371,7 @@ func (s *MongoStore) GetPending(ctx context.Context, limit int) ([]*Message, err
 // claimNextPending atomically claims a single pending message for processing.
 // Uses FindOneAndUpdate to prevent race conditions in HA deployments.
 func (s *MongoStore) claimNextPending(ctx context.Context) (*Message, error) {
-	filter := bson.M{"status": StatusPending}
+	filter := bson.M{"status": bson.M{"$in": []Status{StatusPending, StatusFailed}}}
 	update := bson.M{
 		"$set": bson.M{
 			"status":     StatusProcessing,
@@ -412,7 +413,7 @@ func (s *MongoStore) getPendingMongo(ctx context.Context, limit int) ([]*mongoMe
 
 // claimNextPendingMongo atomically claims a single pending message for processing.
 func (s *MongoStore) claimNextPendingMongo(ctx context.Context) (*mongoMessage, error) {
-	filter := bson.M{"status": StatusPending}
+	filter := bson.M{"status": bson.M{"$in": []Status{StatusPending, StatusFailed}}}
 	update := bson.M{
 		"$set": bson.M{
 			"status":     StatusProcessing,

--- a/outbox/outbox.go
+++ b/outbox/outbox.go
@@ -58,9 +58,10 @@
 //	    published_at TIMESTAMP,
 //	    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
 //	    retry_count  INT NOT NULL DEFAULT 0,
-//	    last_error   TEXT
+//	    last_error   TEXT,
+//	    priority     INT NOT NULL DEFAULT 0
 //	);
-//	CREATE INDEX idx_outbox_pending ON event_outbox(status, created_at) WHERE status = 'pending';
+//	CREATE INDEX idx_outbox_pending ON event_outbox(status, priority DESC, created_at) WHERE status IN ('pending', 'failed');
 //
 // # Complete Example
 //
@@ -152,6 +153,7 @@ type Message struct {
 	Status      Status
 	RetryCount  int
 	LastError   string
+	Priority    int // Higher values are processed first (0 = normal, default)
 }
 
 // Store defines the interface for SQL-based outbox storage with relay support.

--- a/outbox/outbox_test.go
+++ b/outbox/outbox_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func (s *mockStore) GetPending(_ context.Context, limit int) ([]*Message, error)
 	}
 	var pending []*Message
 	for _, msg := range s.messages {
-		if msg.Status == StatusPending && !s.published[msg.ID] {
+		if (msg.Status == StatusPending || msg.Status == StatusFailed) && !s.published[msg.ID] {
 			pending = append(pending, msg)
 			if len(pending) >= limit {
 				break
@@ -509,5 +510,85 @@ func TestMessageStruct(t *testing.T) {
 	}
 	if msg.PublishedAt != nil {
 		t.Error("expected nil PublishedAt")
+	}
+}
+
+func TestRelayMaxRetries(t *testing.T) {
+	store := newMockStore()
+	tr := channel.New(channel.WithBufferSize(100))
+	relay := NewRelay(store, tr,
+		WithPollDelay(50*time.Millisecond),
+		WithMaxRetries(3),
+	)
+
+	store.Insert(context.Background(), nil, &Message{
+		EventName: "test.event",
+		EventID:   "evt-1",
+		Payload:   []byte(`{}`),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go relay.Start(ctx)
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+
+	store.mu.Lock()
+	status := store.messages[0].Status
+	retryCount := store.messages[0].RetryCount
+	store.mu.Unlock()
+
+	if status != StatusFailed {
+		t.Fatalf("expected StatusFailed, got %s", status)
+	}
+	if retryCount < 3 {
+		t.Fatalf("expected retry count >= 3, got %d", retryCount)
+	}
+}
+
+func TestRelayAdaptiveBackpressure(t *testing.T) {
+	store := newMockStore()
+	tr := channel.New(channel.WithBufferSize(100))
+
+	var called atomic.Bool
+	strategy := &testBackoff{called: &called}
+	relay := NewRelay(store, tr,
+		WithPollDelay(50*time.Millisecond),
+		WithRetryBackoff(strategy),
+	)
+
+	store.Insert(context.Background(), nil, &Message{
+		EventName: "test.event",
+		EventID:   "evt-1",
+		Payload:   []byte(`{}`),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go relay.Start(ctx)
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	if !called.Load() {
+		t.Fatal("expected backoff strategy to be called on failures")
+	}
+}
+
+type testBackoff struct {
+	called *atomic.Bool
+}
+
+func (b *testBackoff) NextDelay(attempt int) time.Duration {
+	b.called.Store(true)
+	return 100 * time.Millisecond
+}
+
+func TestRelayPriority(t *testing.T) {
+	msg := &Message{
+		EventName: "test.event",
+		EventID:   "evt-1",
+		Payload:   []byte(`{}`),
+		Priority:  10,
+	}
+	if msg.Priority != 10 {
+		t.Fatalf("expected priority 10, got %d", msg.Priority)
 	}
 }

--- a/outbox/outbox_test.go
+++ b/outbox/outbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -61,10 +62,17 @@ func (s *mockStore) GetPending(_ context.Context, limit int) ([]*Message, error)
 	for _, msg := range s.messages {
 		if (msg.Status == StatusPending || msg.Status == StatusFailed) && !s.published[msg.ID] {
 			pending = append(pending, msg)
-			if len(pending) >= limit {
-				break
-			}
 		}
+	}
+	// Sort by priority DESC, then created_at ASC (matches real store behavior)
+	sort.Slice(pending, func(i, j int) bool {
+		if pending[i].Priority != pending[j].Priority {
+			return pending[i].Priority > pending[j].Priority
+		}
+		return pending[i].CreatedAt.Before(pending[j].CreatedAt)
+	})
+	if len(pending) > limit {
+		pending = pending[:limit]
 	}
 	return pending, nil
 }
@@ -609,12 +617,18 @@ func TestRelayPriority(t *testing.T) {
 	}
 	store.mu.Unlock()
 
-	// Verify GetPending returns both
+	// Verify GetPending returns high priority first
 	msgs, err := store.GetPending(ctx, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(msgs) != 2 {
 		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].EventID != "high" {
+		t.Fatalf("expected high-priority message first, got %s", msgs[0].EventID)
+	}
+	if msgs[1].EventID != "low" {
+		t.Fatalf("expected low-priority message second, got %s", msgs[1].EventID)
 	}
 }

--- a/outbox/outbox_test.go
+++ b/outbox/outbox_test.go
@@ -582,13 +582,39 @@ func (b *testBackoff) NextDelay(attempt int) time.Duration {
 }
 
 func TestRelayPriority(t *testing.T) {
-	msg := &Message{
+	store := newMockStore()
+	ctx := context.Background()
+
+	// Insert low priority first, then high priority
+	store.Insert(ctx, nil, &Message{
 		EventName: "test.event",
-		EventID:   "evt-1",
+		EventID:   "low",
+		Payload:   []byte(`{}`),
+		Priority:  1,
+	})
+	store.Insert(ctx, nil, &Message{
+		EventName: "test.event",
+		EventID:   "high",
 		Payload:   []byte(`{}`),
 		Priority:  10,
+	})
+
+	// Verify priority is stored correctly
+	store.mu.Lock()
+	if store.messages[0].Priority != 1 {
+		t.Fatalf("expected priority 1, got %d", store.messages[0].Priority)
 	}
-	if msg.Priority != 10 {
-		t.Fatalf("expected priority 10, got %d", msg.Priority)
+	if store.messages[1].Priority != 10 {
+		t.Fatalf("expected priority 10, got %d", store.messages[1].Priority)
+	}
+	store.mu.Unlock()
+
+	// Verify GetPending returns both
+	msgs, err := store.GetPending(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
 	}
 }

--- a/outbox/postgres.go
+++ b/outbox/postgres.go
@@ -117,8 +117,8 @@ func (s *PostgresStore) Insert(ctx context.Context, tx *sql.Tx, msg *Message) er
 	}
 
 	query := fmt.Sprintf(`
-		INSERT INTO %s (event_name, event_id, payload, metadata, status, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO %s (event_name, event_id, payload, metadata, status, created_at, priority)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING id
 	`, s.tableName)
 
@@ -129,6 +129,7 @@ func (s *PostgresStore) Insert(ctx context.Context, tx *sql.Tx, msg *Message) er
 		metadataJSON,
 		StatusPending,
 		time.Now(),
+		msg.Priority,
 	).Scan(&msg.ID)
 
 	return err
@@ -152,10 +153,10 @@ func (s *PostgresStore) Insert(ctx context.Context, tx *sql.Tx, msg *Message) er
 // Returns the messages and any error. Returns empty slice if no pending messages.
 func (s *PostgresStore) GetPending(ctx context.Context, limit int) ([]*Message, error) {
 	query := fmt.Sprintf(`
-		SELECT id, event_name, event_id, payload, metadata, created_at, retry_count
+		SELECT id, event_name, event_id, payload, metadata, created_at, retry_count, COALESCE(priority, 0)
 		FROM %s
 		WHERE status IN ($1, $2)
-		ORDER BY created_at
+		ORDER BY priority DESC, created_at
 		LIMIT $3
 		FOR UPDATE SKIP LOCKED
 	`, s.tableName)
@@ -197,10 +198,10 @@ func (s *PostgresStore) ProcessPending(ctx context.Context, limit int, fn func(m
 	defer tx.Rollback() //nolint:errcheck
 
 	query := fmt.Sprintf(`
-		SELECT id, event_name, event_id, payload, metadata, created_at, retry_count
+		SELECT id, event_name, event_id, payload, metadata, created_at, retry_count, COALESCE(priority, 0)
 		FROM %s
 		WHERE status IN ($1, $2)
-		ORDER BY created_at
+		ORDER BY priority DESC, created_at
 		LIMIT $3
 		FOR UPDATE SKIP LOCKED
 	`, s.tableName)
@@ -260,6 +261,7 @@ func (s *PostgresStore) scanMessages(rows *sql.Rows) ([]*Message, error) {
 			&metadataJSON,
 			&msg.CreatedAt,
 			&msg.RetryCount,
+			&msg.Priority,
 		)
 		if err != nil {
 			return nil, err

--- a/outbox/postgres.go
+++ b/outbox/postgres.go
@@ -48,10 +48,11 @@ func WithTable(table string) PostgresStoreOption {
 //	    published_at TIMESTAMP,
 //	    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
 //	    retry_count  INT NOT NULL DEFAULT 0,
-//	    last_error   TEXT
+//	    last_error   TEXT,
+//	    priority     INT NOT NULL DEFAULT 0
 //	);
-//	CREATE INDEX idx_outbox_pending ON event_outbox(status, created_at)
-//	    WHERE status = 'pending';
+//	CREATE INDEX idx_outbox_pending ON event_outbox(status, priority DESC, created_at)
+//	    WHERE status IN ('pending', 'failed');
 type PostgresStore struct {
 	db        *sql.DB
 	tableName string

--- a/outbox/redis.go
+++ b/outbox/redis.go
@@ -114,6 +114,10 @@ func WithMaxLen(maxLen int64) RedisStoreOption {
 
 // RedisStore implements outbox storage using Redis Streams with Consumer Groups.
 // Consumer Groups provide exactly-once delivery semantics for HA deployments.
+//
+// Note: Redis Streams are append-only and ordered by stream ID. The Priority field
+// is persisted but does not affect delivery order. Use PostgreSQL or MongoDB stores
+// when priority-based ordering is required.
 type RedisStore struct {
 	client       redis.Cmdable
 	pendingKey   string
@@ -172,6 +176,7 @@ func (s *RedisStore) Insert(ctx context.Context, msg *RedisMessage) (string, err
 			"metadata":    metadata,
 			"created_at":  msg.CreatedAt.Unix(),
 			"retry_count": msg.RetryCount,
+			"priority":    msg.Priority,
 		},
 	}
 

--- a/outbox/redis.go
+++ b/outbox/redis.go
@@ -45,6 +45,7 @@ type RedisMessage struct {
 	CreatedAt  time.Time         `json:"created_at"`
 	RetryCount int               `json:"retry_count"`
 	LastError  string            `json:"last_error,omitempty"`
+	Priority   int               `json:"priority"`
 }
 
 // ToMessage converts RedisMessage to Message
@@ -59,6 +60,7 @@ func (m *RedisMessage) ToMessage() *Message {
 		CreatedAt:  m.CreatedAt,
 		RetryCount: m.RetryCount,
 		LastError:  m.LastError,
+		Priority:   m.Priority,
 		Status:     StatusPending,
 	}
 }

--- a/outbox/redis.go
+++ b/outbox/redis.go
@@ -350,6 +350,10 @@ func (s *RedisStore) parseStreamMessage(msg redis.XMessage) (*RedisMessage, erro
 		m.RetryCount, _ = strconv.Atoi(retryCount)
 	}
 
+	if priority, ok := msg.Values["priority"].(string); ok {
+		m.Priority, _ = strconv.Atoi(priority)
+	}
+
 	return m, nil
 }
 

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -6,8 +6,13 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/rbaliyan/event/v3/backoff"
 	"github.com/rbaliyan/event/v3/transport"
 	"github.com/rbaliyan/event/v3/transport/message"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Relay polls the outbox and publishes messages to the transport.
@@ -42,24 +47,28 @@ import (
 //	// Shutdown gracefully
 //	cancel()
 type Relay struct {
-	store      Store
-	transport  transport.Transport
-	pollDelay  time.Duration
-	batchSize  int
-	logger     *slog.Logger
-	cleanupAge time.Duration // How old published messages should be before deletion
-	metrics    *Metrics
+	store        Store
+	transport    transport.Transport
+	pollDelay    time.Duration
+	batchSize    int
+	logger       *slog.Logger
+	cleanupAge   time.Duration // How old published messages should be before deletion
+	metrics      *Metrics
+	maxRetries   int              // 0 = unlimited retries (default)
+	retryBackoff backoff.Strategy // nil = no backoff delay between retries
 }
 
 // RelayOption configures a Relay.
 type RelayOption func(*relayOptions)
 
 type relayOptions struct {
-	pollDelay  time.Duration
-	batchSize  int
-	logger     *slog.Logger
-	cleanupAge time.Duration
-	metrics    *Metrics
+	pollDelay    time.Duration
+	batchSize    int
+	logger       *slog.Logger
+	cleanupAge   time.Duration
+	metrics      *Metrics
+	maxRetries   int
+	retryBackoff backoff.Strategy
 }
 
 // WithPollDelay sets the polling interval.
@@ -110,6 +119,30 @@ func WithMetrics(m *Metrics) RelayOption {
 	}
 }
 
+// WithMaxRetries sets the maximum number of publish attempts before routing to DLQ.
+// When a message's RetryCount reaches this limit and a DLQ store is configured,
+// the message is moved to the DLQ instead of being retried.
+// Set to 0 (default) for unlimited retries.
+func WithMaxRetries(n int) RelayOption {
+	return func(o *relayOptions) {
+		if n > 0 {
+			o.maxRetries = n
+		}
+	}
+}
+
+// WithRetryBackoff sets a backoff strategy for failed messages.
+// On each failure, the relay skips the message until the backoff delay elapses
+// based on the message's retry count.
+func WithRetryBackoff(strategy backoff.Strategy) RelayOption {
+	return func(o *relayOptions) {
+		if strategy != nil {
+			o.retryBackoff = strategy
+		}
+	}
+}
+
+
 // NewRelay creates a new outbox relay.
 //
 // The relay polls the store for pending messages and publishes them to
@@ -146,13 +179,15 @@ func NewRelay(store Store, t transport.Transport, opts ...RelayOption) *Relay {
 	}
 
 	return &Relay{
-		store:      store,
-		transport:  t,
-		pollDelay:  o.pollDelay,
-		batchSize:  o.batchSize,
-		logger:     logger,
-		cleanupAge: o.cleanupAge,
-		metrics:    o.metrics,
+		store:        store,
+		transport:    t,
+		pollDelay:    o.pollDelay,
+		batchSize:    o.batchSize,
+		logger:       logger,
+		cleanupAge:   o.cleanupAge,
+		metrics:      o.metrics,
+		maxRetries:   o.maxRetries,
+		retryBackoff: o.retryBackoff,
 	}
 }
 
@@ -194,12 +229,23 @@ func (r *Relay) Start(ctx context.Context) error {
 	cleanupTicker := time.NewTicker(time.Hour)
 	defer cleanupTicker.Stop()
 
+	var consecutiveFailures int
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			r.publishPending(ctx)
+			failures := r.publishPending(ctx)
+			// Adaptive backpressure: back off polling when failures occur
+			if r.retryBackoff != nil && failures > 0 {
+				consecutiveFailures++
+				delay := r.retryBackoff.NextDelay(consecutiveFailures)
+				ticker.Reset(delay)
+			} else if consecutiveFailures > 0 {
+				consecutiveFailures = 0
+				ticker.Reset(r.pollDelay)
+			}
 		case <-cleanupTicker.C:
 			r.cleanup(ctx)
 		}
@@ -209,6 +255,21 @@ func (r *Relay) Start(ctx context.Context) error {
 // publishPending fetches and publishes pending messages.
 // This is the main processing loop that runs on each poll tick.
 // Returns the number of messages that failed to publish.
+// shouldSkip returns true if a message has exceeded the max retry limit.
+// When max retries is configured, messages that have been retried too many times
+// are left as StatusFailed and logged as exhausted.
+func (r *Relay) shouldSkip(msg *Message) bool {
+	if r.maxRetries > 0 && msg.RetryCount >= r.maxRetries {
+		r.log().Warn("message exceeded max retries, skipping",
+			"id", msg.ID,
+			"event", msg.EventName,
+			"retry_count", msg.RetryCount,
+			"max_retries", r.maxRetries)
+		return true
+	}
+	return false
+}
+
 func (r *Relay) publishPending(ctx context.Context) (failures int) {
 	// Use ProcessPending for stores that support transactional processing
 	// (PostgresStore). This holds row locks for the duration of processing,
@@ -217,6 +278,9 @@ func (r *Relay) publishPending(ctx context.Context) (failures int) {
 		ProcessPending(ctx context.Context, limit int, fn func(msg *Message) error) error
 	}); ok {
 		if err := ps.ProcessPending(ctx, r.batchSize, func(msg *Message) error {
+			if r.shouldSkip(msg) {
+				return nil
+			}
 			if err := r.publishMessage(ctx, msg); err != nil {
 				r.log().Error("failed to publish message",
 					"id", msg.ID,
@@ -245,6 +309,10 @@ func (r *Relay) publishPending(ctx context.Context) (failures int) {
 	}
 
 	for _, msg := range messages {
+		if r.shouldSkip(msg) {
+			continue
+		}
+
 		if err := r.publishMessage(ctx, msg); err != nil {
 			r.log().Error("failed to publish message",
 				"id", msg.ID,
@@ -271,9 +339,33 @@ func (r *Relay) publishPending(ctx context.Context) (failures int) {
 	return failures
 }
 
-// publishMessage publishes a single message to the transport
+// publishMessage publishes a single message to the transport.
+// If the message metadata contains W3C trace context headers, a child span is created
+// to link the relay publish to the original transaction's trace.
 func (r *Relay) publishMessage(ctx context.Context, msg *Message) error {
 	start := time.Now()
+
+	// Extract trace context from metadata if present (W3C traceparent/tracestate)
+	var spanCtx trace.SpanContext
+	if msg.Metadata != nil {
+		carrier := propagation.MapCarrier(msg.Metadata)
+		extracted := otel.GetTextMapPropagator().Extract(ctx, carrier)
+		spanCtx = trace.SpanContextFromContext(extracted)
+	}
+
+	// Create a span for the relay publish operation
+	if spanCtx.IsValid() {
+		ctx = trace.ContextWithRemoteSpanContext(ctx, spanCtx)
+	}
+	tracer := otel.Tracer("outbox.relay")
+	ctx, span := tracer.Start(ctx, fmt.Sprintf("outbox.publish %s", msg.EventName),
+		trace.WithAttributes(
+			attribute.String("event.name", msg.EventName),
+			attribute.String("event.id", msg.EventID),
+			attribute.Int("retry_count", msg.RetryCount),
+		),
+		trace.WithSpanKind(trace.SpanKindProducer))
+	defer span.End()
 
 	// msg.Payload is already []byte - pass directly to transport
 	transportMsg := message.New(
@@ -281,12 +373,14 @@ func (r *Relay) publishMessage(ctx context.Context, msg *Message) error {
 		"outbox",
 		msg.Payload,
 		msg.Metadata,
+		message.WithSpanContext(span.SpanContext()),
 	)
 
 	err := r.transport.Publish(ctx, msg.EventName, transportMsg)
 	duration := time.Since(start)
 
 	if err != nil {
+		span.RecordError(err)
 		if r.metrics != nil {
 			r.metrics.RecordFailed(ctx, msg.EventName)
 		}

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -142,7 +142,6 @@ func WithRetryBackoff(strategy backoff.Strategy) RelayOption {
 	}
 }
 
-
 // NewRelay creates a new outbox relay.
 //
 // The relay polls the store for pending messages and publishes them to
@@ -252,24 +251,29 @@ func (r *Relay) Start(ctx context.Context) error {
 	}
 }
 
-// publishPending fetches and publishes pending messages.
-// This is the main processing loop that runs on each poll tick.
-// Returns the number of messages that failed to publish.
 // shouldSkip returns true if a message has exceeded the max retry limit.
-// When max retries is configured, messages that have been retried too many times
-// are left as StatusFailed and logged as exhausted.
-func (r *Relay) shouldSkip(msg *Message) bool {
+// When max retries is configured, exhausted messages are re-marked as failed
+// with a descriptive error to prevent infinite re-fetch loops.
+func (r *Relay) shouldSkip(ctx context.Context, msg *Message) bool {
 	if r.maxRetries > 0 && msg.RetryCount >= r.maxRetries {
-		r.log().Warn("message exceeded max retries, skipping",
+		r.log().Warn("message exceeded max retries",
 			"id", msg.ID,
 			"event", msg.EventName,
 			"retry_count", msg.RetryCount,
 			"max_retries", r.maxRetries)
+		// Re-mark as failed with descriptive error so GetPending doesn't re-fetch
+		// (MarkFailed increments retry_count, pushing it further past the threshold)
+		if markErr := r.store.MarkFailed(ctx, msg.ID, fmt.Errorf("exceeded max retries (%d)", r.maxRetries)); markErr != nil {
+			r.log().Error("failed to mark exhausted message", "id", msg.ID, "error", markErr)
+		}
 		return true
 	}
 	return false
 }
 
+// publishPending fetches and publishes pending messages.
+// This is the main processing loop that runs on each poll tick.
+// Returns the number of messages that failed to publish.
 func (r *Relay) publishPending(ctx context.Context) (failures int) {
 	// Use ProcessPending for stores that support transactional processing
 	// (PostgresStore). This holds row locks for the duration of processing,
@@ -278,7 +282,7 @@ func (r *Relay) publishPending(ctx context.Context) (failures int) {
 		ProcessPending(ctx context.Context, limit int, fn func(msg *Message) error) error
 	}); ok {
 		if err := ps.ProcessPending(ctx, r.batchSize, func(msg *Message) error {
-			if r.shouldSkip(msg) {
+			if r.shouldSkip(ctx, msg) {
 				return nil
 			}
 			if err := r.publishMessage(ctx, msg); err != nil {
@@ -309,7 +313,7 @@ func (r *Relay) publishPending(ctx context.Context) (failures int) {
 	}
 
 	for _, msg := range messages {
-		if r.shouldSkip(msg) {
+		if r.shouldSkip(ctx, msg) {
 			continue
 		}
 

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -119,9 +119,9 @@ func WithMetrics(m *Metrics) RelayOption {
 	}
 }
 
-// WithMaxRetries sets the maximum number of publish attempts before routing to DLQ.
-// When a message's RetryCount reaches this limit and a DLQ store is configured,
-// the message is moved to the DLQ instead of being retried.
+// WithMaxRetries sets the maximum number of publish attempts before permanently
+// marking the message as failed. Once exceeded, the message remains in the outbox
+// with StatusFailed and is no longer retried.
 // Set to 0 (default) for unlimited retries.
 func WithMaxRetries(n int) RelayOption {
 	return func(o *relayOptions) {


### PR DESCRIPTION
## Summary

### Outbox Relay Resilience
- **Max retries**: `WithMaxRetries(n)` stops retrying permanently broken messages after N attempts, leaving them as `StatusFailed` for manual inspection
- **Adaptive backpressure**: `WithRetryBackoff(strategy)` applies exponential backoff to the poll interval on consecutive failures, preventing transport hammering. Resets to normal polling on success. Reuses existing `backoff.Strategy` interface
- No DLQ routing from outbox (the outbox itself serves as the failure store — see discussion in PR)

### Outbox Trace Propagation
- Relay `publishMessage` now creates OTel spans with event name, event ID, and retry count attributes
- Extracts W3C traceparent/tracestate from message metadata to link relay publishes to original transaction traces
- Passes span context through to transport messages via `message.WithSpanContext`

### Per-Stage Latency Metrics
- `event.publish_duration_seconds` histogram on `Bus.Send()` for transport publish latency (opt-in via existing metrics config)

### DLQ Alert Hooks
- `WithDLQAlertHook(fn, threshold)` on monitor HTTP handler — callback invoked during system view refresh when DLQ pending count exceeds threshold
- Users wire to their alerting system (Slack, PagerDuty, etc.)

### Outbox Priority
- `Priority int` field on `Message` struct (0 = normal, higher = more urgent)
- PostgreSQL/MongoDB: `GetPending` sorts by `priority DESC, created_at ASC`
- Redis: Priority stored in stream entry (insertion-order limitation noted)
- Backward compatible: default priority 0, existing messages unaffected

## Test plan
- [x] `go test -race -count=1 ./...` — all 35 packages pass
- [x] `go build ./...` — clean
- [x] All changes backward compatible (new fields default to zero values)