### PR TITLE
fix(metrics): use single shared meter for observable gauges

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -63,15 +63,12 @@ type Bus struct {
 	// DLQ store for automatic dead letter routing
 	dlqStore DLQStore
 	// Cached OTel instruments (initialized once during construction)
-	busAttr            attribute.KeyValue // bus="name" attribute for all metrics
-	publishedCounter   metric.Int64Counter
-	subscribedCounter  metric.Int64Counter
-	publishDuration    metric.Float64Histogram
-	handlerDuration    metric.Float64Histogram
-	handlerErrors      metric.Int64Counter
-	// Observable gauge registrations (for cleanup on Close)
-	lagRegistration   metric.Registration
-	eventRegistration metric.Registration
+	busAttr          attribute.KeyValue // bus="name" attribute for all metrics
+	publishedCounter metric.Int64Counter
+	subscribedCounter metric.Int64Counter
+	publishDuration  metric.Float64Histogram
+	handlerDuration  metric.Float64Histogram
+	handlerErrors    metric.Int64Counter
 }
 
 // NewBus creates a new event bus and registers it in the global registry.
@@ -118,10 +115,12 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 		dlqStore:         o.dlqStore,
 	}
 
-	// Initialize OTel instruments if metrics enabled
+	// Initialize OTel instruments if metrics enabled.
+	// All buses share a single meter to avoid duplicate instrument registrations
+	// that cause Prometheus exporter conflicts.
 	if bus.metricsEnabled {
 		bus.busAttr = attribute.String("bus", name)
-		meter := otel.Meter(name)
+		meter := sharedMeter()
 		bus.publishedCounter, _ = meter.Int64Counter("event.published",
 			metric.WithDescription("Total number of events published"))
 		bus.subscribedCounter, _ = meter.Int64Counter("event.subscribed",
@@ -135,9 +134,7 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0))
 		bus.handlerErrors, _ = meter.Int64Counter("event.handler_errors_total",
 			metric.WithDescription("Total number of subscriber handler errors"))
-
-		bus.initLagGauges(meter)
-		bus.initEventGauges(meter)
+		initGauges(meter)
 	}
 
 	// Register in global registry (use LoadOrStore to handle race condition)
@@ -146,79 +143,6 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 	}
 
 	return bus, nil
-}
-
-// initLagGauges registers observable OTel gauges for consumer lag metrics.
-// Called during NewBus when metrics are enabled. The gauges are driven by the
-// OTel SDK's collection cycle — no polling loop is needed.
-func (b *Bus) initLagGauges(meter metric.Meter) {
-	lm, ok := b.transport.(transport.LagMonitor)
-	if !ok {
-		return
-	}
-
-	lagGauge, _ := meter.Int64ObservableGauge("event.consumer_lag",
-		metric.WithDescription("Number of unprocessed messages per event and consumer group"),
-		metric.WithUnit("{message}"))
-	pendingGauge, _ := meter.Int64ObservableGauge("event.pending_messages",
-		metric.WithDescription("Messages delivered but not yet acknowledged per event and consumer group"),
-		metric.WithUnit("{message}"))
-	oldestPendingGauge, _ := meter.Float64ObservableGauge("event.oldest_pending_seconds",
-		metric.WithDescription("Age of the oldest unacknowledged message per event and consumer group"),
-		metric.WithUnit("s"))
-
-	busAttr := b.busAttr
-	b.lagRegistration, _ = meter.RegisterCallback(
-		func(ctx context.Context, observer metric.Observer) error {
-			lags, err := lm.ConsumerLag(ctx)
-			if err != nil {
-				return nil // Don't fail the scrape on transient errors
-			}
-			for _, lag := range lags {
-				attrs := metric.WithAttributes(
-					busAttr,
-					attribute.String("event", lag.Event),
-					attribute.String("consumer_group", lag.ConsumerGroup),
-				)
-				observer.ObserveInt64(lagGauge, lag.Lag, attrs)
-				observer.ObserveInt64(pendingGauge, lag.PendingMessages, attrs)
-				observer.ObserveFloat64(oldestPendingGauge, lag.OldestPending.Seconds(), attrs)
-			}
-			return nil
-		},
-		lagGauge, pendingGauge, oldestPendingGauge,
-	)
-}
-
-// initEventGauges registers observable gauges for registered event count
-// and active subscriber count per event.
-func (b *Bus) initEventGauges(meter metric.Meter) {
-	registeredGauge, _ := meter.Int64ObservableGauge("event.registered_events",
-		metric.WithDescription("Number of events currently registered on this bus"),
-		metric.WithUnit("{event}"))
-	subscribersGauge, _ := meter.Int64ObservableGauge("event.active_subscribers",
-		metric.WithDescription("Number of active subscribers per event"),
-		metric.WithUnit("{subscriber}"))
-
-	busAttr := b.busAttr
-	b.eventRegistration, _ = meter.RegisterCallback(
-		func(ctx context.Context, observer metric.Observer) error {
-			b.eventMutex.RLock()
-			defer b.eventMutex.RUnlock()
-
-			observer.ObserveInt64(registeredGauge, int64(len(b.events)),
-				metric.WithAttributes(busAttr))
-
-			for _, ev := range b.events {
-				if topo, ok := ev.(eventTopology); ok {
-					observer.ObserveInt64(subscribersGauge, topo.subscriberCount(),
-						metric.WithAttributes(busAttr, attribute.String("event", topo.eventName())))
-				}
-			}
-			return nil
-		},
-		registeredGauge, subscribersGauge,
-	)
 }
 
 // ID returns the bus ID
@@ -370,14 +294,6 @@ func (b *Bus) Close(ctx context.Context) error {
 			b.logger.Warn("drain timeout exceeded, proceeding with shutdown",
 				"timeout", b.drainTimeout)
 		}
-	}
-
-	// Unregister observable gauge callbacks
-	if b.lagRegistration != nil {
-		_ = b.lagRegistration.Unregister()
-	}
-	if b.eventRegistration != nil {
-		_ = b.eventRegistration.Unregister()
 	}
 
 	var errs []error

--- a/bus_gauges.go
+++ b/bus_gauges.go
@@ -1,0 +1,112 @@
+package event
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+const meterName = "github.com/rbaliyan/event/v3"
+
+var (
+	gaugesMu   sync.Mutex
+	gaugesInit bool
+)
+
+// sharedMeter returns the single OTel meter used by all buses.
+// Using one meter avoids duplicate instrument registrations that cause
+// Prometheus exporter conflicts when multiple buses exist.
+func sharedMeter() metric.Meter {
+	return otel.Meter(meterName)
+}
+
+// resetGauges allows tests to reset the gauge registration state
+// so that a new meter provider can be used.
+func resetGauges() {
+	gaugesMu.Lock()
+	defer gaugesMu.Unlock()
+	gaugesInit = false
+}
+
+// initGauges registers package-level observable gauges once.
+// A single callback iterates all buses in the global registry,
+// emitting per-bus data points distinguished by a "bus" attribute.
+func initGauges(meter metric.Meter) {
+	gaugesMu.Lock()
+	defer gaugesMu.Unlock()
+	if gaugesInit {
+		return
+	}
+	gaugesInit = true
+
+	{
+		// Event/subscriber gauges
+		registeredGauge, _ := meter.Int64ObservableGauge("event.registered_events",
+			metric.WithDescription("Number of events currently registered on this bus"),
+			metric.WithUnit("{event}"))
+		subscribersGauge, _ := meter.Int64ObservableGauge("event.active_subscribers",
+			metric.WithDescription("Number of active subscribers per event"),
+			metric.WithUnit("{subscriber}"))
+
+		// Consumer lag gauges
+		lagGauge, _ := meter.Int64ObservableGauge("event.consumer_lag",
+			metric.WithDescription("Number of unprocessed messages per event and consumer group"),
+			metric.WithUnit("{message}"))
+		pendingGauge, _ := meter.Int64ObservableGauge("event.pending_messages",
+			metric.WithDescription("Messages delivered but not yet acknowledged per event and consumer group"),
+			metric.WithUnit("{message}"))
+		oldestPendingGauge, _ := meter.Float64ObservableGauge("event.oldest_pending_seconds",
+			metric.WithDescription("Age of the oldest unacknowledged message per event and consumer group"),
+			metric.WithUnit("s"))
+
+		meter.RegisterCallback(
+			func(ctx context.Context, observer metric.Observer) error {
+				busRegistry.Range(func(key, value any) bool {
+					bus := value.(*Bus)
+					if !bus.metricsEnabled {
+						return true
+					}
+					busAttr := bus.busAttr
+
+					// Event and subscriber counts
+					bus.eventMutex.RLock()
+					observer.ObserveInt64(registeredGauge, int64(len(bus.events)),
+						metric.WithAttributes(busAttr))
+					for _, ev := range bus.events {
+						if topo, ok := ev.(eventTopology); ok {
+							observer.ObserveInt64(subscribersGauge, topo.subscriberCount(),
+								metric.WithAttributes(busAttr, attribute.String("event", topo.eventName())))
+						}
+					}
+					bus.eventMutex.RUnlock()
+
+					// Consumer lag (if transport supports it)
+					if lm, ok := bus.transport.(transport.LagMonitor); ok {
+						lags, err := lm.ConsumerLag(ctx)
+						if err == nil {
+							for _, lag := range lags {
+								attrs := metric.WithAttributes(
+									busAttr,
+									attribute.String("event", lag.Event),
+									attribute.String("consumer_group", lag.ConsumerGroup),
+								)
+								observer.ObserveInt64(lagGauge, lag.Lag, attrs)
+								observer.ObserveInt64(pendingGauge, lag.PendingMessages, attrs)
+								observer.ObserveFloat64(oldestPendingGauge, lag.OldestPending.Seconds(), attrs)
+							}
+						}
+					}
+
+					return true
+				})
+				return nil
+			},
+			registeredGauge, subscribersGauge, lagGauge, pendingGauge, oldestPendingGauge,
+		)
+	}
+}

--- a/bus_gauges.go
+++ b/bus_gauges.go
@@ -25,13 +25,6 @@ func sharedMeter() metric.Meter {
 	return otel.Meter(meterName)
 }
 
-// resetGauges allows tests to reset the gauge registration state
-// so that a new meter provider can be used.
-func resetGauges() {
-	gaugesMu.Lock()
-	defer gaugesMu.Unlock()
-	gaugesInit = false
-}
 
 // initGauges registers package-level observable gauges once.
 // A single callback iterates all buses in the global registry,
@@ -64,7 +57,7 @@ func initGauges(meter metric.Meter) {
 			metric.WithDescription("Age of the oldest unacknowledged message per event and consumer group"),
 			metric.WithUnit("s"))
 
-		meter.RegisterCallback(
+		_, _ = meter.RegisterCallback(
 			func(ctx context.Context, observer metric.Observer) error {
 				busRegistry.Range(func(key, value any) bool {
 					bus := value.(*Bus)

--- a/bus_metrics_test.go
+++ b/bus_metrics_test.go
@@ -13,6 +13,13 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
+// resetGauges resets gauge registration state so tests can use a fresh meter provider.
+func resetGauges() {
+	gaugesMu.Lock()
+	defer gaugesMu.Unlock()
+	gaugesInit = false
+}
+
 // setupMetricsProvider installs a test meter provider and returns the reader
 // and a cleanup function that restores the previous global provider.
 func setupMetricsProvider(t *testing.T) *sdkmetric.ManualReader {

--- a/bus_metrics_test.go
+++ b/bus_metrics_test.go
@@ -21,8 +21,10 @@ func setupMetricsProvider(t *testing.T) *sdkmetric.ManualReader {
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	prev := otel.GetMeterProvider()
 	otel.SetMeterProvider(provider)
+	resetGauges() // Allow gauge re-registration with the new provider
 	t.Cleanup(func() {
 		otel.SetMeterProvider(prev)
+		resetGauges()
 		_ = provider.Shutdown(context.Background())
 	})
 	return reader
@@ -256,7 +258,7 @@ func TestMetricsDisabled(t *testing.T) {
 	}
 }
 
-func TestLagCallbackUnregisteredOnClose(t *testing.T) {
+func TestLagNotReportedAfterClose(t *testing.T) {
 	reader := setupMetricsProvider(t)
 
 	lagTransport := &mockLagTransport{
@@ -276,15 +278,14 @@ func TestLagCallbackUnregisteredOnClose(t *testing.T) {
 
 	bus.Close(context.Background())
 
-	// After close, the callback should be unregistered.
-	// Update the transport lags — they should NOT appear.
+	// After close, bus is removed from registry so the callback skips it.
 	lagTransport.lags = []transport.ConsumerLag{
 		{Event: "test", Lag: 999},
 	}
 
 	_, _, int64Gauges, _ = collectMetrics(t, reader)
 	if int64Gauges["event.consumer_lag"] == 999 {
-		t.Error("lag callback still active after Close()")
+		t.Error("lag still reported after Close()")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace per-bus `otel.Meter(busName)` with a single package-level `otel.Meter("github.com/rbaliyan/event/v3")` shared by all buses
- Replace per-bus `RegisterCallback` for observable gauges with one package-level callback that iterates the global bus registry
- Each bus's data points are distinguished by the `bus` attribute
- Closed buses are automatically skipped since `Bus.Close()` removes them from the registry

Fixes Prometheus exporter error: `collected metric "event_registered_events" was collected before with the same name and label values` when multiple buses exist.

## Test plan

- [x] `TestMultiBusMetricsDistinguishedByBusLabel` — two buses produce distinct data points
- [x] `TestLagNotReportedAfterClose` — closed bus no longer emits lag gauges
- [x] All metrics tests pass (8 tests)
- [x] Full test suite passes with `-race` (36 packages)