### PR TITLE
ci: pin checkout action in dependabot-tidy workflow

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pin `actions/checkout@v6` to commit hash to resolve Scorecard PinnedDependenciesID alert.