### PR TITLE
feat(outbox): add PG LISTEN/NOTIFY wake-up for Relay

### DIFF
--- a/outbox/postgres.go
+++ b/outbox/postgres.go
@@ -18,7 +18,8 @@ import (
 type PostgresStoreOption func(*postgresStoreOptions)
 
 type postgresStoreOptions struct {
-	table string
+	table         string
+	notifyChannel string
 }
 
 // WithTable sets a custom table name for the PostgreSQL outbox store.
@@ -54,10 +55,49 @@ func WithTable(table string) PostgresStoreOption {
 //	);
 //	CREATE INDEX idx_outbox_pending ON event_outbox(status, priority DESC, created_at)
 //	    WHERE status IN ('pending', 'failed');
-type PostgresStore struct {
-	db        *sql.DB
-	tableName string
+// WithNotifyChannel sets the PostgreSQL NOTIFY channel name emitted on each Insert.
+// Listeners using pq.NewListener can subscribe to this channel to be woken up
+// immediately when new messages arrive instead of relying solely on polling.
+// The default channel is "event_outbox_pending".
+func WithNotifyChannel(channel string) PostgresStoreOption {
+	return func(o *postgresStoreOptions) {
+		if channel != "" {
+			o.notifyChannel = channel
+		}
+	}
 }
+
+// PostgresStore implements Store for PostgreSQL.
+//
+// PostgresStore uses PostgreSQL's transactional capabilities for reliable
+// message storage. It supports concurrent relay instances using
+// SELECT FOR UPDATE SKIP LOCKED to prevent duplicate processing.
+//
+// Required Schema:
+//
+//	CREATE TABLE event_outbox (
+//	    id           BIGSERIAL PRIMARY KEY,
+//	    event_name   VARCHAR(255) NOT NULL,
+//	    event_id     VARCHAR(36) NOT NULL,
+//	    payload      BYTEA NOT NULL,
+//	    metadata     JSONB,
+//	    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+//	    published_at TIMESTAMP,
+//	    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+//	    retry_count  INT NOT NULL DEFAULT 0,
+//	    last_error   TEXT,
+//	    priority     INT NOT NULL DEFAULT 0
+//	);
+//	CREATE INDEX idx_outbox_pending ON event_outbox(status, priority DESC, created_at)
+//	    WHERE status IN ('pending', 'failed');
+type PostgresStore struct {
+	db            *sql.DB
+	tableName     string
+	notifyChannel string
+}
+
+// NotifyChannel returns the PostgreSQL NOTIFY channel name emitted on each Insert.
+func (s *PostgresStore) NotifyChannel() string { return s.notifyChannel }
 
 // NewPostgresStore creates a new PostgreSQL outbox store.
 //
@@ -69,15 +109,17 @@ func NewPostgresStore(db *sql.DB, opts ...PostgresStoreOption) (*PostgresStore, 
 	}
 
 	o := &postgresStoreOptions{
-		table: "event_outbox",
+		table:         "event_outbox",
+		notifyChannel: "event_outbox_pending",
 	}
 	for _, opt := range opts {
 		opt(o)
 	}
 
 	return &PostgresStore{
-		db:        db,
-		tableName: o.table,
+		db:            db,
+		tableName:     o.table,
+		notifyChannel: o.notifyChannel,
 	}, nil
 }
 
@@ -135,7 +177,15 @@ func (s *PostgresStore) Insert(ctx context.Context, tx *sql.Tx, msg *Message) er
 		msg.Priority,
 	).Scan(&msg.ID)
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Notify any listening relay that a new message is pending.
+	// This fires when the caller's transaction commits, not at INSERT time.
+	// Ignored if no relay is listening — the relay catches up via its fallback ticker.
+	_, _ = tx.ExecContext(ctx, `SELECT pg_notify($1, '')`, s.notifyChannel)
+	return nil
 }
 
 // GetPending retrieves pending and failed messages for publishing.

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/rbaliyan/event/v3/backoff"
 	"github.com/rbaliyan/event/v3/transport"
 	"github.com/rbaliyan/event/v3/transport/message"
@@ -47,28 +48,32 @@ import (
 //	// Shutdown gracefully
 //	cancel()
 type Relay struct {
-	store        Store
-	transport    transport.Transport
-	pollDelay    time.Duration
-	batchSize    int
-	logger       *slog.Logger
-	cleanupAge   time.Duration // How old published messages should be before deletion
-	metrics      *Metrics
-	maxRetries   int              // 0 = unlimited retries (default)
-	retryBackoff backoff.Strategy // nil = no backoff delay between retries
+	store           Store
+	transport       transport.Transport
+	pollDelay       time.Duration
+	batchSize       int
+	logger          *slog.Logger
+	cleanupAge      time.Duration // How old published messages should be before deletion
+	metrics         *Metrics
+	maxRetries      int              // 0 = unlimited retries (default)
+	retryBackoff    backoff.Strategy // nil = no backoff delay between retries
+	listener        *pq.Listener     // optional: wake up on PG NOTIFY instead of only polling
+	listenerChannel string
 }
 
 // RelayOption configures a Relay.
 type RelayOption func(*relayOptions)
 
 type relayOptions struct {
-	pollDelay    time.Duration
-	batchSize    int
-	logger       *slog.Logger
-	cleanupAge   time.Duration
-	metrics      *Metrics
-	maxRetries   int
-	retryBackoff backoff.Strategy
+	pollDelay       time.Duration
+	batchSize       int
+	logger          *slog.Logger
+	cleanupAge      time.Duration
+	metrics         *Metrics
+	maxRetries      int
+	retryBackoff    backoff.Strategy
+	listener        *pq.Listener
+	listenerChannel string
 }
 
 // WithPollDelay sets the polling interval.
@@ -142,6 +147,34 @@ func WithRetryBackoff(strategy backoff.Strategy) RelayOption {
 	}
 }
 
+// WithNotifyListener configures the relay to wake up immediately on PostgreSQL
+// NOTIFY events in addition to its regular polling ticker.
+//
+// When set, the relay subscribes to channel on startup and calls publishPending
+// each time a notification arrives. The polling ticker remains active as a
+// fallback safety net (useful for catching up on notifications missed during
+// a relay restart).
+//
+// Pair this with a PostgresStore: the store emits NOTIFY on each Insert, and
+// the relay wakes up immediately instead of waiting for the next poll tick.
+//
+// Example:
+//
+//	listener := pq.NewListener(dsn, 10*time.Second, time.Minute, nil)
+//	store, _ := outbox.NewPostgresStore(db)
+//	relay := outbox.NewRelay(store, transport,
+//	    outbox.WithPollDelay(5*time.Second),          // fallback interval
+//	    outbox.WithNotifyListener(listener, store.NotifyChannel()),
+//	)
+func WithNotifyListener(l *pq.Listener, channel string) RelayOption {
+	return func(o *relayOptions) {
+		if l != nil && channel != "" {
+			o.listener = l
+			o.listenerChannel = channel
+		}
+	}
+}
+
 // NewRelay creates a new outbox relay.
 //
 // The relay polls the store for pending messages and publishes them to
@@ -178,15 +211,17 @@ func NewRelay(store Store, t transport.Transport, opts ...RelayOption) *Relay {
 	}
 
 	return &Relay{
-		store:        store,
-		transport:    t,
-		pollDelay:    o.pollDelay,
-		batchSize:    o.batchSize,
-		logger:       logger,
-		cleanupAge:   o.cleanupAge,
-		metrics:      o.metrics,
-		maxRetries:   o.maxRetries,
-		retryBackoff: o.retryBackoff,
+		store:           store,
+		transport:       t,
+		pollDelay:       o.pollDelay,
+		batchSize:       o.batchSize,
+		logger:          logger,
+		cleanupAge:      o.cleanupAge,
+		metrics:         o.metrics,
+		maxRetries:      o.maxRetries,
+		retryBackoff:    o.retryBackoff,
+		listener:        o.listener,
+		listenerChannel: o.listenerChannel,
 	}
 }
 
@@ -221,30 +256,50 @@ func (r *Relay) log() *slog.Logger {
 //	// Later, to stop:
 //	cancel()
 func (r *Relay) Start(ctx context.Context) error {
+	// Subscribe to PG NOTIFY if a listener is configured.
+	// Errors here are non-fatal: fall back to polling only.
+	if r.listener != nil {
+		if err := r.listener.Listen(r.listenerChannel); err != nil {
+			r.log().Warn("failed to listen on notify channel, using polling only",
+				"channel", r.listenerChannel, "error", err)
+		} else {
+			defer func() { _ = r.listener.Unlisten(r.listenerChannel) }()
+		}
+	}
+
 	ticker := time.NewTicker(r.pollDelay)
 	defer ticker.Stop()
 
-	// Also start a cleanup ticker
 	cleanupTicker := time.NewTicker(time.Hour)
 	defer cleanupTicker.Stop()
 
 	var consecutiveFailures int
 
+	publish := func() {
+		failures := r.publishPending(ctx)
+		if r.retryBackoff != nil && failures > 0 {
+			consecutiveFailures++
+			delay := r.retryBackoff.NextDelay(consecutiveFailures)
+			ticker.Reset(delay)
+		} else if consecutiveFailures > 0 {
+			consecutiveFailures = 0
+			ticker.Reset(r.pollDelay)
+		}
+	}
+
+	var notifyC <-chan *pq.Notification
+	if r.listener != nil {
+		notifyC = r.listener.Notify
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-notifyC:
+			publish()
 		case <-ticker.C:
-			failures := r.publishPending(ctx)
-			// Adaptive backpressure: back off polling when failures occur
-			if r.retryBackoff != nil && failures > 0 {
-				consecutiveFailures++
-				delay := r.retryBackoff.NextDelay(consecutiveFailures)
-				ticker.Reset(delay)
-			} else if consecutiveFailures > 0 {
-				consecutiveFailures = 0
-				ticker.Reset(r.pollDelay)
-			}
+			publish()
 		case <-cleanupTicker.C:
 			r.cleanup(ctx)
 		}


### PR DESCRIPTION
## Summary

- `PostgresStore.Insert()` emits `pg_notify(notifyChannel, '')` inside the caller's `*sql.Tx`, so the relay wakes up immediately when that transaction commits
- `Relay.Start()` accepts an optional `*pq.Listener` via `WithNotifyListener(l, channel)` — subscribes on startup and calls `publishPending` on each notification
- Default notify channel: `"event_outbox_pending"` (configurable via `WithNotifyChannel` on `PostgresStore`)
- `PostgresStore.NotifyChannel()` exposes the channel name so callers don't need to hard-code it
- Polling ticker stays active as a fallback safety net
- No schema changes. No new dependencies (`lib/pq` already in `go.mod`)

## Usage

```go
l := pq.NewListener(dsn, 10*time.Second, time.Minute, nil)
store, _ := outbox.NewPostgresStore(db)
relay := outbox.NewRelay(store, transport,
    outbox.WithPollDelay(5*time.Second), // fallback only
    outbox.WithNotifyListener(l, store.NotifyChannel()),
)
```
The relay wakes up within microseconds of the application transaction committing instead of waiting up to 100ms (or 5s with the longer fallback poll).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass