### PR TITLE
feat(outbox): add metrics/tracing to MongoRelay and async index creation

### DIFF
--- a/outbox/mongodb.go
+++ b/outbox/mongodb.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -136,9 +137,15 @@ func NewMongoStore(db *mongo.Database, opts ...MongoStoreOption) (*MongoStore, e
 		opt(o)
 	}
 
-	return &MongoStore{
+	s := &MongoStore{
 		collection: db.Collection(o.collection),
-	}, nil
+	}
+	go func() { // #nosec G118 — background goroutine intentionally outlives constructor context
+		if err := s.EnsureIndexes(context.Background()); err != nil {
+			slog.Default().Error("failed to ensure outbox indexes", "error", err, "collection", o.collection)
+		}
+	}()
+	return s, nil
 }
 
 // Collection returns the underlying MongoDB collection

--- a/outbox/relay_mongo.go
+++ b/outbox/relay_mongo.go
@@ -2,11 +2,16 @@ package outbox
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/rbaliyan/event/v3/transport"
 	"github.com/rbaliyan/event/v3/transport/message"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // RelayMode defines how the relay watches for new messages.
@@ -38,6 +43,7 @@ type MongoRelay struct {
 	stuckDuration    time.Duration        // How long before a processing message is considered stuck
 	resumeTokenStore ResumeTokenStore     // For change stream resume (optional)
 	changeStreamOpts *changeStreamOptions // Internal change stream state
+	metrics          *Metrics
 }
 
 // changeStreamOptions holds change stream specific options
@@ -130,6 +136,12 @@ func (r *MongoRelay) WithStuckDuration(d time.Duration) *MongoRelay {
 	return r
 }
 
+// WithMetrics enables OpenTelemetry metrics for the relay.
+func (r *MongoRelay) WithMetrics(m *Metrics) *MongoRelay {
+	r.metrics = m
+	return r
+}
+
 // Start begins watching the outbox and publishing messages.
 // This method blocks until the context is cancelled.
 //
@@ -195,6 +207,9 @@ func (r *MongoRelay) startChangeStream(ctx context.Context) error {
 
 	if r.resumeTokenStore != nil {
 		csRelay = csRelay.WithResumeTokenStore(r.resumeTokenStore)
+	}
+	if r.metrics != nil {
+		csRelay = csRelay.WithMetrics(r.metrics)
 	}
 
 	r.log().Info("relay started in changestream mode")
@@ -293,17 +308,55 @@ func (r *MongoRelay) publishPending(ctx context.Context) {
 	}
 }
 
-// publishMessage publishes a single message to the transport
+// publishMessage publishes a single message to the transport.
+// If the message metadata contains W3C trace context headers, a child span is created
+// to link the relay publish to the original transaction's trace.
 func (r *MongoRelay) publishMessage(ctx context.Context, msg *mongoMessage) error {
-	// msg.Payload is already []byte - pass directly to transport
+	start := time.Now()
+
+	// Extract trace context from metadata if present (W3C traceparent/tracestate)
+	var spanCtx trace.SpanContext
+	if msg.Metadata != nil {
+		carrier := propagation.MapCarrier(msg.Metadata)
+		extracted := otel.GetTextMapPropagator().Extract(ctx, carrier)
+		spanCtx = trace.SpanContextFromContext(extracted)
+	}
+
+	if spanCtx.IsValid() {
+		ctx = trace.ContextWithRemoteSpanContext(ctx, spanCtx)
+	}
+	tracer := otel.Tracer("outbox.mongo_relay")
+	ctx, span := tracer.Start(ctx, fmt.Sprintf("outbox.publish %s", msg.EventName),
+		trace.WithAttributes(
+			attribute.String("event.name", msg.EventName),
+			attribute.String("event.id", msg.EventID),
+		),
+		trace.WithSpanKind(trace.SpanKindProducer))
+	defer span.End()
+
 	transportMsg := message.New(
 		msg.EventID,
 		"outbox",
 		msg.Payload,
 		msg.Metadata,
+		message.WithSpanContext(span.SpanContext()),
 	)
 
-	return r.transport.Publish(ctx, msg.EventName, transportMsg)
+	err := r.transport.Publish(ctx, msg.EventName, transportMsg)
+	duration := time.Since(start)
+
+	if err != nil {
+		span.RecordError(err)
+		if r.metrics != nil {
+			r.metrics.RecordFailed(ctx, msg.EventName)
+		}
+		return err
+	}
+
+	if r.metrics != nil {
+		r.metrics.RecordPublished(ctx, msg.EventName, duration)
+	}
+	return nil
 }
 
 // cleanup removes old published messages
@@ -316,6 +369,9 @@ func (r *MongoRelay) cleanup(ctx context.Context) {
 
 	if deleted > 0 {
 		r.log().Info("cleaned up old outbox messages", "count", deleted)
+		if r.metrics != nil {
+			r.metrics.RecordCleaned(ctx, deleted)
+		}
 	}
 }
 

--- a/outbox/relay_mongo_changestream.go
+++ b/outbox/relay_mongo_changestream.go
@@ -13,6 +13,10 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ResumeTokenStore defines the interface for persisting Change Stream resume tokens.
@@ -103,6 +107,7 @@ type ChangeStreamRelay struct {
 	batchSize        int
 	resumeTokenStore ResumeTokenStore
 	fullDocumentMode string // "updateLookup" or "whenAvailable" for MongoDB 6.0+
+	metrics          *Metrics
 
 	mu          sync.Mutex
 	resumeToken bson.Raw
@@ -162,6 +167,12 @@ func (r *ChangeStreamRelay) WithBatchSize(size int) *ChangeStreamRelay {
 // If not set, the relay will start from the current time on restart.
 func (r *ChangeStreamRelay) WithResumeTokenStore(store ResumeTokenStore) *ChangeStreamRelay {
 	r.resumeTokenStore = store
+	return r
+}
+
+// WithMetrics enables OpenTelemetry metrics for the relay.
+func (r *ChangeStreamRelay) WithMetrics(m *Metrics) *ChangeStreamRelay {
+	r.metrics = m
 	return r
 }
 
@@ -361,16 +372,54 @@ func (r *ChangeStreamRelay) claimMessage(ctx context.Context, id bson.ObjectID) 
 }
 
 // publishMessage publishes a single message to the transport.
+// If the message metadata contains W3C trace context headers, a child span is created
+// to link the relay publish to the original transaction's trace.
 func (r *ChangeStreamRelay) publishMessage(ctx context.Context, msg *mongoMessage) error {
-	// msg.Payload is already []byte - pass directly to transport
+	start := time.Now()
+
+	// Extract trace context from metadata if present (W3C traceparent/tracestate)
+	var spanCtx trace.SpanContext
+	if msg.Metadata != nil {
+		carrier := propagation.MapCarrier(msg.Metadata)
+		extracted := otel.GetTextMapPropagator().Extract(ctx, carrier)
+		spanCtx = trace.SpanContextFromContext(extracted)
+	}
+
+	if spanCtx.IsValid() {
+		ctx = trace.ContextWithRemoteSpanContext(ctx, spanCtx)
+	}
+	tracer := otel.Tracer("outbox.changestream_relay")
+	ctx, span := tracer.Start(ctx, fmt.Sprintf("outbox.publish %s", msg.EventName),
+		trace.WithAttributes(
+			attribute.String("event.name", msg.EventName),
+			attribute.String("event.id", msg.EventID),
+		),
+		trace.WithSpanKind(trace.SpanKindProducer))
+	defer span.End()
+
 	transportMsg := message.New(
 		msg.EventID,
 		"outbox",
 		msg.Payload,
 		msg.Metadata,
+		message.WithSpanContext(span.SpanContext()),
 	)
 
-	return r.transport.Publish(ctx, msg.EventName, transportMsg)
+	err := r.transport.Publish(ctx, msg.EventName, transportMsg)
+	duration := time.Since(start)
+
+	if err != nil {
+		span.RecordError(err)
+		if r.metrics != nil {
+			r.metrics.RecordFailed(ctx, msg.EventName)
+		}
+		return err
+	}
+
+	if r.metrics != nil {
+		r.metrics.RecordPublished(ctx, msg.EventName, duration)
+	}
+	return nil
 }
 
 // saveResumeToken persists the resume token for crash recovery.
@@ -434,6 +483,9 @@ func (r *ChangeStreamRelay) cleanup(ctx context.Context) {
 
 	if deleted > 0 {
 		r.log().Info("cleaned up old outbox messages", "count", deleted)
+		if r.metrics != nil {
+			r.metrics.RecordCleaned(ctx, deleted)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **MongoRelay / ChangeStreamRelay metrics**: Add `WithMetrics(*Metrics)` builder method to both relay types. `publishMessage` now records `RecordPublished`/`RecordFailed` (with duration for published), and `cleanup` records `RecordCleaned`.
- **MongoRelay / ChangeStreamRelay tracing**: `publishMessage` now creates an OTel producer span per message, extracts W3C trace context from message metadata to link back to the original transaction's trace, and attaches the span context to the outgoing transport message. This mirrors the existing tracing in the generic `Relay.publishMessage`.
- **Metrics propagation**: `MongoRelay.startChangeStream` passes its configured `*Metrics` to the delegated `ChangeStreamRelay` automatically.
- **Async index creation**: `NewMongoStore` now creates indexes in a background goroutine so service startup is not delayed by index creation on large collections.

## Test plan

- [ ] `go build ./outbox/...` passes (no compile errors)
- [ ] `go test ./outbox/...` passes
- [ ] Manually verify a relay instance with `WithMetrics` emits counters and histograms
- [ ] Verify trace spans appear in backend when OTel exporter is configured