### PR TITLE
perf(mongodb): optimize monitor and outbox query performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.48.2
@@ -58,7 +59,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect

--- a/monitor/mongodb.go
+++ b/monitor/mongodb.go
@@ -12,6 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	"golang.org/x/sync/errgroup"
 )
 
 /*
@@ -182,15 +183,27 @@ func (s *MongoStore) Indexes() []mongo.IndexModel {
 			Keys:    bson.D{{Key: "event_id", Value: 1}, {Key: "subscription_id", Value: 1}},
 			Options: options.Index().SetUnique(true),
 		},
-		// event_name + started_at: supports filtering by event with time-range queries
-		// and eliminates in-memory sorts on the result set.
+		// event_name + cursor sort key: covers filtered+paginated List queries on event_name.
 		{
-			Keys: bson.D{{Key: "event_name", Value: 1}, {Key: "started_at", Value: 1}},
+			Keys: bson.D{
+				{Key: "event_name", Value: 1},
+				{Key: "started_at", Value: 1},
+				{Key: "event_id", Value: 1},
+				{Key: "subscription_id", Value: 1},
+			},
 		},
-		// status + started_at: supports "show all failed/pending events in last N hours"
-		// queries without in-memory sorts.
+		// status + cursor sort key: covers filtered+paginated List queries on status.
 		{
-			Keys: bson.D{{Key: "status", Value: 1}, {Key: "started_at", Value: 1}},
+			Keys: bson.D{
+				{Key: "status", Value: 1},
+				{Key: "started_at", Value: 1},
+				{Key: "event_id", Value: 1},
+				{Key: "subscription_id", Value: 1},
+			},
+		},
+		// event_id + started_at: covers GetByEventID (filter by event, sort by time).
+		{
+			Keys: bson.D{{Key: "event_id", Value: 1}, {Key: "started_at", Value: 1}},
 		},
 		// bus_id + started_at: supports per-bus filtering in multi-store deployments.
 		{
@@ -627,6 +640,10 @@ func (s *MongoStore) RecordComplete(ctx context.Context, params event.RecordComp
 }
 
 // Summary returns aggregated statistics using a MongoDB $facet aggregation pipeline.
+//
+// oldest/newest are fetched via separate index-backed FindOne calls rather than
+// $sort+$limit inside $facet, which would force an in-memory sort of the full
+// matched working set. The three operations run concurrently.
 func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, error) {
 	matchStage := s.buildFilter(filter)
 
@@ -674,24 +691,8 @@ func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, erro
 					"failed":  bson.M{"$sum": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{"$status", "failed"}}, 1, 0}}},
 				}}},
 			},
-			"oldest": mongo.Pipeline{
-				{{Key: "$sort", Value: bson.M{"started_at": 1}}},
-				{{Key: "$limit", Value: 1}},
-				{{Key: "$project", Value: bson.M{"started_at": 1}}},
-			},
-			"newest": mongo.Pipeline{
-				{{Key: "$sort", Value: bson.M{"started_at": -1}}},
-				{{Key: "$limit", Value: 1}},
-				{{Key: "$project", Value: bson.M{"started_at": 1}}},
-			},
 		}}},
 	}
-
-	cursor, err := s.collection.Aggregate(ctx, pipeline)
-	if err != nil {
-		return nil, fmt.Errorf("summary aggregate: %w", err)
-	}
-	defer func() { _ = cursor.Close(ctx) }()
 
 	var r struct {
 		ByStatus []struct {
@@ -716,23 +717,63 @@ func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, erro
 			AvgDur *float64 `bson:"avg_dur"`
 			Failed int64    `bson:"failed"`
 		} `bson:"global"`
-		Oldest []struct {
-			StartedAt time.Time `bson:"started_at"`
-		} `bson:"oldest"`
-		Newest []struct {
-			StartedAt time.Time `bson:"started_at"`
-		} `bson:"newest"`
 	}
 
-	if !cursor.Next(ctx) {
-		return &Summary{
-			ByStatus:    make(map[Status]int64),
-			ByEventName: make(map[string]*EventStats),
-		}, nil
+	var oldest, newest time.Time
+	var hasOldest, hasNewest bool
+
+	proj := bson.D{{Key: "started_at", Value: 1}}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		cursor, err := s.collection.Aggregate(egCtx, pipeline)
+		if err != nil {
+			return fmt.Errorf("summary aggregate: %w", err)
+		}
+		defer func() { _ = cursor.Close(egCtx) }()
+		if cursor.Next(egCtx) {
+			return cursor.Decode(&r)
+		}
+		return cursor.Err()
+	})
+
+	eg.Go(func() error {
+		var doc struct {
+			StartedAt time.Time `bson:"started_at"`
+		}
+		err := s.collection.FindOne(egCtx, matchStage,
+			options.FindOne().SetProjection(proj).SetSort(bson.D{{Key: "started_at", Value: 1}}),
+		).Decode(&doc)
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+			return fmt.Errorf("oldest: %w", err)
+		}
+		if err == nil {
+			oldest, hasOldest = doc.StartedAt, true
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		var doc struct {
+			StartedAt time.Time `bson:"started_at"`
+		}
+		err := s.collection.FindOne(egCtx, matchStage,
+			options.FindOne().SetProjection(proj).SetSort(bson.D{{Key: "started_at", Value: -1}}),
+		).Decode(&doc)
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+			return fmt.Errorf("newest: %w", err)
+		}
+		if err == nil {
+			newest, hasNewest = doc.StartedAt, true
+		}
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
-	if err := cursor.Decode(&r); err != nil {
-		return nil, fmt.Errorf("decode summary: %w", err)
-	}
+
 	summary := &Summary{
 		ByStatus:    make(map[Status]int64, len(r.ByStatus)),
 		ByEventName: make(map[string]*EventStats, len(r.ByEvent)),
@@ -777,12 +818,12 @@ func (s *MongoStore) Summary(ctx context.Context, filter Filter) (*Summary, erro
 		}
 	}
 
-	if len(r.Oldest) > 0 {
-		t := r.Oldest[0].StartedAt
+	if hasOldest {
+		t := oldest
 		summary.TimeRange.Oldest = &t
 	}
-	if len(r.Newest) > 0 {
-		t := r.Newest[0].StartedAt
+	if hasNewest {
+		t := newest
 		summary.TimeRange.Newest = &t
 	}
 

--- a/outbox/mongodb.go
+++ b/outbox/mongodb.go
@@ -68,7 +68,8 @@ type mongoMessage struct {
 	Payload     []byte            `bson:"payload"`
 	Metadata    map[string]string `bson:"metadata,omitempty"`
 	CreatedAt   time.Time         `bson:"created_at"`
-	ClaimedAt   *time.Time        `bson:"claimed_at,omitempty"` // When claimed for processing (HA)
+	ClaimedAt   *time.Time        `bson:"claimed_at,omitempty"`
+	ClaimedBy   string            `bson:"claimed_by,omitempty"`
 	PublishedAt *time.Time        `bson:"published_at,omitempty"`
 	Status      Status            `bson:"status"`
 	RetryCount  int               `bson:"retry_count"`
@@ -162,6 +163,7 @@ func (s *MongoStore) Collection() *mongo.Collection {
 //	_, err := collection.Indexes().CreateMany(ctx, indexes)
 func (s *MongoStore) Indexes() []mongo.IndexModel {
 	return []mongo.IndexModel{
+		// Primary relay query: claim next pending/failed message ordered by priority then age.
 		{
 			Keys: bson.D{
 				{Key: "status", Value: 1},
@@ -169,10 +171,21 @@ func (s *MongoStore) Indexes() []mongo.IndexModel {
 				{Key: "created_at", Value: 1},
 			},
 		},
+		// RecoverStuck: find processing messages whose claimed_at has expired.
 		{
 			Keys: bson.D{
-				{Key: "published_at", Value: 1},
+				{Key: "status", Value: 1},
+				{Key: "claimed_at", Value: 1},
 			},
+		},
+		// MarkPublishedByEventID / MarkFailedByEventID: update by application event ID.
+		{
+			Keys: bson.D{{Key: "event_id", Value: 1}},
+		},
+		// Delete: cleanup published messages older than a cutoff.
+		// Sparse so the index only contains documents where published_at is set.
+		{
+			Keys:    bson.D{{Key: "published_at", Value: 1}},
 			Options: options.Index().SetSparse(true),
 		},
 	}
@@ -355,89 +368,107 @@ func (s *MongoStore) Store(ctx context.Context, eventName string, eventID string
 	return err
 }
 
-// GetPending retrieves pending messages for publishing with atomic claiming.
-// Uses FindOneAndUpdate to atomically claim messages, preventing duplicate
-// processing by multiple relay instances in HA deployments.
+// GetPending retrieves pending messages for publishing with atomic batch claiming.
 func (s *MongoStore) GetPending(ctx context.Context, limit int) ([]*Message, error) {
-	var messages []*Message
-
-	for i := 0; i < limit; i++ {
-		msg, err := s.claimNextPending(ctx)
-		if err != nil {
-			if errors.Is(err, mongo.ErrNoDocuments) {
-				break // No more pending messages
-			}
-			return messages, fmt.Errorf("claim pending: %w", err)
-		}
-		messages = append(messages, msg)
-	}
-
-	return messages, nil
-}
-
-// claimNextPending atomically claims a single pending message for processing.
-// Uses FindOneAndUpdate to prevent race conditions in HA deployments.
-func (s *MongoStore) claimNextPending(ctx context.Context) (*Message, error) {
-	filter := bson.M{"status": bson.M{"$in": []Status{StatusPending, StatusFailed}}}
-	update := bson.M{
-		"$set": bson.M{
-			"status":     StatusProcessing,
-			"claimed_at": time.Now(),
-		},
-	}
-	opts := options.FindOneAndUpdate().
-		SetSort(bson.D{{Key: "priority", Value: -1}, {Key: "created_at", Value: 1}}).
-		SetReturnDocument(options.After)
-
-	var mongoMsg mongoMessage
-	err := s.collection.FindOneAndUpdate(ctx, filter, update, opts).Decode(&mongoMsg)
+	msgs, err := s.claimBatch(ctx, limit)
 	if err != nil {
 		return nil, err
 	}
-
-	return mongoMsg.toMessage(), nil
+	result := make([]*Message, len(msgs))
+	for i, m := range msgs {
+		result[i] = m.toMessage()
+	}
+	return result, nil
 }
 
-// getPendingMongo retrieves pending messages as mongoMessage with atomic claiming.
-// Uses FindOneAndUpdate to atomically claim messages, preventing duplicate
-// processing by multiple relay instances in HA deployments.
+// getPendingMongo retrieves pending messages as mongoMessage with atomic batch claiming.
 func (s *MongoStore) getPendingMongo(ctx context.Context, limit int) ([]*mongoMessage, error) {
-	var messages []*mongoMessage
-
-	for i := 0; i < limit; i++ {
-		msg, err := s.claimNextPendingMongo(ctx)
-		if err != nil {
-			if errors.Is(err, mongo.ErrNoDocuments) {
-				break // No more pending messages
-			}
-			return messages, fmt.Errorf("claim pending: %w", err)
-		}
-		messages = append(messages, msg)
-	}
-
-	return messages, nil
+	return s.claimBatch(ctx, limit)
 }
 
-// claimNextPendingMongo atomically claims a single pending message for processing.
-func (s *MongoStore) claimNextPendingMongo(ctx context.Context) (*mongoMessage, error) {
-	filter := bson.M{"status": bson.M{"$in": []Status{StatusPending, StatusFailed}}}
-	update := bson.M{
-		"$set": bson.M{
-			"status":     StatusProcessing,
-			"claimed_at": time.Now(),
-		},
+// claimBatch atomically claims up to limit pending/failed messages in 3 round-trips
+// instead of limit round-trips, regardless of batch size.
+//
+// Algorithm:
+//  1. Find up to limit candidate IDs (read, uses {status,priority,created_at} index)
+//  2. UpdateMany on those IDs with a unique claim token (write, atomic per-doc status check)
+//  3. Fetch the messages we won — IDs we lost to a concurrent relay are excluded by token
+func (s *MongoStore) claimBatch(ctx context.Context, limit int) ([]*mongoMessage, error) {
+	if limit <= 0 {
+		return nil, nil
 	}
-	opts := options.FindOneAndUpdate().
-		SetSort(bson.D{{Key: "priority", Value: -1}, {Key: "created_at", Value: 1}}).
-		SetReturnDocument(options.After)
 
-	var mongoMsg mongoMessage
-	err := s.collection.FindOneAndUpdate(ctx, filter, update, opts).Decode(&mongoMsg)
+	pendingFilter := bson.M{"status": bson.M{"$in": []Status{StatusPending, StatusFailed}}}
+
+	// Step 1: collect candidate IDs ordered by priority then age.
+	candidateCursor, err := s.collection.Find(ctx, pendingFilter,
+		options.Find().
+			SetSort(bson.D{{Key: "priority", Value: -1}, {Key: "created_at", Value: 1}}).
+			SetLimit(int64(limit)).
+			SetProjection(bson.D{{Key: "_id", Value: 1}}),
+	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("find candidates: %w", err)
+	}
+	defer func() { _ = candidateCursor.Close(ctx) }()
+
+	var ids []bson.ObjectID
+	for candidateCursor.Next(ctx) {
+		var doc struct {
+			ID bson.ObjectID `bson:"_id"`
+		}
+		if err := candidateCursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode candidate: %w", err)
+		}
+		ids = append(ids, doc.ID)
+	}
+	if err := candidateCursor.Err(); err != nil {
+		return nil, fmt.Errorf("candidates cursor: %w", err)
+	}
+	if len(ids) == 0 {
+		return nil, nil
 	}
 
-	return &mongoMsg, nil
+	// Step 2: atomically claim. The status check in the filter means any ID
+	// already claimed by a concurrent relay instance is silently skipped.
+	claimToken := uuid.New().String()
+	now := time.Now()
+	_, err = s.collection.UpdateMany(ctx,
+		bson.M{
+			"_id":    bson.M{"$in": ids},
+			"status": bson.M{"$in": []Status{StatusPending, StatusFailed}},
+		},
+		bson.M{"$set": bson.M{
+			"status":     StatusProcessing,
+			"claimed_at": now,
+			"claimed_by": claimToken,
+		}},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("claim batch: %w", err)
+	}
+
+	// Step 3: fetch exactly the messages we claimed.
+	// Primary key lookup on ids (efficient) + claimed_by filter to drop any
+	// that a concurrent relay won the race on between steps 1 and 2.
+	fetchCursor, err := s.collection.Find(ctx, bson.M{
+		"_id":        bson.M{"$in": ids},
+		"claimed_by": claimToken,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch claimed: %w", err)
+	}
+	defer func() { _ = fetchCursor.Close(ctx) }()
+
+	var messages []*mongoMessage
+	for fetchCursor.Next(ctx) {
+		var msg mongoMessage
+		if err := fetchCursor.Decode(&msg); err != nil {
+			return nil, fmt.Errorf("decode message: %w", err)
+		}
+		messages = append(messages, &msg)
+	}
+	return messages, fetchCursor.Err()
 }
 
 // MarkPublished marks a message as successfully published
@@ -569,9 +600,8 @@ func (s *MongoStore) RetryFailed(ctx context.Context, maxRetries int) (int64, er
 		"retry_count": bson.M{"$lt": maxRetries},
 	}
 	update := bson.M{
-		"$set": bson.M{
-			"status": StatusPending,
-		},
+		"$set":   bson.M{"status": StatusPending},
+		"$unset": bson.M{"claimed_by": ""},
 	}
 
 	result, err := s.collection.UpdateMany(ctx, filter, update)
@@ -604,12 +634,8 @@ func (s *MongoStore) RecoverStuck(ctx context.Context, stuckDuration time.Durati
 		"claimed_at": bson.M{"$lt": cutoff},
 	}
 	update := bson.M{
-		"$set": bson.M{
-			"status": StatusPending,
-		},
-		"$unset": bson.M{
-			"claimed_at": "",
-		},
+		"$set":   bson.M{"status": StatusPending},
+		"$unset": bson.M{"claimed_at": "", "claimed_by": ""},
 	}
 
 	result, err := s.collection.UpdateMany(ctx, filter, update)

--- a/outbox/relay_mongo.go
+++ b/outbox/relay_mongo.go
@@ -200,7 +200,7 @@ func (r *MongoRelay) startPolling(ctx context.Context) error {
 func (r *MongoRelay) nextPollTimer(_ context.Context) <-chan time.Time {
 	delay := r.pollDelay
 	if r.pollJitter > 0 {
-		delay += time.Duration(rand.Int64N(int64(r.pollJitter)))
+		delay += time.Duration(rand.Int64N(int64(r.pollJitter))) // #nosec G404 -- jitter needs no cryptographic security
 	}
 	return time.After(delay)
 }

--- a/outbox/relay_mongo.go
+++ b/outbox/relay_mongo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"time"
 
 	"github.com/rbaliyan/event/v3/transport"
@@ -37,6 +38,7 @@ type MongoRelay struct {
 	transport        transport.Transport
 	mode             RelayMode
 	pollDelay        time.Duration
+	pollJitter       time.Duration        // Random jitter added to each poll interval to desynchronise pods
 	batchSize        int
 	logger           *slog.Logger
 	cleanupAge       time.Duration
@@ -96,6 +98,15 @@ func (r *MongoRelay) WithResumeTokenStore(store ResumeTokenStore) *MongoRelay {
 // WithPollDelay sets the polling interval
 func (r *MongoRelay) WithPollDelay(d time.Duration) *MongoRelay {
 	r.pollDelay = d
+	return r
+}
+
+// WithPollJitter sets a maximum random jitter added to each poll interval.
+// Each tick sleeps for pollDelay + rand[0, jitter), desynchronising pods that
+// share the same nominal poll delay and reducing UpdateMany write contention.
+// A jitter of 50% of pollDelay is a reasonable default when running 2+ pods.
+func (r *MongoRelay) WithPollJitter(jitter time.Duration) *MongoRelay {
+	r.pollJitter = jitter
 	return r
 }
 
@@ -163,31 +174,35 @@ func (r *MongoRelay) Start(ctx context.Context) error {
 
 // startPolling runs the relay in polling mode.
 func (r *MongoRelay) startPolling(ctx context.Context) error {
-	ticker := time.NewTicker(r.pollDelay)
-	defer ticker.Stop()
-
-	// Cleanup ticker for old published messages
 	cleanupTicker := time.NewTicker(time.Hour)
 	defer cleanupTicker.Stop()
 
-	// Recovery ticker for stuck messages (check every minute)
 	recoveryTicker := time.NewTicker(time.Minute)
 	defer recoveryTicker.Stop()
 
-	r.log().Info("relay started in poll mode", "poll_delay", r.pollDelay)
+	r.log().Info("relay started in poll mode", "poll_delay", r.pollDelay, "poll_jitter", r.pollJitter)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ticker.C:
-			r.publishPending(ctx)
 		case <-cleanupTicker.C:
 			r.cleanup(ctx)
 		case <-recoveryTicker.C:
 			r.recoverStuck(ctx)
+		case <-r.nextPollTimer(ctx):
+			r.publishPending(ctx)
 		}
 	}
+}
+
+// nextPollTimer returns a channel that fires after pollDelay + rand[0, pollJitter).
+func (r *MongoRelay) nextPollTimer(_ context.Context) <-chan time.Time {
+	delay := r.pollDelay
+	if r.pollJitter > 0 {
+		delay += time.Duration(rand.Int64N(int64(r.pollJitter)))
+	}
+	return time.After(delay)
 }
 
 // startChangeStream runs the relay using MongoDB Change Streams.


### PR DESCRIPTION
## Summary

- **monitor**: extend composite indexes to cover full cursor sort key, add `{event_id,started_at}` index, pull `oldest`/`newest` out of `$facet` into concurrent index-backed `FindOne` calls
- **outbox**: add `{status,claimed_at}` and `{event_id}` indexes, replace serial N×`FindOneAndUpdate` claim loop with a 3-query batch claim, add poll jitter option

## Changes

### monitor/mongodb.go

**Index changes** (two existing indexes extended, one new):

| Before | After | Covers |
|---|---|---|
| `{status, started_at}` | `{status, started_at, event_id, subscription_id}` | Filtered+paginated `List`/`Count` on status — full cursor sort key in one scan |
| `{event_name, started_at}` | `{event_name, started_at, event_id, subscription_id}` | Same for event_name filter |
| _(missing)_ | `{event_id, started_at}` | `GetByEventID` — eliminates in-memory sort |

**`Summary` pipeline** — `oldest`/`newest` pulled out of `$facet`:

Previously computed as `$sort+$limit` sub-pipelines inside `$facet`. After `$match` materializes its working set, indexes no longer apply — those sorts were O(N) over the full matched set (observed: 26s on 24h of data). Now they run as separate `FindOne` calls traversing the `{started_at,...}` index in O(log N), concurrent with the `$facet` aggregation via `errgroup`.

### outbox/mongodb.go + relay_mongo.go

**Root cause of 66% findAndModify error rate:**

With the old serial `FindOneAndUpdate` loop, two relay pods with the same poll delay always targeted the same document (identical sort order). Every tick: 2 pods × 100 `FindOneAndUpdate` calls = 200 `findAndModify` commands racing on the same documents → WiredTiger write conflicts surfacing as `findAndModify` errors.

**Fix 1 — batch claim (eliminates findAndModify entirely):**

`claimBatch` replaces all `FindOneAndUpdate` calls with 3 queries regardless of batch size:

```
1. Find(filter, sort, limit=N, proj={_id:1})           read  — no write conflict possible
2. UpdateMany({_id:$in ids, status:$in [pending,failed]},
              {$set:{status:processing, claimed_by:token}})  write — "update", not "findAndModify"
3. Find({_id:$in ids, claimed_by:token})               read  — primary key lookups
```

`findAndModify` error count drops from ~42/s to zero. At `batchSize=100`/`pollDelay=100ms` the MongoDB write ops also drop from ~1000/s to ~30/s.

**Fix 2 — poll jitter (eliminates UpdateMany contention between pods):**

Even with `claimBatch`, two pods polling in lockstep run their `UpdateMany` on the same documents simultaneously, creating WiredTiger contention. `WithPollJitter` adds `rand[0, jitter)` to each poll interval so one pod completes its claim before the other starts:

```go
relay := outbox.NewMongoRelay(store, transport).
    WithPollJitter(50 * time.Millisecond)
```

**New indexes:**

| Index | Covers |
|---|---|
| `{status, claimed_at}` | `RecoverStuck` — was scanning all `status=processing` docs |
| `{event_id}` | `MarkPublishedByEventID` / `MarkFailedByEventID` — were doing collection scans |

`RetryFailed` and `RecoverStuck` now `$unset claimed_by` when resetting messages to pending.

## Test plan

- [ ] Run `go test ./monitor/... ./outbox/...`
- [ ] On a live collection: `EnsureIndexes` creates new indexes; manually drop the old shorter `{status,started_at}` and `{event_name,started_at}` indexes (superseded by the extended ones)
- [ ] Confirm `Summary` latency improvement on a collection with 24h+ of data
- [ ] Confirm `findAndModify` error rate in MongoDB Atlas drops to zero after deploy
- [ ] Confirm outbox relay throughput improvement with 2+ pods and `WithPollJitter(50ms)`