### PR TITLE
perf(monitor): replace single-field indexes with compound indexes

### DIFF
--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -43,11 +43,11 @@ Document structure:
 
 Indexes:
 db.monitor_entries.createIndex({"event_id": 1, "subscription_id": 1}, {unique: true})
-db.monitor_entries.createIndex({"event_name": 1})
-db.monitor_entries.createIndex({"status": 1})
-db.monitor_entries.createIndex({"started_at": 1})
-db.monitor_entries.createIndex({"delivery_mode": 1})
-db.monitor_entries.createIndex({"subscriber_name": 1})
+db.monitor_entries.createIndex({"event_name": 1, "started_at": 1})
+db.monitor_entries.createIndex({"status": 1, "started_at": 1})
+db.monitor_entries.createIndex({"bus_id": 1, "started_at": 1})
+db.monitor_entries.createIndex({"subscriber_name": 1, "started_at": 1})
+db.monitor_entries.createIndex({"started_at": 1, "event_id": 1, "subscription_id": 1})
 */
 
 // mongoEntry represents a monitor entry document in MongoDB.
@@ -176,24 +176,38 @@ func (s *MongoStore) Collection() *mongo.Collection {
 //	_, err := collection.Indexes().CreateMany(ctx, indexes)
 func (s *MongoStore) Indexes() []mongo.IndexModel {
 	return []mongo.IndexModel{
+		// Unique constraint: primary key for upserts, point lookups, and status updates.
 		{
 			Keys:    bson.D{{Key: "event_id", Value: 1}, {Key: "subscription_id", Value: 1}},
 			Options: options.Index().SetUnique(true),
 		},
+		// event_name + started_at: supports filtering by event with time-range queries
+		// and eliminates in-memory sorts on the result set.
 		{
-			Keys: bson.D{{Key: "event_name", Value: 1}},
+			Keys: bson.D{{Key: "event_name", Value: 1}, {Key: "started_at", Value: 1}},
 		},
+		// status + started_at: supports "show all failed/pending events in last N hours"
+		// queries without in-memory sorts.
 		{
-			Keys: bson.D{{Key: "status", Value: 1}},
+			Keys: bson.D{{Key: "status", Value: 1}, {Key: "started_at", Value: 1}},
 		},
+		// bus_id + started_at: supports per-bus filtering in multi-store deployments.
 		{
-			Keys: bson.D{{Key: "started_at", Value: 1}},
+			Keys: bson.D{{Key: "bus_id", Value: 1}, {Key: "started_at", Value: 1}},
 		},
+		// subscriber_name + started_at: supports per-subscriber filtering with time range.
 		{
-			Keys: bson.D{{Key: "delivery_mode", Value: 1}},
+			Keys: bson.D{{Key: "subscriber_name", Value: 1}, {Key: "started_at", Value: 1}},
 		},
+		// started_at + event_id + subscription_id: covers DeleteOlderThan (range on
+		// started_at), unfiltered List queries, and the full cursor sort key
+		// (started_at, event_id, subscription_id) used in cursor-based pagination.
 		{
-			Keys: bson.D{{Key: "subscriber_name", Value: 1}},
+			Keys: bson.D{
+				{Key: "started_at", Value: 1},
+				{Key: "event_id", Value: 1},
+				{Key: "subscription_id", Value: 1},
+			},
 		},
 	}
 }

--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -28,6 +28,7 @@ Document structure:
     "subscriber_description": string,
     "event_name": string,
     "bus_id": string,
+    "instance_id": string,
     "delivery_mode": string,
     "metadata": object,
     "status": string,


### PR DESCRIPTION
## Summary

- Replaces 5 single-field MongoDB indexes with compound indexes that include `started_at` as a trailing key
- Adds `{bus_id, started_at}` index for multi-store deployments
- Drops the `{delivery_mode}` index (only 2 distinct values, never useful as a leading key)

## Problem

`List`, `Count`, and `Summary` queries combine a categorical filter (`event_name`, `status`, `bus_id`, `subscriber_name`) with a `started_at` time range and sort by `(started_at, event_id, subscription_id)`. With single-field indexes, MongoDB could filter using the categorical index but was forced to do an **in-memory sort** on the entire result set — expensive when a single event name has many entries.

## Index changes

| Old | New | Benefit |
|-----|-----|---------|
| `{event_name: 1}` | `{event_name: 1, started_at: 1}` | Filter + sort in one index scan |
| `{status: 1}` | `{status: 1, started_at: 1}` | No in-memory sort for "show all failed events" |
| `{started_at: 1}` | `{started_at: 1, event_id: 1, subscription_id: 1}` | Covers `DeleteOlderThan` and the full cursor sort key |
| `{subscriber_name: 1}` | `{subscriber_name: 1, started_at: 1}` | Per-subscriber time-range queries |
| `{delivery_mode: 1}` | *(dropped)* | Low-cardinality, query planner ignores it |
| *(none)* | `{bus_id: 1, started_at: 1}` | Per-bus queries in multi-store deployments |

## Migration note

`EnsureIndexes` creates new indexes on startup but does not drop old ones. After deploying, drop the stale indexes on existing collections:

```js
db._event_monitor.dropIndex("event_name_1")
db._event_monitor.dropIndex("status_1")
db._event_monitor.dropIndex("started_at_1")
db._event_monitor.dropIndex("delivery_mode_1")
db._event_monitor.dropIndex("subscriber_name_1")
```