### PR TITLE
feat(transport): add bridge transport for source-to-sink forwarding

### DIFF
--- a/transport/bridge/bridge.go
+++ b/transport/bridge/bridge.go
@@ -1,0 +1,335 @@
+package bridge
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// Errors returned by [New].
+var (
+	ErrSourceRequired = errors.New("bridge: source transport is required")
+	ErrSinkRequired   = errors.New("bridge: sink transport is required")
+)
+
+// defaultPumpBuffer is the source-subscription buffer size when the
+// caller does not override it with [WithPumpBuffer].
+const defaultPumpBuffer = 256
+
+// Transport forwards messages from a [Source] into a [Sink] through a
+// composable middleware pipeline.
+//
+// From the bus's perspective Transport behaves like the sink:
+// [Publish], [Subscribe], [RegisterEvent] and [UnregisterEvent] all
+// delegate to the sink. The source participates only inside the pump
+// that runs per registered event.
+//
+// The base Transport performs no deduplication, no dead-letter
+// handling, and no distributed coordination. All such behaviours are
+// supplied by middleware passed to [WithMiddleware] so each caller
+// enables only what their source/sink pair requires.
+type Transport struct {
+	status int32 // 1 = open, 0 = closed
+
+	source Source
+	sink   Sink
+
+	middleware        []Middleware
+	pumpBuffer        int
+	pumpSubscribeOpts []transport.SubscribeOption
+
+	logger  *slog.Logger
+	onError func(error)
+
+	mu    sync.Mutex
+	pumps map[string]*pump
+}
+
+// New constructs a bridge. Both source and sink MUST be non-nil.
+//
+// source supplies messages (typically a receive-only transport such as
+// a MongoDB change stream). Its Publish is never called — the [Source]
+// interface does not even require it.
+//
+// sink receives forwarded messages and exposes the subscription
+// surface consumed by the bus. It MUST support Publish.
+//
+// Any [transport.Transport] satisfies both [Source] and [Sink]
+// structurally, so existing transports are valid arguments without
+// wrapping.
+func New(source Source, sink Sink, opts ...Option) (*Transport, error) {
+	if source == nil {
+		return nil, ErrSourceRequired
+	}
+	if sink == nil {
+		return nil, ErrSinkRequired
+	}
+
+	t := &Transport{
+		status:     1,
+		source:     source,
+		sink:       sink,
+		pumpBuffer: defaultPumpBuffer,
+		logger:     transport.Logger("transport>bridge"),
+		onError:    func(error) {},
+		pumps:      make(map[string]*pump),
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t, nil
+}
+
+func (t *Transport) isOpen() bool {
+	return atomic.LoadInt32(&t.status) == 1
+}
+
+// RegisterEvent registers the event on the sink, tolerates the same
+// on the source (sources with global subscriptions often return
+// ErrEventAlreadyExists), then starts a pump that forwards source
+// messages for name through the middleware pipeline.
+//
+// A successful RegisterEvent guarantees that a pump is running and
+// Subscribe on the sink will see the forwarded messages.
+// pumpRegistering is a sentinel stored in the pumps map while a
+// RegisterEvent is in progress. This prevents a concurrent call for
+// the same name from starting a second pump.
+var pumpRegistering = &pump{}
+
+func (t *Transport) RegisterEvent(ctx context.Context, name string) error {
+	if !t.isOpen() {
+		return transport.ErrTransportClosed
+	}
+
+	// Acquire a per-name registration slot under the lock. If the
+	// name already has a pump (or another goroutine is registering it)
+	// we return immediately. This eliminates the race where two
+	// concurrent RegisterEvent("same") both pass an existence check.
+	t.mu.Lock()
+	if t.pumps == nil {
+		t.mu.Unlock()
+		return transport.ErrTransportClosed
+	}
+	if _, exists := t.pumps[name]; exists {
+		t.mu.Unlock()
+		return transport.ErrEventAlreadyExists
+	}
+	t.pumps[name] = pumpRegistering // sentinel: slot reserved
+	t.mu.Unlock()
+
+	// On any failure path, release the slot so a retry can succeed.
+	cleanup := func() {
+		t.mu.Lock()
+		if t.pumps != nil && t.pumps[name] == pumpRegistering {
+			delete(t.pumps, name)
+		}
+		t.mu.Unlock()
+	}
+
+	if err := t.sink.RegisterEvent(ctx, name); err != nil {
+		cleanup()
+		return err
+	}
+
+	// Sources often register lazily or at the pipeline level; treat
+	// ErrEventAlreadyExists as benign.
+	if err := t.source.RegisterEvent(ctx, name); err != nil &&
+		!errors.Is(err, transport.ErrEventAlreadyExists) {
+		t.logger.Warn("source register failed; continuing",
+			"event", name, "error", err)
+	}
+
+	p, err := startPump(ctx, pumpConfig{
+		name:              name,
+		source:            t.source,
+		sink:              t.sink,
+		middleware:        t.middleware,
+		bufferSize:        t.pumpBuffer,
+		logger:            t.logger.With("event", name),
+		onError:           t.onError,
+		pumpSubscribeOpts: t.pumpSubscribeOpts,
+	})
+	if err != nil {
+		cleanup()
+		return err
+	}
+
+	t.mu.Lock()
+	if t.pumps == nil || !t.isOpen() {
+		t.mu.Unlock()
+		p.stop(ctx)
+		return transport.ErrTransportClosed
+	}
+	t.pumps[name] = p // replace sentinel with real pump
+	t.mu.Unlock()
+
+	t.logger.Debug("registered event", "event", name)
+	return nil
+}
+
+// UnregisterEvent stops the pump for name and unregisters the event on
+// both underlying transports. Returns [transport.ErrEventNotRegistered]
+// if name was not registered via this bridge.
+func (t *Transport) UnregisterEvent(ctx context.Context, name string) error {
+	if !t.isOpen() {
+		return transport.ErrTransportClosed
+	}
+
+	t.mu.Lock()
+	if t.pumps == nil {
+		t.mu.Unlock()
+		return transport.ErrTransportClosed
+	}
+	p, ok := t.pumps[name]
+	if !ok || p == pumpRegistering {
+		t.mu.Unlock()
+		return transport.ErrEventNotRegistered
+	}
+	delete(t.pumps, name)
+	t.mu.Unlock()
+
+	p.stop(ctx)
+
+	if err := t.source.UnregisterEvent(ctx, name); err != nil {
+		t.logger.Warn("source unregister failed",
+			"event", name, "error", err)
+	}
+	if err := t.sink.UnregisterEvent(ctx, name); err != nil {
+		t.logger.Warn("sink unregister failed",
+			"event", name, "error", err)
+	}
+
+	t.logger.Debug("unregistered event", "event", name)
+	return nil
+}
+
+// Publish delegates to the sink. Direct publishes bypass the source
+// and the middleware pipeline — they are normal sink publishes. Use
+// this for synthetic events originating in the application rather
+// than from the source.
+func (t *Transport) Publish(ctx context.Context, name string, msg transport.Message) error {
+	if !t.isOpen() {
+		return transport.ErrTransportClosed
+	}
+	return t.sink.Publish(ctx, name, msg)
+}
+
+// Subscribe delegates to the sink. Consumers read from the sink, which
+// supplies the consumer-group / load-balancing semantics the bridge
+// exists to provide.
+func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transport.SubscribeOption) (transport.Subscription, error) {
+	if !t.isOpen() {
+		return nil, transport.ErrTransportClosed
+	}
+	return t.sink.Subscribe(ctx, name, opts...)
+}
+
+// Close stops every pump and closes both underlying transports. The
+// first error is returned; others are logged.
+func (t *Transport) Close(ctx context.Context) error {
+	if !atomic.CompareAndSwapInt32(&t.status, 1, 0) {
+		return nil
+	}
+
+	t.mu.Lock()
+	pumps := t.pumps
+	t.pumps = nil
+	t.mu.Unlock()
+
+	for _, p := range pumps {
+		p.stop(ctx)
+	}
+
+	var firstErr error
+	if err := t.source.Close(ctx); err != nil {
+		t.logger.Warn("source close failed", "error", err)
+		firstErr = err
+	}
+	if err := t.sink.Close(ctx); err != nil {
+		t.logger.Warn("sink close failed", "error", err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	t.logger.Debug("transport closed")
+	return firstErr
+}
+
+// Health reports the composed health of source and sink. The bridge is
+// Healthy only when both are healthy. Transports that do not implement
+// [transport.HealthChecker] are assumed healthy.
+func (t *Transport) Health(ctx context.Context) *transport.HealthCheckResult {
+	start := time.Now()
+	result := &transport.HealthCheckResult{
+		CheckedAt:  start,
+		Details:    make(map[string]any),
+		Components: make(map[string]*transport.HealthCheckResult),
+	}
+
+	if !t.isOpen() {
+		result.Status = transport.HealthStatusUnhealthy
+		result.Message = "transport is closed"
+		result.Latency = time.Since(start)
+		return result
+	}
+
+	result.Status = transport.HealthStatusHealthy
+	result.Message = "bridge transport is healthy"
+
+	if checker, ok := t.source.(transport.HealthChecker); ok {
+		h := checker.Health(ctx)
+		result.Components["source"] = h
+		switch h.Status {
+		case transport.HealthStatusUnhealthy:
+			result.Status = transport.HealthStatusUnhealthy
+			result.Message = "source unhealthy — no events flowing"
+		case transport.HealthStatusDegraded:
+			if result.Status == transport.HealthStatusHealthy {
+				result.Status = transport.HealthStatusDegraded
+				result.Message = "source degraded"
+			}
+		}
+	}
+	if checker, ok := t.sink.(transport.HealthChecker); ok {
+		h := checker.Health(ctx)
+		result.Components["sink"] = h
+		switch h.Status {
+		case transport.HealthStatusUnhealthy:
+			result.Status = transport.HealthStatusUnhealthy
+			result.Message = "sink unhealthy — events cannot be forwarded"
+		case transport.HealthStatusDegraded:
+			if result.Status == transport.HealthStatusHealthy {
+				result.Status = transport.HealthStatusDegraded
+				result.Message = "sink degraded"
+			}
+		}
+	}
+
+	t.mu.Lock()
+	pumpCount := len(t.pumps)
+	t.mu.Unlock()
+
+	result.Latency = time.Since(start)
+	result.Details["type"] = "bridge"
+	result.Details["pumps"] = pumpCount
+	result.Details["middleware"] = len(t.middleware)
+	return result
+}
+
+// Name identifies this transport in topology reports.
+func (t *Transport) Name() string { return "bridge" }
+
+// Compile-time interface checks.
+var (
+	_ transport.Transport     = (*Transport)(nil)
+	_ transport.HealthChecker = (*Transport)(nil)
+	_ transport.Named         = (*Transport)(nil)
+)

--- a/transport/bridge/bridge_test.go
+++ b/transport/bridge/bridge_test.go
@@ -1,0 +1,797 @@
+package bridge_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+	"github.com/rbaliyan/event/v3/transport/bridge"
+)
+
+// -----------------------------------------------------------------------------
+// Fakes
+// -----------------------------------------------------------------------------
+
+// fakeTransport is a minimal test double that implements transport.Transport.
+// It records published messages and exposes a channel for injecting
+// messages into subscribers (simulating a source).
+type fakeTransport struct {
+	mu            sync.Mutex
+	events        map[string]*fakeEvent
+	publishErr    error
+	publishErrMap map[string]error // per-event override
+	published     []publishRecord  // every successful Publish call
+	publishHook   func(name string, msg transport.Message)
+	unregCount    int
+	closed        bool
+}
+
+type fakeEvent struct {
+	name        string
+	subscribers []*fakeSub
+}
+
+type fakeSub struct {
+	id     string
+	ch     chan transport.Message
+	closed atomic.Bool
+	done   chan struct{}
+}
+
+type publishRecord struct {
+	Event string
+	Msg   transport.Message
+}
+
+func newFakeTransport() *fakeTransport {
+	return &fakeTransport{
+		events:        make(map[string]*fakeEvent),
+		publishErrMap: make(map[string]error),
+	}
+}
+
+func (f *fakeTransport) RegisterEvent(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.events[name]; ok {
+		return transport.ErrEventAlreadyExists
+	}
+	f.events[name] = &fakeEvent{name: name}
+	return nil
+}
+
+func (f *fakeTransport) UnregisterEvent(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ev, ok := f.events[name]
+	if !ok {
+		return transport.ErrEventNotRegistered
+	}
+	for _, s := range ev.subscribers {
+		s.closeOnce()
+	}
+	delete(f.events, name)
+	f.unregCount++
+	return nil
+}
+
+func (f *fakeTransport) Publish(_ context.Context, name string, msg transport.Message) error {
+	f.mu.Lock()
+	if err, ok := f.publishErrMap[name]; ok && err != nil {
+		f.mu.Unlock()
+		return err
+	}
+	if f.publishErr != nil {
+		err := f.publishErr
+		f.mu.Unlock()
+		return err
+	}
+	f.published = append(f.published, publishRecord{Event: name, Msg: msg})
+	hook := f.publishHook
+	f.mu.Unlock()
+
+	if hook != nil {
+		hook(name, msg)
+	}
+
+	// Also deliver to any subscribers of this event so the fake can
+	// act as a sink that clients subscribe to.
+	f.mu.Lock()
+	ev := f.events[name]
+	var subs []*fakeSub
+	if ev != nil {
+		subs = append(subs, ev.subscribers...)
+	}
+	f.mu.Unlock()
+
+	for _, s := range subs {
+		if s.closed.Load() {
+			continue
+		}
+		select {
+		case s.ch <- msg:
+		default:
+		}
+	}
+	return nil
+}
+
+func (f *fakeTransport) Subscribe(_ context.Context, name string, _ ...transport.SubscribeOption) (transport.Subscription, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ev, ok := f.events[name]
+	if !ok {
+		return nil, transport.ErrEventNotRegistered
+	}
+	s := &fakeSub{
+		id:   transport.NewID(),
+		ch:   make(chan transport.Message, 64),
+		done: make(chan struct{}),
+	}
+	ev.subscribers = append(ev.subscribers, s)
+	return s, nil
+}
+
+func (f *fakeTransport) Close(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+	for _, ev := range f.events {
+		for _, s := range ev.subscribers {
+			s.closeOnce()
+		}
+	}
+	return nil
+}
+
+// inject pushes a message to every subscriber of name. Simulates a
+// receive-only source emitting an event.
+func (f *fakeTransport) inject(name string, msg transport.Message) {
+	f.mu.Lock()
+	ev := f.events[name]
+	var subs []*fakeSub
+	if ev != nil {
+		subs = append(subs, ev.subscribers...)
+	}
+	f.mu.Unlock()
+	for _, s := range subs {
+		if s.closed.Load() {
+			continue
+		}
+		s.ch <- msg
+	}
+}
+
+func (f *fakeTransport) publishedEvents() []publishRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]publishRecord, len(f.published))
+	copy(out, f.published)
+	return out
+}
+
+func (f *fakeTransport) setPublishErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.publishErr = err
+}
+
+func (s *fakeSub) ID() string                              { return s.id }
+func (s *fakeSub) Messages() <-chan transport.Message      { return s.ch }
+func (s *fakeSub) Close(_ context.Context) error           { s.closeOnce(); return nil }
+func (s *fakeSub) closeOnce() {
+	if s.closed.CompareAndSwap(false, true) {
+		close(s.done)
+		close(s.ch)
+	}
+}
+
+// testMessage is a minimal transport.Message for tests.
+type testMessage struct {
+	id      string
+	payload []byte
+	meta    map[string]string
+	ackFn   func(error) error
+}
+
+func newMsg(id string) *testMessage {
+	return &testMessage{id: id, meta: map[string]string{}}
+}
+
+func (m *testMessage) ID() string                  { return m.id }
+func (m *testMessage) Source() string              { return "test" }
+func (m *testMessage) Payload() []byte             { return m.payload }
+func (m *testMessage) Metadata() map[string]string { return m.meta }
+func (m *testMessage) Timestamp() time.Time        { return time.Unix(0, 0) }
+func (m *testMessage) RetryCount() int             { return 0 }
+func (m *testMessage) Context() context.Context    { return context.Background() }
+func (m *testMessage) Ack(err error) error {
+	if m.ackFn != nil {
+		return m.ackFn(err)
+	}
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+// Constructor
+// -----------------------------------------------------------------------------
+
+func TestNew_errors(t *testing.T) {
+	sink := newFakeTransport()
+	src := newFakeTransport()
+
+	if _, err := bridge.New(nil, sink); !errors.Is(err, bridge.ErrSourceRequired) {
+		t.Errorf("nil source: got %v, want ErrSourceRequired", err)
+	}
+	if _, err := bridge.New(src, nil); !errors.Is(err, bridge.ErrSinkRequired) {
+		t.Errorf("nil sink: got %v, want ErrSinkRequired", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Basic pump: source → sink
+// -----------------------------------------------------------------------------
+
+func TestPump_forwardsMessages(t *testing.T) {
+	src := newFakeTransport()
+	sink := newFakeTransport()
+	ctx := context.Background()
+
+	// Pre-register on source so pump can subscribe.
+	if err := src.RegisterEvent(ctx, "orders"); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := bridge.New(src, sink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = b.Close(ctx) })
+
+	if err := b.RegisterEvent(ctx, "orders"); err != nil {
+		t.Fatal(err)
+	}
+
+	src.inject("orders", newMsg("m1"))
+	src.inject("orders", newMsg("m2"))
+
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 2 }, time.Second)
+
+	got := sink.publishedEvents()
+	if got[0].Event != "orders" || got[0].Msg.ID() != "m1" {
+		t.Errorf("msg[0] = %+v, want event=orders id=m1", got[0])
+	}
+	if got[1].Msg.ID() != "m2" {
+		t.Errorf("msg[1].ID = %s, want m2", got[1].Msg.ID())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Publish / Subscribe delegate to sink
+// -----------------------------------------------------------------------------
+
+func TestPublishDelegatesToSink(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+
+	if err := b.RegisterEvent(ctx, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Publish(ctx, "x", newMsg("direct")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The direct publish should appear on the sink (once), and NOT be
+	// fed back through the source pump.
+	got := sink.publishedEvents()
+	if len(got) != 1 || got[0].Msg.ID() != "direct" {
+		t.Errorf("sink got %+v, want 1 direct publish", got)
+	}
+}
+
+func TestSubscribeDelegatesToSink(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+
+	_ = b.RegisterEvent(ctx, "x")
+
+	sub, err := b.Subscribe(ctx, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sub.Close(ctx) })
+
+	src.inject("x", newMsg("through"))
+
+	select {
+	case msg := <-sub.Messages():
+		if msg.ID() != "through" {
+			t.Errorf("got %s, want through", msg.ID())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no message delivered to subscriber")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Middleware: Dedup
+// -----------------------------------------------------------------------------
+
+func TestDedupMiddleware_suppressesDuplicates(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	coord := bridge.NewMemoryCoordinator()
+	var skipped int32
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(
+			bridge.Dedup(coord, bridge.DefaultDedupKey, time.Minute,
+				bridge.WithDedupOnSkip(func(_ string, _ transport.Message) {
+					atomic.AddInt32(&skipped, 1)
+				}),
+			),
+		),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	// Same ID injected three times — only the first should publish.
+	src.inject("x", newMsg("dup"))
+	src.inject("x", newMsg("dup"))
+	src.inject("x", newMsg("dup"))
+
+	waitFor(t, func() bool {
+		return len(sink.publishedEvents()) == 1 && atomic.LoadInt32(&skipped) == 2
+	}, time.Second)
+
+	if got := len(sink.publishedEvents()); got != 1 {
+		t.Errorf("sink publishes = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&skipped); got != 2 {
+		t.Errorf("skipped = %d, want 2", got)
+	}
+}
+
+func TestDedupMiddleware_differentIDsPassThrough(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	coord := bridge.NewMemoryCoordinator()
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.Dedup(coord, bridge.DefaultDedupKey, time.Minute)),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	for i := range 5 {
+		src.inject("x", newMsg(fmt.Sprintf("m%d", i)))
+	}
+
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 5 }, time.Second)
+}
+
+func TestDedup_failClosedOnCoordinatorError(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	sentinel := errors.New("coord down")
+	coord := &erroringCoord{err: sentinel}
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.Dedup(coord, bridge.DefaultDedupKey, time.Minute)),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	var acked sync.WaitGroup
+	acked.Add(1)
+	msg := newMsg("m1")
+	var ackErr error
+	msg.ackFn = func(err error) error { ackErr = err; acked.Done(); return nil }
+
+	src.inject("x", msg)
+	acked.Wait()
+
+	if len(sink.publishedEvents()) != 0 {
+		t.Errorf("sink should not have received message, got %d", len(sink.publishedEvents()))
+	}
+	if !errors.Is(ackErr, sentinel) {
+		t.Errorf("ack err = %v, want coord down (nack for redelivery)", ackErr)
+	}
+}
+
+func TestDedup_failOpenOnCoordinatorError(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	coord := &erroringCoord{err: errors.New("down")}
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.Dedup(coord, bridge.DefaultDedupKey, time.Minute,
+			bridge.WithDedupFailOpen(true),
+		)),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("m1"))
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 1 }, time.Second)
+}
+
+// -----------------------------------------------------------------------------
+// Middleware: DLQ
+// -----------------------------------------------------------------------------
+
+func TestDLQMiddleware_catchesSinkErrors(t *testing.T) {
+	src, sink, dlq := newFakeTransport(), newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+	_ = dlq.RegisterEvent(ctx, "x.failed")
+
+	sentinel := errors.New("sink unavailable")
+	sink.setPublishErr(sentinel)
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.DLQ(dlq, "x.failed")),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	var ackErr error
+	var acked sync.WaitGroup
+	acked.Add(1)
+	msg := newMsg("failing")
+	msg.ackFn = func(err error) error { ackErr = err; acked.Done(); return nil }
+
+	src.inject("x", msg)
+	acked.Wait()
+
+	if got := len(dlq.publishedEvents()); got != 1 {
+		t.Errorf("DLQ publishes = %d, want 1", got)
+	}
+	if ackErr != nil {
+		t.Errorf("ack err = %v, want nil (DLQ swallowed the error)", ackErr)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Middleware: Filter / Transform / Observe
+// -----------------------------------------------------------------------------
+
+func TestFilterMiddleware(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.Filter(func(_ string, m transport.Message) bool {
+			return m.ID() != "skip"
+		})),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("keep1"))
+	src.inject("x", newMsg("skip"))
+	src.inject("x", newMsg("keep2"))
+
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 2 }, time.Second)
+	ids := []string{sink.publishedEvents()[0].Msg.ID(), sink.publishedEvents()[1].Msg.ID()}
+	if ids[0] != "keep1" || ids[1] != "keep2" {
+		t.Errorf("got %v, want [keep1 keep2]", ids)
+	}
+}
+
+func TestTransformMiddleware(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.Transform(func(_ string, m transport.Message) transport.Message {
+			rewritten := newMsg(m.ID() + "-rewritten")
+			return rewritten
+		})),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("a"))
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 1 }, time.Second)
+
+	if got := sink.publishedEvents()[0].Msg.ID(); got != "a-rewritten" {
+		t.Errorf("got %s, want a-rewritten", got)
+	}
+}
+
+func TestObserveMiddleware_hooksFire(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	var receive, publish, errHook int32
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.Observe(bridge.Hooks{
+			OnReceive: func(_ string, _ transport.Message) { atomic.AddInt32(&receive, 1) },
+			OnPublish: func(_ string, _ transport.Message) { atomic.AddInt32(&publish, 1) },
+			OnError:   func(_ string, _ transport.Message, _ error) { atomic.AddInt32(&errHook, 1) },
+		})),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("ok"))
+	// Wait for the success path to complete before flipping the sink
+	// into an error state — otherwise a fast test can observe the ok
+	// message after the setPublishErr took effect.
+	waitFor(t, func() bool { return atomic.LoadInt32(&publish) == 1 }, time.Second)
+
+	sink.setPublishErr(errors.New("boom"))
+	src.inject("x", newMsg("bad"))
+
+	waitFor(t, func() bool { return atomic.LoadInt32(&errHook) == 1 }, time.Second)
+	if got := atomic.LoadInt32(&receive); got != 2 {
+		t.Errorf("OnReceive fired %d times, want 2", got)
+	}
+	if got := atomic.LoadInt32(&publish); got != 1 {
+		t.Errorf("OnPublish fired %d times, want 1", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Panic recovery
+// -----------------------------------------------------------------------------
+
+func TestPump_recoversFromPanic(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	panicMW := func(next bridge.Handler) bridge.Handler {
+		return func(ctx context.Context, ev string, m transport.Message) error {
+			if m.ID() == "boom" {
+				panic("explode")
+			}
+			return next(ctx, ev, m)
+		}
+	}
+
+	b, _ := bridge.New(src, sink, bridge.WithMiddleware(panicMW))
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	// Panic first, then a normal message — pump must still deliver.
+	src.inject("x", newMsg("boom"))
+	src.inject("x", newMsg("ok"))
+
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 1 }, time.Second)
+	if got := sink.publishedEvents()[0].Msg.ID(); got != "ok" {
+		t.Errorf("recovered pump delivered %s, want ok", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Close / Unregister lifecycle
+// -----------------------------------------------------------------------------
+
+func TestClose_stopsPumps(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink)
+	_ = b.RegisterEvent(ctx, "x")
+
+	if err := b.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Second close is a no-op and must not panic.
+	if err := b.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.RegisterEvent(ctx, "y"); !errors.Is(err, transport.ErrTransportClosed) {
+		t.Errorf("RegisterEvent after close = %v, want ErrTransportClosed", err)
+	}
+}
+
+func TestUnregisterEvent(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	if err := b.UnregisterEvent(ctx, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.UnregisterEvent(ctx, "x"); !errors.Is(err, transport.ErrEventNotRegistered) {
+		t.Errorf("double unregister = %v, want ErrEventNotRegistered", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Coordinator implementations
+// -----------------------------------------------------------------------------
+
+func TestMemoryCoordinator_claimsAndExpires(t *testing.T) {
+	ctx := context.Background()
+	c := bridge.NewMemoryCoordinator()
+
+	ok, err := c.Claim(ctx, "k", 50*time.Millisecond)
+	if err != nil || !ok {
+		t.Fatalf("first claim: ok=%v err=%v", ok, err)
+	}
+	ok, err = c.Claim(ctx, "k", 50*time.Millisecond)
+	if err != nil || ok {
+		t.Errorf("second claim: ok=%v err=%v, want false", ok, err)
+	}
+
+	time.Sleep(70 * time.Millisecond)
+
+	ok, err = c.Claim(ctx, "k", 50*time.Millisecond)
+	if err != nil || !ok {
+		t.Errorf("claim after expiry: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestNoopCoordinator_alwaysClaims(t *testing.T) {
+	ctx := context.Background()
+	c := bridge.NoopCoordinator{}
+	for range 3 {
+		ok, err := c.Claim(ctx, "same", time.Minute)
+		if err != nil || !ok {
+			t.Errorf("noop claim: ok=%v err=%v", ok, err)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Health
+// -----------------------------------------------------------------------------
+
+// healthyFakeTransport wraps fakeTransport and implements HealthChecker.
+type healthyFakeTransport struct {
+	*fakeTransport
+	healthStatus transport.HealthStatus
+	healthMsg    string
+}
+
+func newHealthFake(status transport.HealthStatus, msg string) *healthyFakeTransport {
+	return &healthyFakeTransport{
+		fakeTransport: newFakeTransport(),
+		healthStatus:  status,
+		healthMsg:     msg,
+	}
+}
+
+func (h *healthyFakeTransport) Health(_ context.Context) *transport.HealthCheckResult {
+	return &transport.HealthCheckResult{
+		Status:  h.healthStatus,
+		Message: h.healthMsg,
+	}
+}
+
+func TestHealth_BothHealthy(t *testing.T) {
+	src := newHealthFake(transport.HealthStatusHealthy, "ok")
+	sink := newHealthFake(transport.HealthStatusHealthy, "ok")
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	h := b.Health(ctx)
+	if h.Status != transport.HealthStatusHealthy {
+		t.Errorf("status = %v, want Healthy", h.Status)
+	}
+	if h.Components["source"] == nil || h.Components["sink"] == nil {
+		t.Error("expected source and sink components in health result")
+	}
+}
+
+func TestHealth_SourceUnhealthy(t *testing.T) {
+	src := newHealthFake(transport.HealthStatusUnhealthy, "source down")
+	sink := newHealthFake(transport.HealthStatusHealthy, "ok")
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+
+	h := b.Health(ctx)
+	if h.Status != transport.HealthStatusUnhealthy {
+		t.Errorf("status = %v, want Unhealthy", h.Status)
+	}
+}
+
+func TestHealth_SinkDegraded(t *testing.T) {
+	src := newHealthFake(transport.HealthStatusHealthy, "ok")
+	sink := newHealthFake(transport.HealthStatusDegraded, "slow")
+	ctx := context.Background()
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+
+	h := b.Health(ctx)
+	if h.Status != transport.HealthStatusDegraded {
+		t.Errorf("status = %v, want Degraded", h.Status)
+	}
+}
+
+func TestHealth_AfterClose(t *testing.T) {
+	src := newHealthFake(transport.HealthStatusHealthy, "ok")
+	sink := newHealthFake(transport.HealthStatusHealthy, "ok")
+	ctx := context.Background()
+
+	b, _ := bridge.New(src, sink)
+	_ = b.Close(ctx)
+
+	h := b.Health(ctx)
+	if h.Status != transport.HealthStatusUnhealthy {
+		t.Errorf("status = %v, want Unhealthy (closed)", h.Status)
+	}
+}
+
+func TestHealth_NonHealthCheckerTransports(t *testing.T) {
+	// Plain fakeTransport does NOT implement HealthChecker.
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+
+	b, _ := bridge.New(src, sink)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+
+	h := b.Health(ctx)
+	if h.Status != transport.HealthStatusHealthy {
+		t.Errorf("status = %v, want Healthy (non-checker assumed healthy)", h.Status)
+	}
+	if len(h.Components) != 0 {
+		t.Errorf("components = %v, want none for non-checker transports", h.Components)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+type erroringCoord struct{ err error }
+
+func (e *erroringCoord) Claim(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	return false, e.err
+}
+
+// waitFor polls cond until it returns true or timeout expires.
+func waitFor(t *testing.T, cond func() bool, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timeout waiting for condition")
+}

--- a/transport/bridge/coordinator.go
+++ b/transport/bridge/coordinator.go
@@ -1,0 +1,112 @@
+package bridge
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Coordinator decides which bridge replica publishes a given message.
+//
+// Implementations MUST be safe for concurrent use across goroutines.
+// Implementations SHOULD be safe for concurrent use across processes
+// when they are the operative unit of coordination (which is the whole
+// point). Single-process implementations are only useful for testing
+// or single-replica deployments.
+type Coordinator interface {
+	// Claim atomically asserts ownership of the given dedup key for this
+	// replica. Returns true if this call acquired the key, false if
+	// another replica has already claimed it.
+	//
+	// TTL bounds how long the claim is remembered. The claim MUST expire
+	// after TTL to cap memory/storage usage, but SHOULD live at least as
+	// long as the source's redelivery window so replays don't trigger
+	// double publishes.
+	//
+	// An error return indicates the coordinator itself is unhealthy;
+	// the bridge applies its fail-open or fail-closed policy.
+	Claim(ctx context.Context, key string, ttl time.Duration) (bool, error)
+}
+
+// NoopCoordinator disables deduplication: every call to Claim returns
+// true. Every bridge replica publishes every source message, producing
+// duplicates in the sink proportional to the replica count.
+//
+// Use this only when:
+//   - Running a single replica, or
+//   - The sink itself deduplicates by message ID (e.g. a keyed store), or
+//   - Consumers are idempotent and duplicate publish cost is acceptable.
+type NoopCoordinator struct{}
+
+// Claim always returns true.
+func (NoopCoordinator) Claim(_ context.Context, _ string, _ time.Duration) (bool, error) {
+	return true, nil
+}
+
+// MemoryCoordinator is a process-local deduplication coordinator backed
+// by an in-memory map. It is safe for concurrent use within a single
+// process but provides NO coordination across replicas.
+//
+// Use for tests, single-replica deployments, or as a local cache layer
+// in front of a cross-process coordinator.
+type MemoryCoordinator struct {
+	mu    sync.Mutex
+	keys  map[string]time.Time
+	clock func() time.Time
+}
+
+// NewMemoryCoordinator returns a new in-process coordinator.
+func NewMemoryCoordinator() *MemoryCoordinator {
+	return &MemoryCoordinator{
+		keys:  make(map[string]time.Time),
+		clock: time.Now,
+	}
+}
+
+// Claim records the key with an expiry of now+ttl. Returns true if the
+// key was previously unclaimed or its prior claim has expired.
+func (c *MemoryCoordinator) Claim(_ context.Context, key string, ttl time.Duration) (bool, error) {
+	now := c.clock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if exp, ok := c.keys[key]; ok && exp.After(now) {
+		return false, nil
+	}
+
+	c.keys[key] = now.Add(ttl)
+
+	// Opportunistic GC: if the map has grown noticeably, drop expired keys.
+	// Bounded so Claim stays O(1) amortized.
+	if len(c.keys) > memoryCoordinatorGCThreshold {
+		c.gcLocked(now)
+	}
+
+	return true, nil
+}
+
+// memoryCoordinatorGCThreshold is the map size at which we sweep expired
+// entries. Chosen to keep GC amortized cheap while avoiding unbounded growth.
+const memoryCoordinatorGCThreshold = 1024
+
+// gcLocked removes expired entries. Caller holds c.mu.
+func (c *MemoryCoordinator) gcLocked(now time.Time) {
+	for k, exp := range c.keys {
+		if !exp.After(now) {
+			delete(c.keys, k)
+		}
+	}
+}
+
+// Len reports the number of currently tracked keys. Intended for tests.
+func (c *MemoryCoordinator) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.keys)
+}
+
+// Compile-time checks.
+var (
+	_ Coordinator = NoopCoordinator{}
+	_ Coordinator = (*MemoryCoordinator)(nil)
+)

--- a/transport/bridge/dedup.go
+++ b/transport/bridge/dedup.go
@@ -1,0 +1,121 @@
+package bridge
+
+import (
+	"context"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// DedupKeyFn extracts a deduplication key from a source message. Two
+// messages with the same key are treated as the same logical event by
+// [Dedup].
+//
+// Return an empty string to bypass dedup for that message — it is
+// forwarded unconditionally. Useful for messages that carry no natural
+// identity (control signals, heartbeats).
+type DedupKeyFn func(transport.Message) string
+
+// DefaultDedupKey uses the message ID as the dedup key. Correct when
+// the source guarantees globally unique IDs per logical event (most
+// CDC sources do: MongoDB resume token data, Kafka offset+partition).
+// Override when the message ID changes across redelivery but the
+// logical event does not.
+func DefaultDedupKey(msg transport.Message) string {
+	if msg == nil {
+		return ""
+	}
+	return msg.ID()
+}
+
+// DedupOptions configures the [Dedup] middleware.
+type DedupOptions struct {
+	// FailOpen controls the bridge's behaviour when the coordinator
+	// returns an error.
+	//
+	//   - false (default): treat the coordinator error as a handler
+	//     error. The source redelivers; consistency preserved at the
+	//     cost of liveness while the coordinator is down.
+	//   - true: forward the message anyway. Liveness preserved at the
+	//     cost of possible duplicates.
+	FailOpen bool
+
+	// OnSkip fires when the coordinator reports the key is already
+	// claimed and the message is dropped. Intended for observability.
+	// MUST NOT block.
+	OnSkip func(event string, msg transport.Message)
+}
+
+// Dedup returns middleware that suppresses duplicate publishes across
+// bridge replicas using a [Coordinator]. For each incoming message,
+// the middleware asks the coordinator to claim the key derived from
+// keyFn(msg) for the duration ttl. If the claim succeeds the message
+// continues through the pipeline; otherwise it is dropped (acked on
+// the source).
+//
+// Guarantee:
+//
+//	Exactly one replica per claim window publishes each logical
+//	event to the sink, assuming the coordinator is healthy and
+//	claim TTL exceeds the source's redelivery window.
+//
+// Failure modes:
+//
+//   - Coordinator unavailable: see [DedupOptions.FailOpen].
+//   - Replica crashes after claim before sink publish: the claim is
+//     held until TTL expiry; subsequent redeliveries are dropped as
+//     duplicates → the event is LOST in the sink. Operators who cannot
+//     tolerate this should pair [Dedup] with [DLQ] or use a coordinator
+//     that releases claims on explicit failure.
+//
+// ttl MUST be > 0. Panics otherwise (programmer error at wiring time).
+func Dedup(coord Coordinator, keyFn DedupKeyFn, ttl time.Duration, opts ...func(*DedupOptions)) Middleware {
+	if coord == nil {
+		panic("bridge: Dedup requires a non-nil Coordinator")
+	}
+	if keyFn == nil {
+		keyFn = DefaultDedupKey
+	}
+	if ttl <= 0 {
+		panic("bridge: Dedup requires ttl > 0")
+	}
+	o := DedupOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return func(next Handler) Handler {
+		return func(ctx context.Context, event string, msg transport.Message) error {
+			key := keyFn(msg)
+			if key == "" {
+				return next(ctx, event, msg)
+			}
+			ok, err := coord.Claim(ctx, key, ttl)
+			if err != nil {
+				if o.FailOpen {
+					return next(ctx, event, msg)
+				}
+				return err
+			}
+			if !ok {
+				if o.OnSkip != nil {
+					o.OnSkip(event, msg)
+				}
+				return nil
+			}
+			return next(ctx, event, msg)
+		}
+	}
+}
+
+// WithDedupFailOpen configures [Dedup] to forward messages when the
+// coordinator returns an error. Default is fail-closed.
+func WithDedupFailOpen(v bool) func(*DedupOptions) {
+	return func(o *DedupOptions) { o.FailOpen = v }
+}
+
+// WithDedupOnSkip registers a callback that fires when the coordinator
+// reports the key is already claimed. Use for metrics and debugging.
+func WithDedupOnSkip(fn func(event string, msg transport.Message)) func(*DedupOptions) {
+	return func(o *DedupOptions) { o.OnSkip = fn }
+}

--- a/transport/bridge/doc.go
+++ b/transport/bridge/doc.go
@@ -1,0 +1,74 @@
+// Package bridge provides a transport that forwards messages from a
+// source transport to a sink transport, optionally transforming or
+// filtering them via a composable pipeline.
+//
+// # Motivation
+//
+// Some event sources — MongoDB change streams, PostgreSQL logical
+// replication, file-system watchers — are inherently receive-only: every
+// replica of a horizontally scaled consumer receives every message. This
+// forces one of two shapes:
+//
+//   - Duplicate processing across replicas, relying on handler idempotency.
+//   - Per-message distributed coordination in each subscriber's middleware,
+//     round-tripping a state manager on every handler invocation.
+//
+// The bridge solves this by putting a transport that already owns
+// consumer-group semantics (Redis Streams, Kafka, NATS JetStream) in
+// front of the receive-only source. Every replica reads from the
+// source, and the bridge pipeline decides — per replica, per message —
+// whether to forward, drop, or transform. Downstream consumers subscribe
+// to the sink and inherit its native load balancing.
+//
+// # Composability
+//
+// The bridge itself is pure plumbing: it reads messages from the source
+// and publishes them to the sink. Everything else — deduplication,
+// dead-letter routing, distributed coordination, metrics, tracing — is
+// optional middleware composed via [WithMiddleware]:
+//
+//	t, _ := bridge.New(source, sink,
+//	    bridge.WithMiddleware(
+//	        bridge.Dedup(coord, mongodb.DedupKeyFromChangeStream(), 24*time.Hour),
+//	        bridge.DLQ(dlqSink, "bridge.failed"),
+//	        bridge.Observe(metrics),
+//	    ),
+//	)
+//
+// Callers pick only the middleware their source/sink pair needs. A
+// single-replica bridge with an idempotent sink may need none. A
+// multi-replica bridge onto Redis Streams typically wants [Dedup]. A
+// bridge that cannot tolerate lost messages when the sink misbehaves
+// wants [DLQ]. Users of the distributed package can wrap its state
+// manager as a [Middleware] and register it the same way.
+//
+// # Architecture
+//
+//	              ┌─ replica 1 ─ bridge ─┐
+//	source  ─► ──►├─ replica 2 ─ bridge ─┤──►  sink
+//	 (CDC)        └─ replica N ─ bridge ─┘       │
+//	                      │                      ▼
+//	                 pipeline:             consumers
+//	                 [Dedup → DLQ →
+//	                  sink.Publish]
+//
+// # Delivery semantics
+//
+// The base bridge provides at-least-once delivery to the sink: every
+// source message reaches the sink unless a middleware deliberately
+// drops it. Middleware can strengthen or weaken this contract:
+//
+//   - [Dedup] suppresses re-publishes of the same logical event across
+//     replicas. Its guarantee depends on the claim TTL vs. source
+//     redelivery window — see its documentation.
+//   - [DLQ] rescues messages that fail to publish to the sink,
+//     preventing source redelivery loops at the cost of moving failed
+//     events to a secondary sink.
+//
+// # Contract
+//
+// The sink MUST implement [transport.Transport.Publish]. The source
+// MAY be receive-only — its Publish is never invoked by the bridge.
+// The bridge's own Publish delegates to the sink, so direct publishes
+// bypass the source and the middleware pipeline.
+package bridge

--- a/transport/bridge/interfaces.go
+++ b/transport/bridge/interfaces.go
@@ -1,0 +1,85 @@
+package bridge
+
+import (
+	"context"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// Source is the narrow contract the bridge requires of the upstream
+// end. A Source supplies messages for forwarding; it is NOT asked to
+// publish. Any [transport.Transport] satisfies this interface
+// structurally, so existing transports plug in without an adapter.
+// Purpose-built sources (e.g. a MongoDB change stream wrapper that
+// does not expose the full Transport surface) implement Source
+// directly.
+//
+// A Source MUST deliver messages via [transport.Message] — reusing the
+// canonical message type keeps middleware (dedup, DLQ, observe,
+// transform) transport-agnostic. Sources with richer native types are
+// expected to marshal them into [transport.Message] at the boundary.
+type Source interface {
+	// RegisterEvent is called once before [Subscribe] to let the source
+	// allocate per-event resources. May be a no-op for sources that
+	// subscribe globally (change streams, file watchers) — returning
+	// [transport.ErrEventAlreadyExists] is benign and treated as success.
+	RegisterEvent(ctx context.Context, name string) error
+
+	// UnregisterEvent releases per-event resources. Called when the
+	// bridge unregisters name or during shutdown.
+	UnregisterEvent(ctx context.Context, name string) error
+
+	// Subscribe returns a subscription that emits messages for name.
+	// The subscription's Messages() channel MUST close when the
+	// subscription is closed or the source shuts down. Options passed
+	// here come from the bridge's [WithPumpSubscribeOptions] and are
+	// intended to configure source-specific behaviour (routing, start
+	// position).
+	Subscribe(ctx context.Context, name string, opts ...transport.SubscribeOption) (transport.Subscription, error)
+
+	// Close shuts down the source entirely. Called once by the bridge
+	// during [Transport.Close]. MUST be idempotent.
+	Close(ctx context.Context) error
+}
+
+// Sink is the narrow contract the bridge requires of the downstream
+// end. A Sink accepts published messages and — typically — exposes
+// consumer-group or pub-sub semantics so downstream subscribers can
+// load-balance. Any [transport.Transport] satisfies this interface
+// structurally.
+//
+// A bridge that uses the same value for both source and sink is
+// permitted (and occasionally useful for loopback tests); in that
+// case Close is called once per role but concrete implementations
+// are expected to be Close-idempotent, so the extra call is harmless.
+type Sink interface {
+	// RegisterEvent is called before [Publish] to allocate per-event
+	// resources (e.g. create a Redis Stream, a Kafka topic, a NATS
+	// subject). Errors returned here fail the bridge's
+	// [Transport.RegisterEvent].
+	RegisterEvent(ctx context.Context, name string) error
+
+	// UnregisterEvent releases per-event resources.
+	UnregisterEvent(ctx context.Context, name string) error
+
+	// Publish delivers msg under the named event. Errors bubble up
+	// through the middleware pipeline and, unless caught by middleware
+	// such as [DLQ], cause the source message to be nacked.
+	Publish(ctx context.Context, name string, msg transport.Message) error
+
+	// Subscribe exposes the sink's native subscription surface to the
+	// bus. The bridge delegates its own [Transport.Subscribe] here so
+	// downstream consumers ride whatever semantics the sink provides
+	// (consumer groups, worker pools, broadcast).
+	Subscribe(ctx context.Context, name string, opts ...transport.SubscribeOption) (transport.Subscription, error)
+
+	// Close shuts down the sink entirely. MUST be idempotent.
+	Close(ctx context.Context) error
+}
+
+// Compile-time evidence that any [transport.Transport] can be used as
+// a Source or Sink without an adapter.
+var (
+	_ Source = (transport.Transport)(nil)
+	_ Sink   = (transport.Transport)(nil)
+)

--- a/transport/bridge/metrics.go
+++ b/transport/bridge/metrics.go
@@ -1,0 +1,197 @@
+package bridge
+
+import (
+	"context"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const bridgeMeterName = "github.com/rbaliyan/event/v3/transport/bridge"
+
+// Metrics provides OpenTelemetry instruments for the bridge pipeline.
+//
+// All methods are nil-safe — calling any method on a nil *Metrics is a
+// no-op. Use [NewMetrics] to create an instance with the global meter
+// provider, or pass [WithMeterProvider] for a custom provider (tests).
+//
+// Available instruments:
+//
+//   - bridge_messages_received_total:  counter of messages entering the pipeline
+//   - bridge_messages_forwarded_total: counter of messages successfully forwarded to the sink
+//   - bridge_messages_failed_total:    counter of pipeline errors (sink unavailable, middleware error)
+//   - bridge_messages_skipped_total:   counter of messages intentionally dropped (dedup, filter)
+//   - bridge_forward_duration_seconds: histogram of end-to-end pipeline latency
+type Metrics struct {
+	meter metric.Meter
+
+	receivedTotal   metric.Int64Counter
+	forwardedTotal  metric.Int64Counter
+	failedTotal     metric.Int64Counter
+	skippedTotal    metric.Int64Counter
+	forwardDuration metric.Float64Histogram
+}
+
+// MetricsOption configures [NewMetrics].
+type MetricsOption func(*metricsOptions)
+
+type metricsOptions struct {
+	meterProvider metric.MeterProvider
+	namespace     string
+}
+
+// WithMeterProvider sets a custom OTel meter provider. By default, the
+// global provider is used.
+func WithMeterProvider(provider metric.MeterProvider) MetricsOption {
+	return func(o *metricsOptions) {
+		if provider != nil {
+			o.meterProvider = provider
+		}
+	}
+}
+
+// WithMetricsNamespace prefixes all instrument names. Useful when
+// multiple bridge instances coexist and their metrics must be
+// distinguished.
+//
+//	m, _ := bridge.NewMetrics(bridge.WithMetricsNamespace("orders"))
+//	// → orders_bridge_messages_forwarded_total
+func WithMetricsNamespace(namespace string) MetricsOption {
+	return func(o *metricsOptions) {
+		if namespace != "" {
+			o.namespace = namespace + "_"
+		}
+	}
+}
+
+// NewMetrics creates a Metrics instance and registers all instruments
+// on the configured meter provider.
+func NewMetrics(opts ...MetricsOption) (*Metrics, error) {
+	o := &metricsOptions{
+		meterProvider: otel.GetMeterProvider(),
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	meter := o.meterProvider.Meter(bridgeMeterName)
+	p := o.namespace
+
+	m := &Metrics{meter: meter}
+	var err error
+
+	m.receivedTotal, err = meter.Int64Counter(
+		p+"bridge_messages_received_total",
+		metric.WithDescription("Total messages entering the bridge pipeline"),
+		metric.WithUnit("{message}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.forwardedTotal, err = meter.Int64Counter(
+		p+"bridge_messages_forwarded_total",
+		metric.WithDescription("Messages successfully forwarded to the sink"),
+		metric.WithUnit("{message}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.failedTotal, err = meter.Int64Counter(
+		p+"bridge_messages_failed_total",
+		metric.WithDescription("Messages that failed to forward (sink error, middleware error)"),
+		metric.WithUnit("{message}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.skippedTotal, err = meter.Int64Counter(
+		p+"bridge_messages_skipped_total",
+		metric.WithDescription("Messages intentionally dropped (dedup, filter)"),
+		metric.WithUnit("{message}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m.forwardDuration, err = meter.Float64Histogram(
+		p+"bridge_forward_duration_seconds",
+		metric.WithDescription("End-to-end bridge pipeline latency"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(
+			0.0005, 0.001, 0.005, 0.01, 0.025, 0.05,
+			0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// RecordSkip increments the skipped counter. Call this from
+// [Dedup]'s OnSkip callback or [Filter]'s drop path to count
+// messages intentionally not forwarded to the sink.
+//
+//	bridge.Dedup(coord, keyFn, ttl,
+//	    bridge.WithDedupOnSkip(func(event string, msg transport.Message) {
+//	        m.RecordSkip(context.Background(), event)
+//	    }),
+//	)
+func (m *Metrics) RecordSkip(ctx context.Context, event string) {
+	if m == nil {
+		return
+	}
+	m.skippedTotal.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("event", event),
+	))
+}
+
+// MetricsMiddleware returns a [Middleware] that records pipeline
+// throughput and latency using the provided [Metrics]. If m is nil
+// the middleware is a no-op passthrough.
+//
+// The middleware increments received_total on every call, then
+// delegates to next. On success it increments forwarded_total; on
+// error, failed_total. Duration covers the full downstream call
+// (including any inner middleware).
+//
+// Place this FIRST in the middleware chain to measure the complete
+// pipeline, or LAST to measure only the sink publish:
+//
+//	bridge.WithMiddleware(
+//	    bridge.MetricsMiddleware(m),   // outermost — sees everything
+//	    bridge.Dedup(coord, keyFn, ttl),
+//	    bridge.DLQ(dlqSink, "failed"),
+//	)
+func MetricsMiddleware(m *Metrics) Middleware {
+	return func(next Handler) Handler {
+		if m == nil {
+			return next
+		}
+		return func(ctx context.Context, event string, msg transport.Message) error {
+			attrs := metric.WithAttributes(attribute.String("event", event))
+
+			m.receivedTotal.Add(ctx, 1, attrs)
+
+			start := time.Now()
+			err := next(ctx, event, msg)
+			duration := time.Since(start).Seconds()
+
+			m.forwardDuration.Record(ctx, duration, attrs)
+
+			if err != nil {
+				m.failedTotal.Add(ctx, 1, attrs)
+			} else {
+				m.forwardedTotal.Add(ctx, 1, attrs)
+			}
+			return err
+		}
+	}
+}

--- a/transport/bridge/metrics_test.go
+++ b/transport/bridge/metrics_test.go
@@ -1,0 +1,316 @@
+package bridge_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+	"github.com/rbaliyan/event/v3/transport/bridge"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// testBridgeMetrics creates a Metrics backed by a ManualReader.
+func testBridgeMetrics(t *testing.T) (*bridge.Metrics, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	m, err := bridge.NewMetrics(bridge.WithMeterProvider(provider))
+	if err != nil {
+		t.Fatalf("NewMetrics: %v", err)
+	}
+	return m, reader
+}
+
+func collectBridgeMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	return rm
+}
+
+func findBridgeMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	for _, sm := range rm.ScopeMetrics {
+		for i := range sm.Metrics {
+			if sm.Metrics[i].Name == name {
+				return &sm.Metrics[i]
+			}
+		}
+	}
+	return nil
+}
+
+func sumBridgeCounter(m *metricdata.Metrics) int64 {
+	if m == nil {
+		return 0
+	}
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	if !ok {
+		return 0
+	}
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	return total
+}
+
+func histBridgeCount(m *metricdata.Metrics) uint64 {
+	if m == nil {
+		return 0
+	}
+	h, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		return 0
+	}
+	var total uint64
+	for _, dp := range h.DataPoints {
+		total += dp.Count
+	}
+	return total
+}
+
+// ---------- MetricsMiddleware ----------
+
+func TestMetricsMiddleware_ForwardedCounter(t *testing.T) {
+	m, reader := testBridgeMetrics(t)
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.MetricsMiddleware(m)),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("m1"))
+	src.inject("x", newMsg("m2"))
+
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 2 }, time.Second)
+
+	rm := collectBridgeMetrics(t, reader)
+
+	received := findBridgeMetric(rm, "bridge_messages_received_total")
+	if got := sumBridgeCounter(received); got != 2 {
+		t.Errorf("received_total = %d, want 2", got)
+	}
+
+	forwarded := findBridgeMetric(rm, "bridge_messages_forwarded_total")
+	if got := sumBridgeCounter(forwarded); got != 2 {
+		t.Errorf("forwarded_total = %d, want 2", got)
+	}
+
+	failed := findBridgeMetric(rm, "bridge_messages_failed_total")
+	if got := sumBridgeCounter(failed); got != 0 {
+		t.Errorf("failed_total = %d, want 0", got)
+	}
+}
+
+func TestMetricsMiddleware_FailedCounter(t *testing.T) {
+	m, reader := testBridgeMetrics(t)
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	sink.setPublishErr(errors.New("boom"))
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.MetricsMiddleware(m)),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	var acked sync.WaitGroup
+	acked.Add(1)
+	msg := newMsg("f1")
+	msg.ackFn = func(error) error { acked.Done(); return nil }
+	src.inject("x", msg)
+	acked.Wait()
+
+	rm := collectBridgeMetrics(t, reader)
+
+	received := findBridgeMetric(rm, "bridge_messages_received_total")
+	if got := sumBridgeCounter(received); got != 1 {
+		t.Errorf("received_total = %d, want 1", got)
+	}
+
+	forwarded := findBridgeMetric(rm, "bridge_messages_forwarded_total")
+	if got := sumBridgeCounter(forwarded); got != 0 {
+		t.Errorf("forwarded_total = %d, want 0", got)
+	}
+
+	failed := findBridgeMetric(rm, "bridge_messages_failed_total")
+	if got := sumBridgeCounter(failed); got != 1 {
+		t.Errorf("failed_total = %d, want 1", got)
+	}
+}
+
+func TestMetricsMiddleware_Duration(t *testing.T) {
+	m, reader := testBridgeMetrics(t)
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	// Add artificial latency via a middleware so the histogram records > 0.
+	slow := func(next bridge.Handler) bridge.Handler {
+		return func(ctx context.Context, ev string, msg transport.Message) error {
+			time.Sleep(10 * time.Millisecond)
+			return next(ctx, ev, msg)
+		}
+	}
+
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.MetricsMiddleware(m), slow),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("d1"))
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 1 }, time.Second)
+
+	rm := collectBridgeMetrics(t, reader)
+
+	dur := findBridgeMetric(rm, "bridge_forward_duration_seconds")
+	if dur == nil {
+		t.Fatal("forward_duration metric not found")
+	}
+	if got := histBridgeCount(dur); got != 1 {
+		t.Errorf("duration count = %d, want 1", got)
+	}
+	h := dur.Data.(metricdata.Histogram[float64])
+	if h.DataPoints[0].Sum < 0.01 {
+		t.Errorf("duration sum = %f, want >= 0.01", h.DataPoints[0].Sum)
+	}
+}
+
+func TestMetricsMiddleware_NilMetrics(t *testing.T) {
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	// Should not panic with nil metrics.
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(bridge.MetricsMiddleware(nil)),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	src.inject("x", newMsg("m1"))
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 1 }, time.Second)
+}
+
+// ---------- RecordSkip ----------
+
+func TestRecordSkip(t *testing.T) {
+	m, reader := testBridgeMetrics(t)
+	ctx := context.Background()
+
+	m.RecordSkip(ctx, "orders")
+	m.RecordSkip(ctx, "orders")
+	m.RecordSkip(ctx, "payments")
+
+	rm := collectBridgeMetrics(t, reader)
+
+	skipped := findBridgeMetric(rm, "bridge_messages_skipped_total")
+	if got := sumBridgeCounter(skipped); got != 3 {
+		t.Errorf("skipped_total = %d, want 3", got)
+	}
+}
+
+func TestRecordSkip_NilMetrics(t *testing.T) {
+	var m *bridge.Metrics
+	// Must not panic.
+	m.RecordSkip(context.Background(), "x")
+}
+
+// ---------- Dedup + Metrics composition ----------
+
+func TestDedupWithMetricsSkip(t *testing.T) {
+	m, reader := testBridgeMetrics(t)
+	src, sink := newFakeTransport(), newFakeTransport()
+	ctx := context.Background()
+	_ = src.RegisterEvent(ctx, "x")
+
+	coord := bridge.NewMemoryCoordinator()
+	b, _ := bridge.New(src, sink,
+		bridge.WithMiddleware(
+			bridge.MetricsMiddleware(m),
+			bridge.Dedup(coord, bridge.DefaultDedupKey, time.Minute,
+				bridge.WithDedupOnSkip(func(event string, _ transport.Message) {
+					m.RecordSkip(ctx, event)
+				}),
+			),
+		),
+	)
+	t.Cleanup(func() { _ = b.Close(ctx) })
+	_ = b.RegisterEvent(ctx, "x")
+
+	// First is forwarded; second and third are deduped.
+	src.inject("x", newMsg("dup"))
+	src.inject("x", newMsg("dup"))
+	src.inject("x", newMsg("dup"))
+
+	waitFor(t, func() bool { return len(sink.publishedEvents()) == 1 }, time.Second)
+	// Also wait for the skips to be recorded.
+	waitFor(t, func() bool {
+		var rm metricdata.ResourceMetrics
+		reader.Collect(ctx, &rm)
+		sk := findBridgeMetric(rm, "bridge_messages_skipped_total")
+		return sumBridgeCounter(sk) == 2
+	}, time.Second)
+
+	rm := collectBridgeMetrics(t, reader)
+
+	forwarded := findBridgeMetric(rm, "bridge_messages_forwarded_total")
+	// Dedup drops 2 messages by returning nil → outer metrics sees
+	// them as "success". Only 1 actually reached the sink.
+	// The forwarded_total therefore reflects the metrics middleware's
+	// view: 3 received, 3 "succeeded" (nil return).  The skipped_total
+	// counter, fed by RecordSkip, gives the true picture.
+	if got := sumBridgeCounter(forwarded); got != 3 {
+		t.Errorf("forwarded_total = %d, want 3 (metrics sees nil return from dedup)", got)
+	}
+
+	skipped := findBridgeMetric(rm, "bridge_messages_skipped_total")
+	if got := sumBridgeCounter(skipped); got != 2 {
+		t.Errorf("skipped_total = %d, want 2", got)
+	}
+}
+
+// ---------- Namespace ----------
+
+func TestMetrics_WithNamespace(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	m, err := bridge.NewMetrics(bridge.WithMeterProvider(provider), bridge.WithMetricsNamespace("orders"))
+	if err != nil {
+		t.Fatalf("NewMetrics: %v", err)
+	}
+
+	m.RecordSkip(context.Background(), "x")
+
+	rm := collectBridgeMetrics(t, reader)
+
+	skipped := findBridgeMetric(rm, "orders_bridge_messages_skipped_total")
+	if skipped == nil {
+		t.Fatal("namespaced skipped metric not found")
+	}
+	if got := sumBridgeCounter(skipped); got != 1 {
+		t.Errorf("skipped = %d, want 1", got)
+	}
+
+	nonPrefixed := findBridgeMetric(rm, "bridge_messages_skipped_total")
+	if nonPrefixed != nil {
+		t.Error("non-prefixed metric should not exist")
+	}
+}

--- a/transport/bridge/middleware.go
+++ b/transport/bridge/middleware.go
@@ -1,0 +1,174 @@
+package bridge
+
+import (
+	"context"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// Handler processes a single source message. The terminal handler in
+// the pipeline publishes to the sink; intermediate handlers come from
+// [Middleware].
+//
+// Return values are interpreted by the pump:
+//
+//   - nil:   the message is considered handled and is acked on the source.
+//   - error: the message is nacked on the source (and redelivered if
+//     the source supports redelivery).
+//
+// A middleware that wants to "drop" a message (e.g. [Dedup] when the
+// key is already claimed) should return nil WITHOUT calling next.
+type Handler func(ctx context.Context, event string, msg transport.Message) error
+
+// Middleware decorates a [Handler]. Middleware composes in declaration
+// order: the first middleware passed to [WithMiddleware] is the
+// outermost wrapper (runs first and sees the returned error last).
+//
+// Typical shape:
+//
+//	func MyMiddleware(cfg Cfg) Middleware {
+//	    return func(next Handler) Handler {
+//	        return func(ctx context.Context, event string, msg transport.Message) error {
+//	            // pre-processing (may return early to drop or short-circuit)
+//	            err := next(ctx, event, msg)
+//	            // post-processing (e.g. record metrics, route errors)
+//	            return err
+//	        }
+//	    }
+//	}
+type Middleware func(Handler) Handler
+
+// chain composes middleware around a terminal handler. The first
+// middleware in the slice becomes the outermost wrapper.
+func chain(terminal Handler, mws ...Middleware) Handler {
+	h := terminal
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
+}
+
+// publishTo returns the terminal handler that publishes to the given sink.
+func publishTo(sink Sink) Handler {
+	return func(ctx context.Context, event string, msg transport.Message) error {
+		return sink.Publish(ctx, event, msg)
+	}
+}
+
+// DLQ returns middleware that diverts messages whose downstream handler
+// (typically the sink publish) returns an error to a dead-letter sink.
+// The source message is acked after a successful DLQ write, preventing
+// the source from redelivering the failure indefinitely.
+//
+// dlqEvent is the event name to publish under on dlqSink. A single
+// event name is typical ("bridge.failed") since DLQ messages usually
+// go to a shared inspection pipeline; callers who want per-event DLQs
+// can supply a function instead of a fixed name via [DLQFunc].
+//
+// If the DLQ publish itself fails, the original error is returned so
+// the source redelivers and the next bridge replica can retry.
+func DLQ(dlqSink Sink, dlqEvent string) Middleware {
+	return DLQFunc(dlqSink, func(event string, _ transport.Message) string {
+		if dlqEvent != "" {
+			return dlqEvent
+		}
+		return event + ".failed"
+	})
+}
+
+// DLQFunc is the generalised form of [DLQ] that lets callers compute
+// the DLQ event name dynamically from the source event name and
+// message. Typical use is to preserve the source event name:
+//
+//	bridge.DLQFunc(dlqSink, func(ev string, _ transport.Message) string {
+//	    return ev + ".failed"
+//	})
+func DLQFunc(dlqSink Sink, name func(event string, msg transport.Message) string) Middleware {
+	return func(next Handler) Handler {
+		return func(ctx context.Context, event string, msg transport.Message) error {
+			if err := next(ctx, event, msg); err != nil {
+				dlqName := name(event, msg)
+				if dlqErr := dlqSink.Publish(ctx, dlqName, msg); dlqErr != nil {
+					// DLQ write failed — surface the ORIGINAL error so
+					// the source redelivers. We lose the DLQ attempt
+					// but don't mask the real fault.
+					return err
+				}
+				return nil
+			}
+			return nil
+		}
+	}
+}
+
+// Observe returns middleware that invokes the supplied callbacks at
+// well-defined points in the pipeline. All callbacks are optional and
+// MUST NOT block. Any callback being nil disables that signal.
+//
+// The callbacks run synchronously on the pump goroutine; do heavy work
+// (metric emission, trace span creation) with non-blocking primitives.
+func Observe(hooks Hooks) Middleware {
+	return func(next Handler) Handler {
+		return func(ctx context.Context, event string, msg transport.Message) error {
+			if hooks.OnReceive != nil {
+				hooks.OnReceive(event, msg)
+			}
+			err := next(ctx, event, msg)
+			switch {
+			case err != nil && hooks.OnError != nil:
+				hooks.OnError(event, msg, err)
+			case err == nil && hooks.OnPublish != nil:
+				hooks.OnPublish(event, msg)
+			}
+			return err
+		}
+	}
+}
+
+// Hooks is the callback set used by [Observe].
+type Hooks struct {
+	// OnReceive fires as soon as the message enters the pipeline,
+	// before any further middleware or the sink publish.
+	OnReceive func(event string, msg transport.Message)
+	// OnPublish fires after a successful terminal handler (the sink
+	// accepted the message).
+	OnPublish func(event string, msg transport.Message)
+	// OnError fires after any middleware or the terminal handler
+	// returned an error. The error bubbles up to the pump regardless.
+	OnError func(event string, msg transport.Message, err error)
+}
+
+// Filter returns middleware that drops messages for which keep returns
+// false. Dropped messages are acked on the source — they are treated
+// as successfully handled, just not forwarded.
+//
+// Use for messages that the sink does not need (e.g. operations the
+// consumer doesn't care about) that the source cannot filter itself.
+func Filter(keep func(event string, msg transport.Message) bool) Middleware {
+	return func(next Handler) Handler {
+		return func(ctx context.Context, event string, msg transport.Message) error {
+			if !keep(event, msg) {
+				return nil
+			}
+			return next(ctx, event, msg)
+		}
+	}
+}
+
+// Transform returns middleware that replaces each message with the
+// result of fn before it reaches the next handler. Returning a nil
+// message drops the event (same semantics as [Filter] returning false).
+//
+// Use to rewrite payload encoding (BSON → JSON), redact fields, or
+// enrich metadata with bridge-level context.
+func Transform(fn func(event string, msg transport.Message) transport.Message) Middleware {
+	return func(next Handler) Handler {
+		return func(ctx context.Context, event string, msg transport.Message) error {
+			out := fn(event, msg)
+			if out == nil {
+				return nil
+			}
+			return next(ctx, event, out)
+		}
+	}
+}

--- a/transport/bridge/options.go
+++ b/transport/bridge/options.go
@@ -1,0 +1,77 @@
+package bridge
+
+import (
+	"log/slog"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// Option configures a bridge [Transport].
+type Option func(*Transport)
+
+// WithMiddleware installs pipeline middleware that runs on every source
+// message before the terminal sink publish. Middleware compose in
+// declaration order: the first middleware is the outermost wrapper.
+//
+// Multiple calls to WithMiddleware append to the existing chain,
+// preserving order. Pass middleware in the order you want them to run:
+//
+//	bridge.WithMiddleware(
+//	    bridge.Observe(metricsHooks), // outermost: sees every message
+//	    bridge.Dedup(coord, key, ttl), // drop duplicates early
+//	    bridge.Filter(keep),           // drop uninteresting events
+//	    bridge.DLQ(dlqSink, "failed"), // innermost: catch sink errors
+//	)
+//
+// The bridge installs no middleware by default — a bridge with no
+// middleware is a pure source→sink forwarder.
+func WithMiddleware(mws ...Middleware) Option {
+	return func(t *Transport) {
+		t.middleware = append(t.middleware, mws...)
+	}
+}
+
+// WithLogger sets the logger used for internal diagnostics.
+func WithLogger(l *slog.Logger) Option {
+	return func(t *Transport) {
+		if l != nil {
+			t.logger = l
+		}
+	}
+}
+
+// WithErrorHandler installs a callback invoked for asynchronous errors
+// from the pump (pipeline errors not caught by middleware, ack errors).
+// Intended for metrics and alerting. The callback MUST NOT block.
+//
+// For per-message observability, prefer [Observe] middleware — it runs
+// inside the pipeline and has access to the event name and message.
+func WithErrorHandler(fn func(error)) Option {
+	return func(t *Transport) {
+		if fn != nil {
+			t.onError = fn
+		}
+	}
+}
+
+// WithPumpBuffer sets the buffer size for each pump's source
+// subscription. Must be >= 1. Defaults to 256. Increase when source
+// message bursts outpace the middleware pipeline.
+func WithPumpBuffer(n int) Option {
+	return func(t *Transport) {
+		if n >= 1 {
+			t.pumpBuffer = n
+		}
+	}
+}
+
+// WithPumpSubscribeOptions appends options passed to the source
+// transport's Subscribe call made by each pump. Useful for sources
+// that support consumer IDs, routing filters, or custom start
+// positions. Applied after the bridge's own default options so they
+// can override defaults.
+func WithPumpSubscribeOptions(opts ...transport.SubscribeOption) Option {
+	return func(t *Transport) {
+		t.pumpSubscribeOpts = append(t.pumpSubscribeOpts, opts...)
+	}
+}

--- a/transport/bridge/pump.go
+++ b/transport/bridge/pump.go
@@ -1,0 +1,176 @@
+package bridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// pump drives a single registered event: it subscribes to the source,
+// runs each message through the handler pipeline, and acks/nacks the
+// source based on the pipeline's return value.
+//
+// One pump runs per (bridge, event name). It owns a goroutine and a
+// source subscription. Stop drains both.
+type pump struct {
+	name    string
+	sub     transport.Subscription
+	handler Handler
+	logger  *slog.Logger
+	onError func(error)
+
+	cancel   context.CancelFunc
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// pumpConfig bundles the arguments to [startPump] for readability.
+type pumpConfig struct {
+	name              string
+	source            Source
+	sink              Sink
+	middleware        []Middleware
+	bufferSize        int
+	logger            *slog.Logger
+	onError           func(error)
+	pumpSubscribeOpts []transport.SubscribeOption
+}
+
+// startPump subscribes to the source for cfg.name and starts the pump
+// goroutine. Returns an error if the source subscription cannot be
+// established — the caller is expected to surface this as a failed
+// RegisterEvent.
+func startPump(parentCtx context.Context, cfg pumpConfig) (*pump, error) {
+	handler := chain(publishTo(cfg.sink), cfg.middleware...)
+
+	opts := make([]transport.SubscribeOption, 0, len(cfg.pumpSubscribeOpts)+2)
+	// Prefer broadcast semantics: every replica needs to see every
+	// source message so dedup (if any) can decide ownership. Callers
+	// who want different semantics can override via
+	// WithPumpSubscribeOptions.
+	opts = append(opts, transport.WithDeliveryMode(transport.Broadcast))
+	if cfg.bufferSize > 0 {
+		opts = append(opts, transport.WithBufferSize(cfg.bufferSize))
+	}
+	opts = append(opts, cfg.pumpSubscribeOpts...)
+
+	// The subscription inherits a cancellable context so stop() can
+	// unwind cleanly even if the parent context is long-lived.
+	subCtx, cancel := context.WithCancel(parentCtx)
+	sub, err := cfg.source.Subscribe(subCtx, cfg.name, opts...)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("bridge: source subscribe %q: %w", cfg.name, err)
+	}
+
+	p := &pump{
+		name:    cfg.name,
+		sub:     sub,
+		handler: handler,
+		logger:  cfg.logger,
+		onError: cfg.onError,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+
+	go p.run(subCtx)
+	return p, nil
+}
+
+// run is the pump loop. Exits when the subscription closes or the
+// context is cancelled.
+func (p *pump) run(ctx context.Context) {
+	defer close(p.done)
+
+	msgs := p.sub.Messages()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-msgs:
+			if !ok {
+				return
+			}
+			p.handle(ctx, msg)
+		}
+	}
+}
+
+// handle runs a single message through the handler pipeline and acks
+// or nacks the source based on the outcome. Panics are recovered and
+// treated as handler errors so one bad middleware cannot take down
+// the pump goroutine.
+func (p *pump) handle(ctx context.Context, msg transport.Message) {
+	err := safeCall(ctx, p.name, msg, p.handler)
+	if err != nil {
+		p.logger.Warn("pipeline error",
+			"msg_id", msg.ID(), "error", err)
+		if p.onError != nil {
+			p.onError(err)
+		}
+	}
+
+	// Ack the source with the pipeline's outcome. Transports that do
+	// not implement redelivery will still observe the nack (they can
+	// log or no-op). Errors from Ack itself (already-closed sub, etc.)
+	// are logged but not escalated.
+	if ackErr := msg.Ack(err); ackErr != nil &&
+		!errors.Is(ackErr, transport.ErrSubscriptionClosed) {
+		p.logger.Warn("ack failed",
+			"msg_id", msg.ID(), "error", ackErr)
+	}
+}
+
+// safeCall invokes h with panic recovery. A recovered panic is
+// converted to an error so the pump behaves as if the middleware had
+// returned it.
+func safeCall(ctx context.Context, event string, msg transport.Message, h Handler) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = panicAsError(r)
+		}
+	}()
+	return h(ctx, event, msg)
+}
+
+// panicAsError converts a recovered panic value to an error suitable
+// for the normal handler return path.
+func panicAsError(r any) error {
+	switch v := r.(type) {
+	case error:
+		return fmt.Errorf("bridge: handler panic: %w", v)
+	default:
+		return fmt.Errorf("bridge: handler panic: %v", v)
+	}
+}
+
+// stopTimeout bounds how long stop waits for the pump goroutine to
+// exit after cancellation. Long enough for in-flight middleware to
+// finish, short enough to not block a graceful shutdown indefinitely.
+const stopTimeout = 10 * time.Second
+
+// stop cancels the pump's context, closes its source subscription, and
+// waits for the goroutine to exit. If the goroutine does not exit
+// within [stopTimeout] the wait is abandoned (the goroutine will still
+// exit once its cancelled context propagates). Safe to call multiple
+// times; subsequent calls are no-ops.
+func (p *pump) stop(_ context.Context) {
+	p.stopOnce.Do(func() {
+		p.cancel()
+		// Close the subscription so the source stops delivering and
+		// the Messages() channel eventually drains.
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), stopTimeout)
+		defer closeCancel()
+		_ = p.sub.Close(closeCtx)
+		select {
+		case <-p.done:
+		case <-time.After(stopTimeout):
+			p.logger.Warn("pump goroutine did not exit within timeout")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `transport/bridge` package that forwards messages from a receive-only source transport (e.g. MongoDB change streams) into a sink transport with consumer-group semantics (e.g. Redis Streams)
- Composable middleware pipeline: dedup, DLQ, filter, transform, observe, OTel metrics — all optional, caller composes only what their source/sink pair needs
- `Source` and `Sink` are narrow interfaces that any `transport.Transport` satisfies structurally — no adapters needed for existing transports

### Architecture

```
              ┌─ replica 1 ─ bridge ─┐
source  ──►   ├─ replica 2 ─ bridge ─┤──►  sink (consumer groups)
 (CDC)        └─ replica N ─ bridge ─┘          │
                      │                         ▼
                 pipeline:                 consumers
                 [Metrics → Dedup →
                  Filter → DLQ →
                  sink.Publish]
```

### Package contents

| File | Purpose |
|---|---|
| `interfaces.go` | `Source`, `Sink` — narrow interfaces (transport.Transport satisfies both) |
| `bridge.go` | Transport implementation with race-safe RegisterEvent |
| `pump.go` | Per-event goroutine with panic recovery, bounded stop timeout |
| `middleware.go` | `Handler`/`Middleware` types; `DLQ`, `Filter`, `Transform`, `Observe` |
| `dedup.go` | `Dedup` middleware with pluggable `Coordinator` and `DedupKeyFn` |
| `coordinator.go` | `NoopCoordinator`, `MemoryCoordinator` (users bring Redis/Mongo) |
| `metrics.go` | OTel `Metrics` struct, `MetricsMiddleware`, `RecordSkip` |
| `options.go` | `WithMiddleware`, `WithLogger`, `WithPumpBuffer`, etc. |

### Usage

```go
source, _ := mongodb.NewClusterWatch(mongoClient, ...)
sink, _   := redis.New(redisClient, redis.WithConsumerGroup("my-svc"))

t, _ := bridge.New(source, sink,
    bridge.WithMiddleware(
        bridge.MetricsMiddleware(m),
        bridge.Dedup(coord, mongodb.DedupKeyFromChangeStream(), 24*time.Hour),
        bridge.DLQ(dlqSink, "bridge.failed"),
    ),
)

bus, _ := event.NewBus("orders", event.WithTransport(t))
```

## Test plan

- [x] Constructor error cases (nil source/sink)
- [x] Pump forwards messages source → sink
- [x] Publish/Subscribe delegate to sink
- [x] Dedup middleware suppresses duplicates (same ID)
- [x] Dedup passes through different IDs
- [x] Dedup fail-closed on coordinator error (nack for redelivery)
- [x] Dedup fail-open on coordinator error (forward anyway)
- [x] DLQ catches sink errors, acks source
- [x] Filter drops by predicate
- [x] Transform rewrites messages
- [x] Observe hooks fire on receive/publish/error
- [x] Panic recovery — pump continues after middleware panic
- [x] Close stops pumps, idempotent
- [x] UnregisterEvent lifecycle
- [x] MemoryCoordinator claims + TTL expiry
- [x] NoopCoordinator always claims
- [x] Health: both healthy, source unhealthy, sink degraded, after close, non-checker transports
- [x] OTel metrics: forwarded/failed/skipped counters, duration histogram, nil-safety, namespace
- [x] Dedup + Metrics composition (RecordSkip wiring)
- [x] All tests pass with `-race`