### PR TITLE
feat(metrics): add handler, consumer lag, and event/subscriber gauges

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -66,6 +66,11 @@ type Bus struct {
 	publishedCounter   metric.Int64Counter
 	subscribedCounter  metric.Int64Counter
 	publishDuration    metric.Float64Histogram
+	handlerDuration    metric.Float64Histogram
+	handlerErrors      metric.Int64Counter
+	// Observable gauge registrations (for cleanup on Close)
+	lagRegistration   metric.Registration
+	eventRegistration metric.Registration
 }
 
 // NewBus creates a new event bus and registers it in the global registry.
@@ -122,6 +127,15 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 		bus.publishDuration, _ = meter.Float64Histogram("event.publish_duration_seconds",
 			metric.WithDescription("Time to publish a message to the transport"),
 			metric.WithUnit("s"))
+		bus.handlerDuration, _ = meter.Float64Histogram("event.handler_duration_seconds",
+			metric.WithDescription("Time spent executing a subscriber handler"),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0))
+		bus.handlerErrors, _ = meter.Int64Counter("event.handler_errors_total",
+			metric.WithDescription("Total number of subscriber handler errors"))
+
+		bus.initLagGauges(meter)
+		bus.initEventGauges(meter)
 	}
 
 	// Register in global registry (use LoadOrStore to handle race condition)
@@ -130,6 +144,75 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 	}
 
 	return bus, nil
+}
+
+// initLagGauges registers observable OTel gauges for consumer lag metrics.
+// Called during NewBus when metrics are enabled. The gauges are driven by the
+// OTel SDK's collection cycle — no polling loop is needed.
+func (b *Bus) initLagGauges(meter metric.Meter) {
+	lm, ok := b.transport.(transport.LagMonitor)
+	if !ok {
+		return
+	}
+
+	lagGauge, _ := meter.Int64ObservableGauge("event.consumer_lag",
+		metric.WithDescription("Number of unprocessed messages per event and consumer group"),
+		metric.WithUnit("{message}"))
+	pendingGauge, _ := meter.Int64ObservableGauge("event.pending_messages",
+		metric.WithDescription("Messages delivered but not yet acknowledged per event and consumer group"),
+		metric.WithUnit("{message}"))
+	oldestPendingGauge, _ := meter.Float64ObservableGauge("event.oldest_pending_seconds",
+		metric.WithDescription("Age of the oldest unacknowledged message per event and consumer group"),
+		metric.WithUnit("s"))
+
+	b.lagRegistration, _ = meter.RegisterCallback(
+		func(ctx context.Context, observer metric.Observer) error {
+			lags, err := lm.ConsumerLag(ctx)
+			if err != nil {
+				return nil // Don't fail the scrape on transient errors
+			}
+			for _, lag := range lags {
+				attrs := metric.WithAttributes(
+					attribute.String("event", lag.Event),
+					attribute.String("consumer_group", lag.ConsumerGroup),
+				)
+				observer.ObserveInt64(lagGauge, lag.Lag, attrs)
+				observer.ObserveInt64(pendingGauge, lag.PendingMessages, attrs)
+				observer.ObserveFloat64(oldestPendingGauge, lag.OldestPending.Seconds(), attrs)
+			}
+			return nil
+		},
+		lagGauge, pendingGauge, oldestPendingGauge,
+	)
+}
+
+// initEventGauges registers observable gauges for registered event count
+// and active subscriber count per event.
+func (b *Bus) initEventGauges(meter metric.Meter) {
+	registeredGauge, _ := meter.Int64ObservableGauge("event.registered_events",
+		metric.WithDescription("Number of events currently registered on this bus"),
+		metric.WithUnit("{event}"))
+	subscribersGauge, _ := meter.Int64ObservableGauge("event.active_subscribers",
+		metric.WithDescription("Number of active subscribers per event"),
+		metric.WithUnit("{subscriber}"))
+
+	b.eventRegistration, _ = meter.RegisterCallback(
+		func(ctx context.Context, observer metric.Observer) error {
+			b.eventMutex.RLock()
+			defer b.eventMutex.RUnlock()
+
+			observer.ObserveInt64(registeredGauge, int64(len(b.events)))
+
+			for _, ev := range b.events {
+				if topo, ok := ev.(eventTopology); ok {
+					observer.ObserveInt64(subscribersGauge, topo.subscriberCount(),
+						metric.WithAttributes(attribute.String("event", topo.eventName())))
+				}
+			}
+			return nil
+		},
+		registeredGauge, subscribersGauge,
+	)
 }
 
 // ID returns the bus ID
@@ -281,6 +364,14 @@ func (b *Bus) Close(ctx context.Context) error {
 			b.logger.Warn("drain timeout exceeded, proceeding with shutdown",
 				"timeout", b.drainTimeout)
 		}
+	}
+
+	// Unregister observable gauge callbacks
+	if b.lagRegistration != nil {
+		_ = b.lagRegistration.Unregister()
+	}
+	if b.eventRegistration != nil {
+		_ = b.eventRegistration.Unregister()
 	}
 
 	var errs []error
@@ -440,6 +531,20 @@ func (b *Bus) Send(ctx context.Context, eventName string, eventID string, payloa
 			metric.WithAttributes(attribute.String("event", eventName)))
 	}
 	return err
+}
+
+// recordHandlerMetrics records handler duration and error metrics for a subscriber invocation.
+func (b *Bus) recordHandlerMetrics(ctx context.Context, eventName string, duration time.Duration, handlerErr error) {
+	if !b.metricsEnabled {
+		return
+	}
+	attrs := metric.WithAttributes(attribute.String("event", eventName))
+	if b.handlerDuration != nil {
+		b.handlerDuration.Record(ctx, duration.Seconds(), attrs)
+	}
+	if handlerErr != nil && b.handlerErrors != nil {
+		b.handlerErrors.Add(ctx, 1, attrs)
+	}
 }
 
 // Recv creates a subscription to receive messages for the specified event.

--- a/bus_metrics_test.go
+++ b/bus_metrics_test.go
@@ -1,0 +1,335 @@
+package event
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+	"github.com/rbaliyan/event/v3/transport/channel"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// setupMetricsProvider installs a test meter provider and returns the reader
+// and a cleanup function that restores the previous global provider.
+func setupMetricsProvider(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		_ = provider.Shutdown(context.Background())
+	})
+	return reader
+}
+
+// collectMetrics reads all metrics from the reader and returns maps keyed by metric name.
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) (
+	counters map[string]int64,
+	histogramCounts map[string]uint64,
+	int64Gauges map[string]int64,
+	float64Gauges map[string]float64,
+) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	counters = make(map[string]int64)
+	histogramCounts = make(map[string]uint64)
+	int64Gauges = make(map[string]int64)
+	float64Gauges = make(map[string]float64)
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					counters[m.Name] += dp.Value
+				}
+			case metricdata.Histogram[float64]:
+				for _, dp := range data.DataPoints {
+					histogramCounts[m.Name] += dp.Count
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					int64Gauges[m.Name] += dp.Value
+				}
+			case metricdata.Gauge[float64]:
+				for _, dp := range data.DataPoints {
+					float64Gauges[m.Name] += dp.Value
+				}
+			}
+		}
+	}
+	return
+}
+
+func TestHandlerDurationAndErrorMetrics(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	bus := mustNewBus(t, randomString(8), WithTransport(channel.New()))
+	defer bus.Close(context.Background())
+
+	ev := New[string]("handler-metrics-test")
+	if err := Register(context.Background(), bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe a handler that alternates success/failure.
+	done := make(chan struct{}, 2)
+	var callCount int
+	ev.Subscribe(context.Background(), func(ctx context.Context, e Event[string], data string) error {
+		defer func() { done <- struct{}{} }()
+		callCount++
+		if data == "fail" {
+			return errors.New("handler error")
+		}
+		return nil
+	})
+
+	// Publish success and failure.
+	ev.Publish(context.Background(), "ok")
+	if !wait(done, 500) {
+		t.Fatal("timeout waiting for success handler")
+	}
+	ev.Publish(context.Background(), "fail")
+	if !wait(done, 500) {
+		t.Fatal("timeout waiting for failure handler")
+	}
+
+	// Allow metrics propagation.
+	time.Sleep(10 * time.Millisecond)
+
+	counters, histogramCounts, _, _ := collectMetrics(t, reader)
+
+	// handler_duration should have been recorded for both calls.
+	if histogramCounts["event.handler_duration_seconds"] != 2 {
+		t.Errorf("handler_duration_seconds count: got %d, want 2", histogramCounts["event.handler_duration_seconds"])
+	}
+
+	// handler_errors should have been recorded for the failure.
+	if counters["event.handler_errors_total"] != 1 {
+		t.Errorf("handler_errors_total: got %d, want 1", counters["event.handler_errors_total"])
+	}
+}
+
+func TestPublishAndSubscribeCounterMetrics(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	bus := mustNewBus(t, randomString(8), WithTransport(channel.New()))
+	defer bus.Close(context.Background())
+
+	ev := New[string]("counter-metrics-test")
+	if err := Register(context.Background(), bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{}, 1)
+	ev.Subscribe(context.Background(), func(ctx context.Context, e Event[string], data string) error {
+		done <- struct{}{}
+		return nil
+	})
+
+	ev.Publish(context.Background(), "hello")
+	if !wait(done, 500) {
+		t.Fatal("timeout")
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	counters, histogramCounts, _, _ := collectMetrics(t, reader)
+
+	if counters["event.published"] < 1 {
+		t.Errorf("event.published: got %d, want >= 1", counters["event.published"])
+	}
+	if counters["event.subscribed"] < 1 {
+		t.Errorf("event.subscribed: got %d, want >= 1", counters["event.subscribed"])
+	}
+	if histogramCounts["event.publish_duration_seconds"] < 1 {
+		t.Errorf("event.publish_duration_seconds: got %d, want >= 1", histogramCounts["event.publish_duration_seconds"])
+	}
+}
+
+// mockLagTransport wraps a channel transport and implements LagMonitor.
+type mockLagTransport struct {
+	transport.Transport
+	lags []transport.ConsumerLag
+}
+
+func (m *mockLagTransport) ConsumerLag(_ context.Context) ([]transport.ConsumerLag, error) {
+	return m.lags, nil
+}
+
+var _ transport.LagMonitor = (*mockLagTransport)(nil)
+
+func TestConsumerLagGauges(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	lagTransport := &mockLagTransport{
+		Transport: channel.New(),
+		lags: []transport.ConsumerLag{
+			{
+				Event:           "orders.created",
+				ConsumerGroup:   "processor",
+				Lag:             42,
+				PendingMessages: 5,
+				OldestPending:   10 * time.Second,
+			},
+		},
+	}
+
+	bus := mustNewBus(t, randomString(8), WithTransport(lagTransport))
+	defer bus.Close(context.Background())
+
+	_, _, int64Gauges, float64Gauges := collectMetrics(t, reader)
+
+	if int64Gauges["event.consumer_lag"] != 42 {
+		t.Errorf("event.consumer_lag: got %d, want 42", int64Gauges["event.consumer_lag"])
+	}
+	if int64Gauges["event.pending_messages"] != 5 {
+		t.Errorf("event.pending_messages: got %d, want 5", int64Gauges["event.pending_messages"])
+	}
+	if float64Gauges["event.oldest_pending_seconds"] != 10.0 {
+		t.Errorf("event.oldest_pending_seconds: got %f, want 10.0", float64Gauges["event.oldest_pending_seconds"])
+	}
+}
+
+func TestConsumerLagGaugesNotRegisteredWithoutLagMonitor(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	// Channel transport does not implement LagMonitor.
+	bus := mustNewBus(t, randomString(8), WithTransport(channel.New()))
+	defer bus.Close(context.Background())
+
+	_, _, int64Gauges, float64Gauges := collectMetrics(t, reader)
+
+	// No lag gauges should be present.
+	if _, ok := int64Gauges["event.consumer_lag"]; ok {
+		t.Error("event.consumer_lag should not be registered without LagMonitor")
+	}
+	if _, ok := float64Gauges["event.oldest_pending_seconds"]; ok {
+		t.Error("event.oldest_pending_seconds should not be registered without LagMonitor")
+	}
+}
+
+func TestMetricsDisabled(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	bus := mustNewBus(t, randomString(8),
+		WithTransport(channel.New()),
+		WithMetrics(false),
+	)
+	defer bus.Close(context.Background())
+
+	ev := New[string]("no-metrics-test")
+	if err := Register(context.Background(), bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{}, 1)
+	ev.Subscribe(context.Background(), func(ctx context.Context, e Event[string], data string) error {
+		done <- struct{}{}
+		return nil
+	})
+
+	ev.Publish(context.Background(), "x")
+	if !wait(done, 500) {
+		t.Fatal("timeout")
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	counters, histogramCounts, _, _ := collectMetrics(t, reader)
+
+	if counters["event.published"] != 0 {
+		t.Errorf("event.published should be 0 when metrics disabled, got %d", counters["event.published"])
+	}
+	if histogramCounts["event.handler_duration_seconds"] != 0 {
+		t.Errorf("handler_duration_seconds should be 0 when metrics disabled, got %d", histogramCounts["event.handler_duration_seconds"])
+	}
+}
+
+func TestLagCallbackUnregisteredOnClose(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	lagTransport := &mockLagTransport{
+		Transport: channel.New(),
+		lags: []transport.ConsumerLag{
+			{Event: "test", Lag: 100},
+		},
+	}
+
+	bus := mustNewBus(t, randomString(8), WithTransport(lagTransport))
+
+	// Verify lag is reported before close.
+	_, _, int64Gauges, _ := collectMetrics(t, reader)
+	if int64Gauges["event.consumer_lag"] != 100 {
+		t.Fatalf("expected lag 100 before close, got %d", int64Gauges["event.consumer_lag"])
+	}
+
+	bus.Close(context.Background())
+
+	// After close, the callback should be unregistered.
+	// Update the transport lags — they should NOT appear.
+	lagTransport.lags = []transport.ConsumerLag{
+		{Event: "test", Lag: 999},
+	}
+
+	_, _, int64Gauges, _ = collectMetrics(t, reader)
+	if int64Gauges["event.consumer_lag"] == 999 {
+		t.Error("lag callback still active after Close()")
+	}
+}
+
+func TestRegisteredEventsAndActiveSubscribersGauges(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	bus := mustNewBus(t, randomString(8), WithTransport(channel.New()))
+	defer bus.Close(context.Background())
+
+	// Before registering any events.
+	_, _, int64Gauges, _ := collectMetrics(t, reader)
+	if int64Gauges["event.registered_events"] != 0 {
+		t.Errorf("registered_events before registration: got %d, want 0", int64Gauges["event.registered_events"])
+	}
+
+	// Register two events.
+	ev1 := New[string]("gauge-event-1")
+	ev2 := New[string]("gauge-event-2")
+	if err := Register(context.Background(), bus, ev1); err != nil {
+		t.Fatal(err)
+	}
+	if err := Register(context.Background(), bus, ev2); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, int64Gauges, _ = collectMetrics(t, reader)
+	if int64Gauges["event.registered_events"] != 2 {
+		t.Errorf("registered_events: got %d, want 2", int64Gauges["event.registered_events"])
+	}
+
+	// Add subscribers to ev1.
+	ctx := context.Background()
+	noop := func(_ context.Context, _ Event[string], _ string) error { return nil }
+	ev1.Subscribe(ctx, noop)
+	ev1.Subscribe(ctx, noop)
+	ev2.Subscribe(ctx, noop)
+
+	// Allow goroutines to start.
+	time.Sleep(10 * time.Millisecond)
+
+	_, _, int64Gauges, _ = collectMetrics(t, reader)
+
+	// active_subscribers is summed across all events in collectMetrics,
+	// so total should be 3 (2 on ev1 + 1 on ev2).
+	if int64Gauges["event.active_subscribers"] != 3 {
+		t.Errorf("active_subscribers total: got %d, want 3", int64Gauges["event.active_subscribers"])
+	}
+}

--- a/event.go
+++ b/event.go
@@ -632,7 +632,9 @@ func (e *eventImpl[T]) subscribeWithCoalesce(
 					_ = out.msg.Ack(nil)
 				}
 
+				handlerStart := time.Now()
 				handlerErr := wrappedHandler(handlerCtx, e, out.value)
+				bus.recordHandlerMetrics(handlerCtx, e.name, time.Since(handlerStart), handlerErr)
 
 				if bestEffort {
 					if handlerErr != nil {
@@ -834,7 +836,9 @@ func (e *eventImpl[T]) processMessage(
 		workerGroup: subOpts.workerGroup,
 	})
 	handlerCtx = ContextWithRawPayload(handlerCtx, msg.Payload())
+	handlerStart := time.Now()
 	handlerErr := wrappedHandler(handlerCtx, e, typedData)
+	bus.recordHandlerMetrics(handlerCtx, e.name, time.Since(handlerStart), handlerErr)
 
 	if bestEffort {
 		// Already acked. Log errors and move on.


### PR DESCRIPTION
## Summary

- Add OTel handler metrics: `event.handler_duration_seconds` (histogram) and `event.handler_errors_total` (counter) recorded in subscriber dispatch paths
- Add observable gauges for transport consumer lag: `event.consumer_lag`, `event.pending_messages`, `event.oldest_pending_seconds` — driven by `LagMonitor` interface, only registered when transport supports it
- Add observable gauges for bus state: `event.registered_events` and `event.active_subscribers` (per event)
- All gauge callbacks unregistered on `Bus.Close()`

## Test plan

- [x] `TestHandlerDurationAndErrorMetrics` — verifies handler duration histogram and error counter
- [x] `TestPublishAndSubscribeCounterMetrics` — verifies existing publish/subscribe counters still work
- [x] `TestConsumerLagGauges` — verifies lag/pending/oldest gauges via mock LagMonitor transport
- [x] `TestConsumerLagGaugesNotRegisteredWithoutLagMonitor` — verifies gauges skipped for channel transport
- [x] `TestMetricsDisabled` — verifies no metrics recorded when `WithMetrics(false)`
- [x] `TestLagCallbackUnregisteredOnClose` — verifies gauge callback cleanup on close
- [x] `TestRegisteredEventsAndActiveSubscribersGauges` — verifies event/subscriber count gauges
- [x] Full test suite passes with `-race` (36 packages)