### PR TITLE
feat(store/base): add SQLNotFound and RedisNotFound error helpers

### DIFF
--- a/store/base/errors.go
+++ b/store/base/errors.go
@@ -1,0 +1,41 @@
+package base
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// SQLNotFound translates sql.ErrNoRows to fmt.Errorf("%s: %w", id, sentinel).
+// Returns err unchanged for any other error value, including nil.
+//
+// Typical usage in a Get method:
+//
+//	err := row.Scan(...)
+//	if err = base.SQLNotFound(err, id, ErrNotFound); err != nil {
+//	    return nil, err
+//	}
+func SQLNotFound(err error, id string, sentinel error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%s: %w", id, sentinel)
+	}
+	return err
+}
+
+// RedisNotFound translates redis.Nil to fmt.Errorf("%s: %w", id, sentinel).
+// Returns err unchanged for any other error value, including nil.
+//
+// Typical usage in a Get method:
+//
+//	data, err := client.HGet(ctx, key, id).Result()
+//	if err = base.RedisNotFound(err, id, ErrNotFound); err != nil {
+//	    return nil, err
+//	}
+func RedisNotFound(err error, id string, sentinel error) error {
+	if errors.Is(err, redis.Nil) {
+		return fmt.Errorf("%s: %w", id, sentinel)
+	}
+	return err
+}

--- a/store/base/errors_test.go
+++ b/store/base/errors_test.go
@@ -1,0 +1,73 @@
+package base_test
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/rbaliyan/event/v3/store/base"
+)
+
+var errSentinel = errors.New("not found")
+
+func TestSQLNotFound(t *testing.T) {
+	t.Run("translates ErrNoRows", func(t *testing.T) {
+		err := base.SQLNotFound(sql.ErrNoRows, "id-1", errSentinel)
+		if !errors.Is(err, errSentinel) {
+			t.Fatalf("expected sentinel, got %v", err)
+		}
+		if err.Error() != "id-1: not found" {
+			t.Fatalf("unexpected message: %s", err.Error())
+		}
+	})
+
+	t.Run("passes other errors through", func(t *testing.T) {
+		other := errors.New("connection reset")
+		err := base.SQLNotFound(other, "id-1", errSentinel)
+		if err != other {
+			t.Fatalf("expected original error, got %v", err)
+		}
+	})
+
+	t.Run("passes nil through", func(t *testing.T) {
+		if err := base.SQLNotFound(nil, "id-1", errSentinel); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("wrapped ErrNoRows is translated", func(t *testing.T) {
+		wrapped := errors.Join(sql.ErrNoRows, errors.New("detail"))
+		err := base.SQLNotFound(wrapped, "id-2", errSentinel)
+		if !errors.Is(err, errSentinel) {
+			t.Fatalf("expected sentinel for wrapped ErrNoRows, got %v", err)
+		}
+	})
+}
+
+func TestRedisNotFound(t *testing.T) {
+	t.Run("translates redis.Nil", func(t *testing.T) {
+		err := base.RedisNotFound(redis.Nil, "id-1", errSentinel)
+		if !errors.Is(err, errSentinel) {
+			t.Fatalf("expected sentinel, got %v", err)
+		}
+		if err.Error() != "id-1: not found" {
+			t.Fatalf("unexpected message: %s", err.Error())
+		}
+	})
+
+	t.Run("passes other errors through", func(t *testing.T) {
+		other := errors.New("connection reset")
+		err := base.RedisNotFound(other, "id-1", errSentinel)
+		if err != other {
+			t.Fatalf("expected original error, got %v", err)
+		}
+	})
+
+	t.Run("passes nil through", func(t *testing.T) {
+		if err := base.RedisNotFound(nil, "id-1", errSentinel); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `SQLNotFound(err, id, sentinel)` to `store/base` — translates `sql.ErrNoRows` to a caller-supplied sentinel error with `"%s: %w"` format
- Adds `RedisNotFound(err, id, sentinel)` — same pattern for `redis.Nil`
- Both helpers use `errors.Is` internally, guarding against the `err == sql.ErrNoRows` comparison mistake on wrapped errors

## Context

Part of Phase 1.1 thin storage primitives. These helpers normalise not-found handling across SQL and Redis backends in DLQ, Scheduler, Saga, and Outbox. Satellite repos already import `store/base` so no new dependencies are required.

## Test plan

- [x] Unit tests for both helpers covering: sentinel translation, passthrough of other errors, nil passthrough, wrapped `sql.ErrNoRows`
- [x] `go test ./store/base/...` passes