### PR TITLE
feat(metrics): add operation dimension to bridge metrics and filter-drop counter

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -66,9 +66,10 @@ type Bus struct {
 	busAttr          attribute.KeyValue // bus="name" attribute for all metrics
 	publishedCounter metric.Int64Counter
 	subscribedCounter metric.Int64Counter
-	publishDuration  metric.Float64Histogram
-	handlerDuration  metric.Float64Histogram
-	handlerErrors    metric.Int64Counter
+	publishDuration       metric.Float64Histogram
+	handlerDuration       metric.Float64Histogram
+	handlerErrors         metric.Int64Counter
+	filterDroppedCounter  metric.Int64Counter
 }
 
 // NewBus creates a new event bus and registers it in the global registry.
@@ -134,6 +135,9 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0))
 		bus.handlerErrors, _ = meter.Int64Counter("event.handler_errors_total",
 			metric.WithDescription("Total number of subscriber handler errors"))
+		bus.filterDroppedCounter, _ = meter.Int64Counter("event_messages_filter_dropped_total",
+			metric.WithDescription("Messages silently dropped by WithMessageFilter before handler dispatch"),
+			metric.WithUnit("{message}"))
 		initGauges(meter)
 	}
 
@@ -193,6 +197,24 @@ func (b *Bus) PoisonDetector() PoisonDetector {
 // MonitorStore returns the bus-level monitor store (may be nil)
 func (b *Bus) MonitorStore() MonitorStore {
 	return b.monitorStore
+}
+
+// recordFilterDrop increments the filter-drop counter when a message is
+// rejected by WithMessageFilter before reaching the handler. Both event
+// and operation are used as metric attributes so that cross-stream
+// delivery bugs (e.g. an insert landing in an update-only consumer group)
+// appear as {event="caserecord.updated.global", operation="insert"} spikes.
+func (b *Bus) recordFilterDrop(eventName, operation string) {
+	if b.filterDroppedCounter == nil {
+		return
+	}
+	b.filterDroppedCounter.Add(context.Background(), 1,
+		metric.WithAttributes(
+			b.busAttr,
+			attribute.String("event", eventName),
+			attribute.String("operation", operation),
+		),
+	)
 }
 
 // SchemaProvider returns the bus-level schema provider (may be nil).

--- a/bus_metrics_test.go
+++ b/bus_metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // resetGauges resets gauge registration state so tests can use a fresh meter provider.
@@ -387,5 +388,71 @@ func TestRegisteredEventsAndActiveSubscribersGauges(t *testing.T) {
 	// so total should be 3 (2 on ev1 + 1 on ev2).
 	if int64Gauges["event.active_subscribers"] != 3 {
 		t.Errorf("active_subscribers total: got %d, want 3", int64Gauges["event.active_subscribers"])
+	}
+}
+
+// TestFilterDropCounter verifies that event_messages_filter_dropped_total is
+// incremented when WithMessageFilter rejects a message before handler dispatch.
+// This is the key observable for cross-stream delivery bugs: if an insert
+// lands in an update-only consumer group, the counter records
+// {event="...", operation="insert"} rather than the expected operation type.
+func TestFilterDropCounter(t *testing.T) {
+	reader := setupMetricsProvider(t)
+
+	bus := mustNewBus(t, randomString(8), WithTransport(channel.New()))
+	defer bus.Close(context.Background())
+
+	// Event accepts only messages with operation="update".
+	ev := New[string]("filter-drop-test",
+		WithMessageFilter(func(meta map[string]string) bool {
+			return meta["operation"] == "update"
+		}),
+	)
+	if err := Register(context.Background(), bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	received := make(chan string, 5)
+	if err := ev.Subscribe(context.Background(), func(_ context.Context, _ Event[string], data string) error {
+		received <- data
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// Publish one matching message and two that will be filtered.
+	// We inject directly via the bus transport so we can set the operation
+	// metadata that WithMessageFilter inspects.
+	pub := func(op, val string) {
+		t.Helper()
+		msg := transport.NewMessage(transport.NewID(), "test", []byte(`"`+val+`"`),
+			map[string]string{"operation": op}, trace.SpanContext{})
+		if err := bus.Transport().Publish(ctx, "filter-drop-test", msg); err != nil {
+			t.Fatalf("publish: %v", err)
+		}
+	}
+
+	pub("insert", "ins1")  // filtered
+	pub("update", "upd1")  // passes
+	pub("delete", "del1")  // filtered
+
+	// Wait for the passing message to arrive.
+	select {
+	case got := <-received:
+		if got != "upd1" {
+			t.Errorf("received %q, want upd1", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+	// Give filter drops time to be recorded.
+	time.Sleep(20 * time.Millisecond)
+
+	counters, _, _, _ := collectMetrics(t, reader)
+
+	if got := counters["event_messages_filter_dropped_total"]; got != 2 {
+		t.Errorf("filter_dropped_total = %d, want 2", got)
 	}
 }

--- a/event.go
+++ b/event.go
@@ -672,6 +672,7 @@ func (e *eventImpl[T]) filterMessage(msg transport.Message, bus *Bus, subOpts *s
 
 	// Apply pre-decode message filter
 	if e.messageFilter != nil && !e.messageFilter(msg.Metadata()) {
+		bus.recordFilterDrop(e.name, msg.Metadata()["operation"])
 		_ = msg.Ack(nil)
 		return false
 	}

--- a/transport/bridge/distributed.go
+++ b/transport/bridge/distributed.go
@@ -78,7 +78,7 @@ func DistributedDedup(coord distributed.Coordinator, keyFn DedupKeyFn, ttl time.
 			}
 			if !acquired {
 				if metrics != nil {
-					metrics.RecordSkip(ctx, event)
+					metrics.RecordSkip(ctx, event, msg.Metadata()["operation"])
 				}
 				return nil // another replica won — skip
 			}

--- a/transport/bridge/metrics.go
+++ b/transport/bridge/metrics.go
@@ -139,17 +139,22 @@ func NewMetrics(opts ...MetricsOption) (*Metrics, error) {
 // [Dedup]'s OnSkip callback or [Filter]'s drop path to count
 // messages intentionally not forwarded to the sink.
 //
+// operation should be the source message operation type (e.g. "insert",
+// "update", "delete") extracted from msg.Metadata(). Pass an empty string
+// when the operation is not available or not meaningful.
+//
 //	bridge.Dedup(coord, keyFn, ttl,
 //	    bridge.WithDedupOnSkip(func(event string, msg transport.Message) {
-//	        m.RecordSkip(context.Background(), event)
+//	        m.RecordSkip(context.Background(), event, msg.Metadata()["operation"])
 //	    }),
 //	)
-func (m *Metrics) RecordSkip(ctx context.Context, event string) {
+func (m *Metrics) RecordSkip(ctx context.Context, event, operation string) {
 	if m == nil {
 		return
 	}
 	m.skippedTotal.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("event", event),
+		attribute.String("operation", operation),
 	))
 }
 
@@ -176,7 +181,14 @@ func MetricsMiddleware(m *Metrics) Middleware {
 			return next
 		}
 		return func(ctx context.Context, event string, msg transport.Message) error {
-			attrs := metric.WithAttributes(attribute.String("event", event))
+			// Include operation type (e.g. "insert", "update", "delete") so that
+			// cross-stream routing bugs (wrong pump acquiring a dedup slot) are
+			// visible as operation mismatches on forwarded/failed counters.
+			operation := msg.Metadata()["operation"]
+			attrs := metric.WithAttributes(
+				attribute.String("event", event),
+				attribute.String("operation", operation),
+			)
 
 			m.receivedTotal.Add(ctx, 1, attrs)
 

--- a/transport/bridge/metrics_test.go
+++ b/transport/bridge/metrics_test.go
@@ -213,9 +213,9 @@ func TestRecordSkip(t *testing.T) {
 	m, reader := testBridgeMetrics(t)
 	ctx := context.Background()
 
-	m.RecordSkip(ctx, "orders")
-	m.RecordSkip(ctx, "orders")
-	m.RecordSkip(ctx, "payments")
+	m.RecordSkip(ctx, "orders", "insert")
+	m.RecordSkip(ctx, "orders", "update")
+	m.RecordSkip(ctx, "payments", "insert")
 
 	rm := collectBridgeMetrics(t, reader)
 
@@ -228,7 +228,7 @@ func TestRecordSkip(t *testing.T) {
 func TestRecordSkip_NilMetrics(t *testing.T) {
 	var m *bridge.Metrics
 	// Must not panic.
-	m.RecordSkip(context.Background(), "x")
+	m.RecordSkip(context.Background(), "x", "insert")
 }
 
 // ---------- Dedup + Metrics composition ----------
@@ -244,8 +244,8 @@ func TestDedupWithMetricsSkip(t *testing.T) {
 		bridge.WithMiddleware(
 			bridge.MetricsMiddleware(m),
 			bridge.Dedup(coord, bridge.DefaultDedupKey, time.Minute,
-				bridge.WithDedupOnSkip(func(event string, _ transport.Message) {
-					m.RecordSkip(ctx, event)
+				bridge.WithDedupOnSkip(func(event string, msg transport.Message) {
+					m.RecordSkip(ctx, event, msg.Metadata()["operation"])
 				}),
 			),
 		),
@@ -297,7 +297,7 @@ func TestMetrics_WithNamespace(t *testing.T) {
 		t.Fatalf("NewMetrics: %v", err)
 	}
 
-	m.RecordSkip(context.Background(), "x")
+	m.RecordSkip(context.Background(), "x", "")
 
 	rm := collectBridgeMetrics(t, reader)
 


### PR DESCRIPTION
## Summary

- **Bridge metrics gain `operation` attribute** — `bridge_messages_received_total`, `bridge_messages_forwarded_total`, `bridge_messages_failed_total`, `bridge_messages_skipped_total`, and `bridge_forward_duration_seconds` now carry `{event, operation}` attributes where `operation` is the source message operation type (insert/update/delete/replace) extracted from message metadata. `RecordSkip` gains a required `operation string` parameter.
- **New `event_messages_filter_dropped_total{bus, event, operation}` counter** — incremented every time `WithMessageFilter` silently drops a message before handler dispatch. Previously these drops produced no observable signal anywhere in the stack.

## Motivation

When a `DistributedDedup` race causes the wrong bridge pump to win (e.g. the "updated" pump acquires the dedup slot for an insert), two things happen that were previously invisible:

1. `bridge_messages_forwarded_total{event="caserecord.updated.global"}` rises — but there was no way to tell those forwards carried `operation=insert` instead of `operation=update`
2. The insert lands in the wrong Redis consumer group, `WithMessageFilter` drops it silently (acked, no counter, no log), and the `caserecord.created` handler never fires

With these changes the full race signature is visible in two Grafana queries:
```
bridge_messages_forwarded_total{event="caserecord.updated.global", operation="insert"} > 0
event_messages_filter_dropped_total{event="caserecord.updated.global", operation="insert"} > 0
```

## Breaking change

`bridge.Metrics.RecordSkip` signature changes from `(ctx, event string)` to `(ctx, event, operation string)`. Callers using `bridge.WithDedupOnSkip` to call `RecordSkip` manually must update to pass `msg.Metadata()["operation"]`. The `DistributedDedup` middleware is updated automatically.