### PR TITLE
fix(distributed): correct ClearPayload ordering and remove runtime redelivery detection

### DIFF
--- a/distributed/distributed_test.go
+++ b/distributed/distributed_test.go
@@ -2,6 +2,8 @@ package distributed
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -309,5 +311,84 @@ func TestRecoveryRunner_Run(t *testing.T) {
 	acquired, _ = sm.Acquire(ctx, "msg-1", time.Hour)
 	if !acquired {
 		t.Fatal("expected acquisition to succeed after runner reset stale state")
+	}
+}
+
+// faultyCoord wraps MemoryStateManager: MarkProcessed can be made to fail,
+// and ClearPayload calls are counted.
+type faultyCoord struct {
+	*MemoryStateManager
+	failMark      bool
+	clearPayloads atomic.Int32
+}
+
+func (f *faultyCoord) MarkProcessed(ctx context.Context, id string) error {
+	if f.failMark {
+		return errors.New("mark processed failed")
+	}
+	return f.MemoryStateManager.MarkProcessed(ctx, id)
+}
+
+func (f *faultyCoord) ClearPayload(ctx context.Context, id string) error {
+	f.clearPayloads.Add(1)
+	return f.MemoryStateManager.ClearPayload(ctx, id)
+}
+
+// countingSender counts Send calls and implements the Publisher (event.Sender) interface.
+type countingSender struct{ n atomic.Int32 }
+
+func (s *countingSender) Send(_ context.Context, _, _ string, _ []byte, _ map[string]string) error {
+	s.n.Add(1)
+	return nil
+}
+
+// TestRecovery_ClearPayloadAfterMarkProcessed verifies that ClearPayload is only
+// called after MarkProcessed succeeds. If MarkProcessed fails, payload must be
+// retained so the next recovery cycle can retry the re-publish.
+func TestRecovery_ClearPayloadAfterMarkProcessed(t *testing.T) {
+	ctx := context.Background()
+
+	inner := NewMemoryStateManager(WithCleanup(false, 0))
+	defer inner.Close()
+
+	coord := &faultyCoord{MemoryStateManager: inner, failMark: true}
+
+	// Acquire and store payload so Phase 1 fires.
+	_, _ = inner.Acquire(ctx, "msg-1", time.Hour)
+	_ = inner.StorePayload(ctx, "msg-1", &MessageData{
+		EventName: "test.event",
+		Payload:   []byte(`"payload"`),
+	})
+
+	pub := &countingSender{}
+
+	runner, err := NewRecoveryRunner(coord,
+		WithStaleTimeout(10*time.Millisecond),
+		WithPublisher(pub),
+	)
+	if err != nil {
+		t.Fatalf("NewRecoveryRunner: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	// First pass: MarkProcessed fails → payload must NOT be cleared.
+	if _, err := runner.RecoverOnce(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n := pub.n.Load(); n != 1 {
+		t.Fatalf("expected 1 re-publish attempt, got %d", n)
+	}
+	if n := coord.clearPayloads.Load(); n != 0 {
+		t.Fatalf("ClearPayload called %d time(s) when MarkProcessed failed; want 0", n)
+	}
+
+	// Second pass: MarkProcessed succeeds → payload must be cleared.
+	coord.failMark = false
+	if _, err := runner.RecoverOnce(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n := coord.clearPayloads.Load(); n != 1 {
+		t.Fatalf("ClearPayload called %d time(s) after successful MarkProcessed; want 1", n)
 	}
 }

--- a/distributed/middleware.go
+++ b/distributed/middleware.go
@@ -2,7 +2,7 @@ package distributed
 
 import (
 	"context"
-	"sync"
+	"log/slog"
 	"time"
 
 	"github.com/rbaliyan/event/v3"
@@ -12,7 +12,7 @@ import (
 type PoolOption func(*poolOptions)
 
 type poolOptions struct {
-	storePayload   *bool // nil = auto-detect from transport, non-nil = explicit
+	storePayload   *bool // nil = unset; resolved at WorkerPoolMiddleware call time
 	maxPayloadSize int   // 0 = no limit
 }
 
@@ -23,13 +23,34 @@ type poolOptions struct {
 // required for transports that don't support re-delivery (e.g., MongoDB
 // Change Streams).
 //
-// By default, payload storage is auto-detected from the transport's
-// SupportsRedelivery() capability. Use this option to override the detection
-// or to make the behavior deterministic at construction time.
+// Use this option when constructing the middleware manually without a Bus
+// reference. Prefer WithBus when a Bus is available — it detects redelivery
+// support automatically and fails construction if the bus is nil.
 func WithPayloadRecovery() PoolOption {
 	return func(o *poolOptions) {
 		t := true
 		o.storePayload = &t
+	}
+}
+
+// WithBus configures the middleware using the bus's transport capabilities.
+// It detects whether the bus transport supports message re-delivery and
+// enables payload storage accordingly. Payload storage is required when
+// the transport cannot re-deliver messages on worker failure (e.g. MongoDB
+// Change Streams).
+//
+// This is the preferred way to configure payload recovery: redelivery
+// support is resolved once at construction time rather than lazily on
+// the first message.
+//
+// Panics if b is nil.
+func WithBus(b *event.Bus) PoolOption {
+	if b == nil {
+		panic("distributed: WithBus requires a non-nil Bus")
+	}
+	return func(o *poolOptions) {
+		store := !b.SupportsRedelivery()
+		o.storePayload = &store
 	}
 }
 
@@ -125,18 +146,21 @@ func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts
 	// Check if coordinator also implements PayloadStore
 	ps, hasPayloadStore := coord.(PayloadStore)
 
+	// Resolve payload storage at construction time.
+	// WithBus or WithPayloadRecovery set o.storePayload explicitly.
+	// If neither is provided, default to false (no payload storage) and warn
+	// so callers know they may need to act.
+	storePayload := false
+	if o.storePayload != nil {
+		storePayload = *o.storePayload
+	} else if hasPayloadStore {
+		// Coordinator supports payload storage but no bus or explicit option was
+		// provided — warn once at construction time so the issue is visible
+		// before any messages flow.
+		slog.Warn("distributed.WorkerPoolMiddleware: coordinator supports payload recovery but redelivery support is unknown; use WithBus(bus) or WithPayloadRecovery() to enable payload storage")
+	}
+
 	return func(next event.Handler[T]) event.Handler[T] {
-		// Track whether the transport supports redelivery
-		var (
-			detectOnce   sync.Once
-			storePayload bool // true when transport lacks redelivery
-		)
-
-		// If explicitly configured, set immediately (no auto-detection needed)
-		if o.storePayload != nil {
-			storePayload = *o.storePayload
-		}
-
 		return func(ctx context.Context, ev event.Event[T], data T) error {
 			// Get message ID from context
 			messageID := event.ContextEventID(ctx)
@@ -144,16 +168,6 @@ func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts
 				// No message ID available, can't acquire state - proceed with processing
 				// This shouldn't happen in normal operation but fail open for safety
 				return next(ctx, ev, data)
-			}
-
-			// Auto-detect transport capability once per subscriber (skipped if explicit)
-			if o.storePayload == nil {
-				detectOnce.Do(func() {
-					bus := event.ContextBus(ctx)
-					if bus != nil && !bus.SupportsRedelivery() {
-						storePayload = true
-					}
-				})
 			}
 
 			// Attempt to acquire the message state

--- a/distributed/recovery.go
+++ b/distributed/recovery.go
@@ -369,16 +369,21 @@ func (r *RecoveryRunner) recoverPayloadEntries(ctx context.Context, ps PayloadSt
 			continue
 		}
 
-		// Re-publish succeeded — clear payload and mark as processed
-		_ = ps.ClearPayload(ctx, entry.MessageID)
+		// Re-publish succeeded — mark processed first, then clear payload.
+		// Order matters: if MarkProcessed fails we keep the payload so the
+		// next recovery cycle can retry. Clearing before marking would leave
+		// the state stuck in "processing" with no payload, causing Phase 2
+		// to reset it and allowing the original message to be reacquired.
 		if err := r.coord.MarkProcessed(ctx, entry.MessageID); err != nil {
 			if r.logger != nil {
-				r.logger.Warn("failed to mark re-published state as processed",
+				r.logger.Warn("failed to mark re-published state as processed, payload retained for next cycle",
 					"message_id", entry.MessageID,
 					"error", err)
 			}
 			r.metrics.recordError(ctx, "mark_processed")
+			continue
 		}
+		_ = ps.ClearPayload(ctx, entry.MessageID)
 		recovered++
 		r.metrics.recordRepublished(ctx, entry.Data.EventName)
 		r.metrics.recordRecovered(ctx)


### PR DESCRIPTION
## Summary

### Recovery phase ordering fix (correctness)

`ClearPayload` was called before `MarkProcessed` in `recoverPayloadEntries`. If `MarkProcessed` failed:
1. Payload gone, state still "processing"  
2. Next cycle: no payload → Phase 1 skips it
3. Phase 2 resets state → original message reacquirable
4. If transport redelivers original + re-published copy is already in flight → duplicate processing

**Fix**: call `ClearPayload` only after `MarkProcessed` succeeds. If `MarkProcessed` fails, retain payload and retry next cycle. Also removed the incorrect `recovered++` / metric recording that happened even on `MarkProcessed` failure.

### Middleware construction-time detection

Removed the `detectOnce.Do` lazy redelivery detection that ran on the first message. If the bus context was nil on that first call (rare but possible), payload storage was silently disabled for all subsequent messages.

**Fix**: resolve at `WorkerPoolMiddleware` construction time via two options:
- `WithBus(bus)` — preferred, detects `bus.SupportsRedelivery()` immediately. Panics if `bus` is nil (fail fast rather than fail silent)
- `WithPayloadRecovery()` — explicit opt-in, unchanged
- Neither provided + coordinator supports `PayloadStore` → `slog.Warn` once at construction time (visible at startup, not on first message)

### Test coverage

Added `TestRecovery_ClearPayloadAfterMarkProcessed` using `faultyCoord` — a wrapper that makes `MarkProcessed` fail controllably and counts `ClearPayload` calls. Verifies payload is NOT cleared on failed `MarkProcessed`, and IS cleared after successful `MarkProcessed`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `go test ./distributed/... -v -run TestRecovery` — all recovery tests pass including new one