### PR TITLE
chore: update Go to 1.25.9

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5.4.0
         with:
-          go-version: '1.25.8'
+          go-version-file: go.mod
 
       - name: Run go mod tidy
         run: go mod tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.8'
+          go-version-file: go.mod
 
       - name: Run tests
         run: go test -race ./...

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: '1.25.8'
+          go-version-file: go.mod
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rbaliyan/event/v3
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20250520111509-a70c2aa677fa


### PR DESCRIPTION
## Summary
- Update Go version from 1.25.8 to 1.25.9 in go.mod
- Switch release, dependabot-tidy, and security workflows to `go-version-file: go.mod`

## Test plan
- [ ] CI passes with Go 1.25.9
- [ ] All existing tests pass