### PR TITLE
docs: remove stale MongoDB references, add event-mongodb migration note

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -96,8 +96,8 @@ No breaking changes planned. All v3.x APIs will remain stable.
 
 All store implementations follow the same interface patterns:
 
-| Store Type | PostgreSQL | MongoDB | Redis | Memory |
-|------------|:----------:|:-------:|:-----:|:------:|
+| Store Type | PostgreSQL | MongoDB† | Redis | Memory |
+|------------|:----------:|:--------:|:-----:|:------:|
 | Scheduler | ✅ | ✅ | ✅ | - |
 | DLQ | ✅ | ✅ | ✅ | ✅ |
 | Saga | ✅ | ✅ | ✅ | ✅ |
@@ -105,6 +105,8 @@ All store implementations follow the same interface patterns:
 | Schema | ✅ | ✅ | ✅ | ✅ |
 | Idempotency | ✅ | ✅ | ✅ | ✅ |
 | Poison | ✅ | - | ✅ | ✅ |
+
+† MongoDB store implementations are provided by the [event-mongodb](https://github.com/rbaliyan/event-mongodb) module, not this package.
 
 ## Middleware Chain Order
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A **production-grade event pub-sub library** for Go with support for distributed
 - **Delivery Modes**: Broadcast (fan-out) or WorkerPool (load balancing)
 
 ### Reliability
-- **Transactional Outbox**: Atomic publish with database writes (PostgreSQL, MongoDB, Redis)
+- **Transactional Outbox**: Atomic publish with database writes (PostgreSQL, Redis; MongoDB via [event-mongodb](https://github.com/rbaliyan/event-mongodb))
 - **Idempotency**: Prevent duplicate processing (Redis, PostgreSQL, in-memory)
 - **Poison Detection**: Auto-quarantine repeatedly failing messages
 - **At-Least-Once Delivery**: Via Redis Streams, NATS, or Kafka
@@ -51,7 +51,9 @@ All packages share consistent patterns:
 - Functional options for configuration
 - Health checks via `health.Checker` interface
 - OpenTelemetry metrics support
-- Multiple backend implementations (PostgreSQL, MongoDB, Redis)
+- Multiple backend implementations (PostgreSQL, Redis, and MongoDB via event-mongodb)
+
+> **Note:** MongoDB implementations for outbox, monitor, distributed state manager, schema, idempotency, and checkpoint were moved to the [event-mongodb](https://github.com/rbaliyan/event-mongodb) module. See each section below for migration details.
 
 ## Installation
 
@@ -210,10 +212,9 @@ func main() {
     db := client.Database("myapp")
 
     // Watch a specific collection
-    transport := mongodb.New(db,
+    transport, _ := mongodb.New(db,
         mongodb.WithCollection("orders"),
         mongodb.WithFullDocument(mongodb.FullDocumentUpdateLookup),
-        mongodb.WithResumeTokenStore(mongodb.NewMongoResumeTokenStore(db)),
     )
 
     bus, _ := event.NewBus("order-watcher", event.WithTransport(transport))
@@ -408,7 +409,10 @@ mongoEvent.Subscribe(ctx, handler,
 For transports without re-delivery (e.g., MongoDB Change Streams), the middleware automatically stores message payload so the RecoveryRunner can re-publish stale events if a worker crashes:
 
 ```go
-coord, _ := distributed.NewMongoStateManager(db)
+// Redis-backed coordinator with payload recovery
+coord, _ := distributed.NewRedisStateManager(redisClient,
+    distributed.WithCompletedTTL(48*time.Hour),
+)
 
 // RecoveryRunner detects PayloadStore capability automatically
 runner, _ := distributed.NewRecoveryRunner(coord,
@@ -419,6 +423,8 @@ runner, _ := distributed.NewRecoveryRunner(coord,
 
 go runner.Run(ctx)
 ```
+
+For MongoDB-backed payload recovery, use `distributed.NewMongoStateManager` from the [event-mongodb](https://github.com/rbaliyan/event-mongodb) module.
 
 Recovery is two-phase:
 1. **Re-publish**: Stale entries with stored payload are re-published via the bus with a new event ID
@@ -443,15 +449,17 @@ orderEvent.Subscribe(ctx, collectAnalytics,
 | Backend | Package | Use Case |
 |---------|---------|----------|
 | Redis | `distributed.NewRedisStateManager` | Distributed deployments (recommended) |
-| MongoDB | `distributed.NewMongoStateManager` | When MongoDB is already your primary store |
+| MongoDB | `distributed.NewMongoStateManager` (event-mongodb) | When MongoDB is already your primary store |
 | Memory | `distributed.NewMemoryStateManager` | Single-instance or testing |
 
 All three backends implement both `Coordinator` and `PayloadStore` interfaces.
 
+The MongoDB backend is provided by the [event-mongodb](https://github.com/rbaliyan/event-mongodb) module.
+
 ### Worker Observability
 
 Query active and completed worker states using the `WorkerStore` interface
-(implemented by `MongoStateManager` and `MemoryStateManager`):
+(implemented by `MemoryStateManager` and `MongoStateManager` from event-mongodb):
 
 ```go
 page, _ := sm.ListWorkers(ctx, distributed.WorkerFilter{
@@ -480,7 +488,7 @@ import (
 func main() {
     ctx := context.Background()
 
-    store, _ := outbox.NewMongoStore(mongoClient.Database("myapp"))
+    store, _ := outbox.NewPostgresStore(db)
 
     bus, _ := event.NewBus("order-service",
         event.WithTransport(transport),
@@ -495,19 +503,23 @@ func main() {
     orderEvent.Publish(ctx, Order{ID: "123"})
 
     // Inside transaction - automatically routes to outbox
-    err := outbox.Transaction(ctx, mongoClient, func(ctx context.Context) error {
-        _, err := ordersCol.InsertOne(ctx, order)
-        if err != nil {
-            return err
-        }
-        return orderEvent.Publish(ctx, order) // Goes to outbox
-    })
+    tx, _ := db.BeginTx(ctx, nil)
+    ctx = event.WithOutboxTx(ctx, tx)
+    _, err := tx.ExecContext(ctx, "INSERT INTO orders ...")
+    if err != nil {
+        tx.Rollback()
+        return
+    }
+    orderEvent.Publish(ctx, order) // Goes to outbox
+    tx.Commit()
 
     // Start relay to publish from outbox to transport
-    relay := outbox.NewMongoRelay(store, transport)
+    relay := outbox.NewRelay(store, transport)
     go relay.Start(ctx)
 }
 ```
+
+For MongoDB outbox support, use the [event-mongodb](https://github.com/rbaliyan/event-mongodb) module.
 
 ## Idempotency
 
@@ -598,7 +610,7 @@ Endpoints:
 
 ### Worker Pool State (HTTP)
 
-When using distributed worker pools with MongoDB, expose worker state
+When using distributed worker pools, expose worker state
 via the monitor HTTP handler:
 
 ```go
@@ -768,8 +780,8 @@ if err := orderSaga.Execute(ctx, sagaID, order); err != nil {
 
 ## Database Support
 
-| Component | PostgreSQL | MongoDB | Redis | In-Memory |
-|-----------|:----------:|:-------:|:-----:|:---------:|
+| Component | PostgreSQL | MongoDB† | Redis | In-Memory |
+|-----------|:----------:|:--------:|:-----:|:---------:|
 | Outbox | ✅ | ✅ | ✅ | - |
 | Idempotency | ✅ | ✅ | ✅ | ✅ |
 | Poison | ✅ | - | ✅ | ✅ |
@@ -779,6 +791,8 @@ if err := orderSaga.Execute(ctx, sagaID, order); err != nil {
 | Scheduler | ✅ | ✅ | ✅ | - |
 | Saga | ✅ | ✅ | ✅ | ✅ |
 | Distributed WP | - | ✅ | ✅ | ✅ |
+
+† MongoDB implementations are provided by the separate [event-mongodb](https://github.com/rbaliyan/event-mongodb) module.
 
 ## Testing
 

--- a/bus_options.go
+++ b/bus_options.go
@@ -208,7 +208,7 @@ func WithStrictSchema(strict bool) BusOption {
 //
 // Example:
 //
-//	store := outbox.NewMongoStore(mongoClient, "events", "outbox")
+//	store, _ := outbox.NewPostgresStore(db)
 //	bus, _ := event.NewBus("my-app",
 //	    event.WithTransport(transport),
 //	    event.WithOutbox(store),
@@ -218,11 +218,13 @@ func WithStrictSchema(strict bool) BusOption {
 //	orderEvent.Publish(ctx, order)
 //
 //	// Inside transaction - goes to outbox
-//	sess.WithTransaction(ctx, func(sessCtx mongo.SessionContext) (any, error) {
-//	    ctx := event.WithOutboxTx(sessCtx, sessCtx)
-//	    ordersCol.UpdateOne(ctx, filter, update)
-//	    return nil, orderEvent.Publish(ctx, order) // Routed to outbox!
-//	})
+//	tx, _ := db.BeginTx(ctx, nil)
+//	ctx = event.WithOutboxTx(ctx, tx)
+//	tx.ExecContext(ctx, "UPDATE orders SET status = $1 WHERE id = $2", "paid", orderID)
+//	orderEvent.Publish(ctx, order) // Routed to outbox!
+//
+// For MongoDB outbox, use the separate event-mongodb module:
+// https://github.com/rbaliyan/event-mongodb
 func WithOutbox(store OutboxStore) BusOption {
 	return func(o *busOptions) {
 		if store != nil {
@@ -238,7 +240,7 @@ func WithOutbox(store OutboxStore) BusOption {
 //
 // Example:
 //
-//	dlqStore := dlq.NewMongoStore(db, dlq.WithCollection("_dlq"))
+//	dlqStore := dlq.NewPostgresStore(db)
 //	bus, _ := event.NewBus("my-app",
 //	    event.WithTransport(transport),
 //	    event.WithDLQ(dlq.NewStoreAdapter(dlqStore, "my-service")),

--- a/checkpoint/memory.go
+++ b/checkpoint/memory.go
@@ -9,7 +9,8 @@ import (
 // MemoryCheckpointStore is an in-memory checkpoint store for testing.
 //
 // This store is not suitable for production as data is lost on restart.
-// Use RedisStore or MongoStore for production workloads.
+// Use RedisStore for production workloads, or the MongoDB checkpoint store
+// from the event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 type MemoryCheckpointStore struct {
 	mu          sync.RWMutex
 	checkpoints map[string]time.Time

--- a/checkpoint/redis.go
+++ b/checkpoint/redis.go
@@ -5,7 +5,7 @@
 //
 // Available implementations:
 //   - RedisStore: Production-ready Redis-backed store
-//   - MongoStore: Production-ready MongoDB-backed store
+//   - For MongoDB checkpoint storage, use the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 //
 // Usage with event subscriptions:
 //

--- a/distributed/claimer.go
+++ b/distributed/claimer.go
@@ -23,8 +23,8 @@
 //   - PayloadStore: Optional interface for persisting message payload for recovery
 //   - WorkerPoolMiddleware: Middleware that uses a Coordinator to emulate WorkerPool
 //   - RedisStateManager: Redis-based implementation using atomic SETNX
-//   - MongoStateManager: MongoDB-based implementation using findOneAndUpdate
 //   - MemoryStateManager: In-memory implementation for single-instance or testing
+//   - For MongoDB, use NewMongoStateManager from the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 //
 // Architecture:
 //
@@ -99,8 +99,8 @@ import (
 //
 // Implementations:
 //   - RedisStateManager: Uses Redis atomic SETNX for distributed deployments
-//   - MongoStateManager: Uses MongoDB atomic findOneAndUpdate
 //   - MemoryStateManager: In-memory for single-instance or testing
+//   - For MongoDB, use NewMongoStateManager from the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 type Coordinator interface {
 	// Acquire atomically transitions a message to "processing" state.
 	//
@@ -130,9 +130,9 @@ type Coordinator interface {
 //   - RecoveryRunner re-publishes stale events via the injected Publisher
 //
 // Implementations:
-//   - MongoStateManager: Stores payload in the same document (atomic with state)
 //   - RedisStateManager: Stores payload in a companion key
 //   - MemoryStateManager: Stores payload in memory (for testing)
+//   - For MongoDB, use NewMongoStateManager from the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 type PayloadStore interface {
 	// StorePayload persists payload alongside a message ID.
 	// Called after a successful Acquire when the transport doesn't support
@@ -193,7 +193,7 @@ type stateOptions struct {
 	cleanupEnabled bool
 	cleanupPeriod  time.Duration
 	instanceID     string
-	// MongoDB-specific options (only used by NewMongoStateManager)
+	// options reserved for use by external state manager implementations
 	collectionName string
 	capped         bool
 	cappedSize     int64
@@ -250,10 +250,10 @@ func WithCleanup(enabled bool, period time.Duration) Option {
 	}
 }
 
-// WithCollection sets the MongoDB collection name for state storage.
+// WithCollection sets the collection name for state storage.
 //
-// This option is only used by NewMongoStateManager and is ignored by other
-// state manager implementations.
+// This option is used by external state manager implementations (e.g., MongoDB)
+// and is ignored by the built-in Redis and Memory state managers.
 //
 // Default: "_message_state"
 func WithCollection(name string) Option {
@@ -279,10 +279,11 @@ func WithInstanceID(id string) Option {
 	}
 }
 
-// WithCapped enables MongoDB capped collection mode for high-throughput scenarios.
+// WithCapped enables capped collection mode for high-throughput scenarios.
 //
-// This option is only used by NewMongoStateManager and is ignored by other
-// state manager implementations.
+// This option is used by external state manager implementations that support
+// capped collections (e.g., MongoDB via event-mongodb) and is ignored by
+// the built-in Redis and Memory state managers.
 //
 // Capped collections are fixed-size collections that automatically remove
 // the oldest documents when the size limit is reached.
@@ -291,7 +292,7 @@ func WithInstanceID(id string) Option {
 //   - sizeBytes: Maximum collection size in bytes (required, minimum 4096)
 //   - maxDocs: Maximum number of documents (0 = unlimited, size-based only)
 //
-// IMPORTANT LIMITATIONS:
+// IMPORTANT LIMITATIONS (when used with MongoDB):
 //   - Reset() becomes a no-op (MongoDB doesn't allow deletes in capped collections)
 //   - No TTL index support
 //   - Failed states wait for size-based removal

--- a/distributed/memory.go
+++ b/distributed/memory.go
@@ -32,7 +32,9 @@ type stateEntry struct {
 // IMPORTANT: MemoryStateManager does NOT provide distributed coordination.
 // In multi-instance deployments, each instance has its own independent state,
 // so the same message could be processed by multiple instances. Use
-// RedisStateManager or MongoStateManager for production distributed deployments.
+// RedisStateManager or a MongoDB-backed state manager (available in the
+// event-mongodb module: https://github.com/rbaliyan/event-mongodb) for
+// production distributed deployments.
 //
 // Features:
 //   - Thread-safe using mutex synchronization

--- a/distributed/recovery.go
+++ b/distributed/recovery.go
@@ -40,12 +40,15 @@ import (
 //
 // Example:
 //
-//	coord := distributed.NewMongoStateManager(db)
+//	coord, _ := distributed.NewRedisStateManager(redisClient)
 //	runner := distributed.NewRecoveryRunner(coord,
 //	    distributed.WithStaleTimeout(2*time.Minute),
 //	    distributed.WithCheckInterval(30*time.Second),
 //	    distributed.WithPublisher(bus), // enables payload-aware recovery
 //	)
+//
+// For MongoDB-backed recovery, use NewMongoStateManager from the
+// event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 //
 //	// Start recovery in background
 //	ctx, cancel := context.WithCancel(context.Background())

--- a/distributed/redis.go
+++ b/distributed/redis.go
@@ -422,8 +422,9 @@ func (s *RedisStateManager) StorePayload(ctx context.Context, messageID string, 
 //
 // Performance note: this scans ALL stale state keys via SCAN, then checks each
 // one for a companion payload key. For large key spaces (>10k stale states),
-// consider using MongoDB-backed state management or setting a batch limit on
-// the RecoveryRunner to cap the number of entries processed per cycle.
+// consider setting a batch limit on the RecoveryRunner to cap the number of
+// entries processed per cycle, or use a MongoDB-backed state manager from the
+// event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 func (s *RedisStateManager) LoadStalePayloads(ctx context.Context, staleTimeout time.Duration, limit int) ([]*StaleMessage, error) {
 	cutoff := time.Now().Add(-staleTimeout)
 	// Scan without limit since we need to filter by payload existence after
@@ -465,7 +466,9 @@ func (s *RedisStateManager) ClearPayload(ctx context.Context, messageID string) 
 
 // RedisStateManager does not implement WorkerStore because listing
 // worker entries via Redis SCAN is O(N) and impractical at scale.
-// Use MongoStateManager or MemoryStateManager for worker observability.
+// Use MemoryStateManager for worker observability in single-instance deployments,
+// or MongoStateManager from the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
+// for distributed worker observability.
 
 // Compile-time interface checks
 var (

--- a/doc.go
+++ b/doc.go
@@ -115,6 +115,7 @@
 //	orderEvent := event.New[Order]("order.created")
 //	event.Register(ctx, bus, orderEvent)  // Schema applied automatically
 //
-// Schema providers: MemoryProvider, PostgresProvider, MongoProvider, RedisProvider.
+// Schema providers: MemoryProvider, PostgresProvider, RedisProvider.
+// For MongoDB schema storage, use the separate event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 // Use WithStrictSchema(true) to fail registration if schema provider returns an error.
 package event

--- a/idempotency/store.go
+++ b/idempotency/store.go
@@ -12,9 +12,11 @@
 //   - Store interface for idempotency tracking
 //   - MemoryStore for single-instance deployments
 //   - RedisStore for distributed deployments with Redis
-//   - MongoStore for distributed deployments with MongoDB
 //   - PostgresStore for distributed deployments with PostgreSQL
 //   - TransactionalStore for database transaction support
+//
+// For MongoDB idempotency storage, use the event-mongodb module:
+// https://github.com/rbaliyan/event-mongodb
 //
 // # Basic Usage
 //
@@ -248,8 +250,7 @@ type TransactionalStore interface {
 	// IsDuplicateTx checks for duplicate within a database transaction.
 	//
 	// The tx parameter is the active database transaction. Implementations
-	// should type-assert to the expected type (e.g., *sql.Tx for SQL databases,
-	// mongo.SessionContext for MongoDB).
+	// should type-assert to the expected type (e.g., *sql.Tx for SQL databases).
 	//
 	// Parameters:
 	//   - ctx: Context for cancellation and deadlines

--- a/middleware.go
+++ b/middleware.go
@@ -305,7 +305,7 @@ type RecordStartParams struct {
 // Implementations:
 //   - monitor.NewMemoryStore(): In-memory store for development/testing
 //   - monitor.NewPostgresStore(db): PostgreSQL-based persistent store
-//   - monitor.NewMongoStore(db): MongoDB-based persistent store
+//   - For MongoDB, use the separate event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 //
 // Example:
 //

--- a/outbox.go
+++ b/outbox.go
@@ -16,10 +16,10 @@ import (
 //	orderEvent.Publish(ctx, order)
 //
 //	// Inside transaction - goes to outbox
-//	outbox.Transaction(ctx, mongoClient, func(ctx context.Context) error {
-//	    ordersCol.UpdateOne(ctx, filter, update)
-//	    return orderEvent.Publish(ctx, order)  // Routed to outbox!
-//	})
+//	tx, _ := db.BeginTx(ctx, nil)
+//	ctx = event.WithOutboxTx(ctx, tx)
+//	ordersTable.UpdateOne(ctx, filter, update)
+//	orderEvent.Publish(ctx, order) // Routed to outbox!
 type OutboxStore interface {
 	// Store persists a message in the outbox within the active transaction.
 	// The transaction session should be extracted from the context.
@@ -41,16 +41,16 @@ type outboxTxKey struct{}
 // WithOutboxTx adds a transaction session to the context.
 // This signals to the Bus that publishes should go to outbox instead of transport.
 //
-// The session value is implementation-specific (e.g., mongo.SessionContext for MongoDB).
+// The session value is implementation-specific (e.g., *sql.Tx for PostgreSQL,
+// or mongo.SessionContext for MongoDB via the event-mongodb module).
 //
 // Example:
 //
-//	// MongoDB transaction
-//	sess.WithTransaction(ctx, func(sessCtx mongo.SessionContext) (any, error) {
-//	    ctx := event.WithOutboxTx(sessCtx, sessCtx)
-//	    // ... business logic ...
-//	    return nil, orderEvent.Publish(ctx, order)  // Goes to outbox
-//	})
+//	// PostgreSQL transaction
+//	tx, _ := db.BeginTx(ctx, nil)
+//	ctx = event.WithOutboxTx(ctx, tx)
+//	// ... business logic ...
+//	orderEvent.Publish(ctx, order)  // Goes to outbox
 func WithOutboxTx(ctx context.Context, session any) context.Context {
 	return context.WithValue(ctx, outboxTxKey{}, session)
 }

--- a/outbox/outbox.go
+++ b/outbox/outbox.go
@@ -14,9 +14,11 @@
 //   - Store interface for outbox persistence
 //   - PostgresStore for PostgreSQL databases
 //   - RedisStore for Redis-based outbox (see redis.go)
-//   - MongoStore for MongoDB (see mongodb.go)
 //   - Publisher interface for storing messages
 //   - Relay for background publishing
+//
+// For MongoDB outbox support, use the event-mongodb module:
+// https://github.com/rbaliyan/event-mongodb
 //
 // # The Problem
 //
@@ -172,7 +174,7 @@ type Message struct {
 // Implementations:
 //   - PostgresStore: For PostgreSQL databases
 //   - RedisStore: For Redis (see redis.go)
-//   - MongoStore: For MongoDB (see mongodb.go)
+//   - For MongoDB, use the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 type Store interface {
 	// Insert adds a message to the outbox within a transaction.
 	//

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -8,7 +8,8 @@
 //
 // Schema providers support two strategies:
 //   - Transport-based: Uses transport's KV/retention if available (NATS KV, Kafka compacted)
-//   - Database fallback: PostgreSQL, MongoDB, or Redis for transports without retention
+//   - Database fallback: PostgreSQL or Redis for transports without retention;
+//     for MongoDB, use the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 //
 // Example usage:
 //

--- a/store/doc.go
+++ b/store/doc.go
@@ -25,7 +25,8 @@
 //
 // MemoryStore[T] - Thread-safe in-memory store for testing and development.
 //
-// MongoStore[T] - MongoDB store with cursor-based pagination and indexes.
+// For MongoDB store implementations, use the event-mongodb module:
+// https://github.com/rbaliyan/event-mongodb
 //
 // # Usage
 //
@@ -41,13 +42,15 @@
 //	    TransitionState(ctx context.Context, id string, from, to Status) error
 //	}
 //
-// Implementations satisfy both core and domain interfaces:
+// Implementations satisfy both core and domain interfaces. For example,
+// using the MongoDB store from the event-mongodb module:
 //
-//	type MongoStore struct {
-//	    *store.MongoStore[*State]
+//	// See github.com/rbaliyan/event-mongodb/store for MongoDB implementation
+//	type MyMongoStore struct {
+//	    *mongostore.MongoStore[*State]
 //	}
 //
-//	func (s *MongoStore) ListByStatus(ctx context.Context, statuses []Status) ([]*State, error) {
+//	func (s *MyMongoStore) ListByStatus(ctx context.Context, statuses []Status) ([]*State, error) {
 //	    return s.Collection().Find(ctx, bson.M{"status": bson.M{"$in": statuses}})
 //	}
 //

--- a/store/store.go
+++ b/store/store.go
@@ -1,8 +1,8 @@
 // Package store provides common store interfaces and utilities for persistence.
 //
 // This package defines a core set of interfaces that can be implemented by
-// different backends (MongoDB, PostgreSQL, Redis, in-memory) while allowing
-// domain-specific extensions.
+// different backends (PostgreSQL, Redis, in-memory, or MongoDB via event-mongodb)
+// while allowing domain-specific extensions.
 //
 // # Architecture
 //
@@ -10,7 +10,7 @@
 //
 //  1. Core Interfaces: Basic CRUD operations common to all stores
 //  2. Domain Extensions: Specialized interfaces for specific use cases
-//  3. Backend Implementations: MongoDB, PostgreSQL, Redis, memory stores
+//  3. Backend Implementations: PostgreSQL, Redis, memory stores (MongoDB via event-mongodb)
 //
 // # Usage
 //
@@ -21,9 +21,8 @@
 //	    ListByStatus(ctx context.Context, statuses []Status) ([]*State, error)
 //	}
 //
-// Backend implementations satisfy both the core and domain interfaces:
-//
-//	func NewMongoSagaStore(db *mongo.Database) SagaStore { ... }
+// Backend implementations satisfy both the core and domain interfaces.
+// For MongoDB implementations, use the event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 package store
 
 import (

--- a/transaction/manager.go
+++ b/transaction/manager.go
@@ -10,9 +10,11 @@
 //   - Transaction interface for database-agnostic transaction handling
 //   - Manager interface for transaction lifecycle management
 //   - SQLManager for SQL database transactions
-//   - MongoManager for MongoDB transactions (see mongodb.go)
 //   - IdempotentHandler for exactly-once message processing
 //   - TransactionalHandler for combining transactions with idempotency
+//
+// For MongoDB transaction management, use the event-mongodb module:
+// https://github.com/rbaliyan/event-mongodb
 //
 // # Basic Usage
 //
@@ -153,7 +155,7 @@ type SQLTransactionProvider interface {
 //
 // Implementations:
 //   - SQLManager: For SQL databases (PostgreSQL, MySQL, SQLite, etc.)
-//   - MongoManager: For MongoDB (see mongodb.go)
+//   - For MongoDB, use the event-mongodb module (https://github.com/rbaliyan/event-mongodb)
 //
 // Example:
 //

--- a/transport/bridge/distributed.go
+++ b/transport/bridge/distributed.go
@@ -33,7 +33,7 @@ import (
 //
 // metrics is optional — pass nil to disable skip counting.
 //
-// Example:
+// Example (mongodb refers to github.com/rbaliyan/event-mongodb):
 //
 //	bridge.WithMiddleware(
 //	    bridge.DistributedDedup(
@@ -64,7 +64,7 @@ func DistributedDedup(coord distributed.Coordinator, keyFn DedupKeyFn, ttl time.
 			// Scope the dedup key by event name so pumps for different
 			// registered events on the same source do not race for the
 			// same slot. Without this, all pumps on a shared-source bus
-			// (e.g. mongodb CS with Created/Updated/Deleted on the same
+			// (e.g. a MongoDB change stream with Created/Updated/Deleted on the same
 			// collection) compete for the same key and only one publishes
 			// — typically to the wrong sink stream for 2/3 of messages.
 			// Prefixing with the event name gives each pump its own

--- a/transport/bridge/doc.go
+++ b/transport/bridge/doc.go
@@ -27,6 +27,7 @@
 // dead-letter routing, distributed coordination, metrics, tracing — is
 // optional middleware composed via [WithMiddleware]:
 //
+//	// mongodb refers to github.com/rbaliyan/event-mongodb
 //	t, _ := bridge.New(source, sink,
 //	    bridge.WithMiddleware(
 //	        bridge.Dedup(coord, mongodb.DedupKeyFromChangeStream(), 24*time.Hour),

--- a/transport/composite/composite.go
+++ b/transport/composite/composite.go
@@ -1,7 +1,7 @@
 // Package composite provides a transport that combines a durable store with
 // a real-time signal transport for low-latency, reliable event delivery.
 //
-// Storage systems (MongoDB, PostgreSQL) provide excellent durability but poor
+// Storage systems (PostgreSQL, MongoDB) provide excellent durability but poor
 // real-time notification. Real-time systems (Redis, NATS) provide instant
 // delivery but poor persistence. The composite transport combines both:
 //
@@ -15,7 +15,7 @@
 //
 // Usage:
 //
-//	store := persistent.NewMemoryStore() // or MongoStore, PostgresStore
+//	store := persistent.NewMemoryStore() // or a PostgreSQL/MongoDB persistent store
 //	signal := redis.New(redisClient)     // or nats.New, channel.New
 //
 //	t, _ := composite.New(store, signal,

--- a/transport/persistent/memory.go
+++ b/transport/persistent/memory.go
@@ -13,7 +13,8 @@ import (
 // persistence across restarts is not required.
 //
 // Note: Messages are lost on process restart. For true persistence,
-// use MongoStore or PostgresStore.
+// use a PostgreSQL store or the MongoDB persistent store from the
+// event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 type MemoryStore struct {
 	mu       sync.RWMutex
 	events   map[string]*memoryEventStore

--- a/transport/persistent/persistent.go
+++ b/transport/persistent/persistent.go
@@ -7,11 +7,12 @@
 //   - Provides natural backpressure (poll-based)
 //
 // This is useful when you need persistence without external infrastructure
-// like Redis or Kafka, using any storage backend (MongoDB, PostgreSQL, memory).
+// like Redis or Kafka, using any storage backend (PostgreSQL, memory, or
+// MongoDB via the event-mongodb module).
 //
 // Usage:
 //
-//	store := persistent.NewMemoryStore() // or NewMongoStore, NewPostgresStore
+//	store := persistent.NewMemoryStore() // or a PostgreSQL/MongoDB store
 //	t := persistent.New(store)
 //
 //	bus, _ := event.NewBus("mybus", event.WithTransport(t))


### PR DESCRIPTION
## Summary

- Remove references to MongoDB implementations that were moved to event-mongodb in the Phase 1.2 unification (#56)
- Add migration notes pointing users to github.com/rbaliyan/event-mongodb in README, COMPATIBILITY.md, and all affected godoc comments
- Update Database Support matrix in README and Store Compatibility matrix in COMPATIBILITY.md with footnote indicating MongoDB is provided by event-mongodb
- Replace MongoDB-specific code examples in outbox/bus_options.go with PostgreSQL equivalents
- Clean up stale `MongoStateManager`, `MongoStore`, `MongoProvider`, `MongoManager` references in distributed/, outbox/, transaction/, schema/, idempotency/, checkpoint/, store/, and transport/ packages

## Checklist
- [x] All removed MongoDB API references updated or removed
- [x] Migration note added to README ecosystem section
- [x] COMPATIBILITY.md Store Compatibility table updated with footnote
- [x] doc.go MongoProvider removed from schema provider list
- [x] bus_options.go outbox example updated to use PostgresStore
- [x] distributed/ package comments updated (claimer.go, memory.go, recovery.go, redis.go)
- [x] Build verified: go build ./... passes