### PR TITLE
fix(redis): apply both MAXLEN and MINID trimming when both are configured

### DIFF
--- a/transport/redis/options.go
+++ b/transport/redis/options.go
@@ -39,13 +39,15 @@ func WithMaxLen(n int64) Option {
 }
 
 // WithMaxAge sets the max age for messages in streams (MINID-based trimming).
-// Messages older than this duration will be automatically trimmed on each publish.
+// Messages older than this duration will be trimmed on each publish.
 //
-// This ensures messages don't stay in Redis forever when no consumers are registered.
-// Redis Streams use timestamp-based IDs, so this calculates MINID from (now - maxAge).
+// When used alone (no WithMaxLen), MINID trimming is applied directly on XADD.
+// When used together with WithMaxLen, count-based trimming is applied on XADD
+// and age-based trimming is applied as a separate XTRIM MINID call after the
+// XADD — both constraints are enforced, non-atomically. XTRIM failure is
+// non-fatal: the count cap from WithMaxLen already prevents unbounded growth.
 //
-// Set to 0 (default) for unlimited retention (messages stay forever).
-// Recommended: Set this to a reasonable value (e.g., 24*time.Hour) for production.
+// Set to 0 (default) for no age-based trimming.
 func WithMaxAge(d time.Duration) Option {
 	return func(t *Transport) {
 		if d > 0 {

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -30,6 +30,7 @@ import (
 // Supports *redis.Client, *redis.ClusterClient, and redis.UniversalClient.
 type Client interface {
 	XAdd(ctx context.Context, a *redis.XAddArgs) *redis.StringCmd
+	XTrimMinIDApprox(ctx context.Context, key string, minID string, limit int64) *redis.IntCmd
 	XGroupCreateMkStream(ctx context.Context, stream, group, start string) *redis.StatusCmd
 	XGroupDestroy(ctx context.Context, stream, group string) *redis.IntCmd
 	XReadGroup(ctx context.Context, a *redis.XReadGroupArgs) *redis.XStreamSliceCmd
@@ -210,14 +211,16 @@ func (t *Transport) Publish(ctx context.Context, name string, msg transport.Mess
 		},
 	}
 
-	// Apply trimming: MINID takes precedence over MAXLEN when both are set,
-	// since combining them in a single XADD is only supported in Redis 7+.
-	if t.maxAge > 0 {
+	// Apply count-based trimming on XADD (hard cap regardless of message age).
+	// When only maxAge is set (no maxLen), fall back to MINID on XADD.
+	// Redis XADD only accepts one trimming strategy per call; age-based cleanup
+	// when both are set is applied via a separate XTRIM below.
+	if t.maxLen > 0 {
+		args.MaxLen = t.maxLen
+		args.Approx = true
+	} else if t.maxAge > 0 {
 		minTime := time.Now().Add(-t.maxAge).UnixMilli()
 		args.MinID = fmt.Sprintf("%d-0", minTime)
-		args.Approx = true
-	} else if t.maxLen > 0 {
-		args.MaxLen = t.maxLen
 		args.Approx = true
 	}
 
@@ -233,6 +236,19 @@ func (t *Transport) Publish(ctx context.Context, name string, msg transport.Mess
 	}
 
 	t.cb.RecordSuccess()
+
+	// When both maxLen and maxAge are configured, apply age-based cleanup as a
+	// separate XTRIM MINID after the XADD. Redis XADD cannot apply both in one
+	// command. XTRIM failure is non-fatal — the count cap already prevents OOM.
+	// Intentionally not calling cb.RecordFailure() here: the XADD succeeded so
+	// the publish succeeded; XTRIM is best-effort secondary cleanup only.
+	if t.maxLen > 0 && t.maxAge > 0 {
+		minTime := time.Now().Add(-t.maxAge).UnixMilli()
+		minID := fmt.Sprintf("%d-0", minTime)
+		if trimErr := t.client.XTrimMinIDApprox(ctx, streamName, minID, 0).Err(); trimErr != nil {
+			t.logger.Debug("age trim failed (non-fatal)", "stream", streamName, "error", trimErr)
+		}
+	}
 
 	t.logger.Debug("published message", "event", name, "msg_id", msg.ID())
 	return nil

--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -197,6 +197,12 @@ func (m *mockRedisClient) XInfoGroups(ctx context.Context, stream string) *redis
 	return cmd
 }
 
+func (m *mockRedisClient) XTrimMinIDApprox(ctx context.Context, key string, minID string, limit int64) *redis.IntCmd {
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(0)
+	return cmd
+}
+
 func (m *mockRedisClient) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Problem

`Publish()` applied MINID (age-based) **or** MAXLEN (count-based) in a single `XADD` — `maxAge` took priority and silently ignored `maxLen`. Callers who set both `WithMaxAge` and `WithMaxLen` had their count cap silently dropped, allowing streams to grow unboundedly until the age window expired.

In production this caused Redis OOM: a default `maxAge=24h` was set upstream, which meant `maxLen=10_000` was never applied. In high-throughput systems (e.g. MongoDB change event bridges) streams accumulated millions of entries per day.

## Root Cause

Redis `XADD` only accepts **one** trimming strategy per call (either `MAXLEN` or `MINID`, not both). The previous `else if` logic made `maxAge` silently win. The doc comment was also wrong — it claimed combining both requires Redis 7+, but no Redis version supports both in a single `XADD`.

## Fix

Use two commands when both limits are set:
1. `XADD` with `MAXLEN ~` — count cap, applied on every publish
2. `XTRIM MINID ~` — age cleanup, separate follow-up, **non-fatal** on failure

When only one limit is configured, behaviour is unchanged:
- `maxLen` only → `XADD MAXLEN` (unchanged)
- `maxAge` only → `XADD MINID` (unchanged)
- both → `XADD MAXLEN` + `XTRIM MINID` (new)

The `XTRIM` failure does not trigger the circuit breaker because the `XADD` succeeded and the count cap already prevents unbounded growth.

## Changes

- `redis.go` — fixed `Publish()` trimming precedence; added `XTrimMinIDApprox` to `Client` interface
- `options.go` — corrected `WithMaxAge` doc comment
- `redis_test.go` — added `XTrimMinIDApprox` stub to `mockRedisClient`

## Test plan

- [ ] Existing redis transport tests pass (`go test ./transport/redis/...`)
- [ ] Verify with a Redis instance: publish with both `WithMaxLen(100)` and `WithMaxAge(1s)`, confirm stream stays ≤100 entries and old entries are deleted after 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)