### PR TITLE
fix: address robustness issues from code review

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -142,7 +142,7 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 		bus.receiveLag, _ = meter.Float64Histogram("event.transport_receive_lag_seconds",
 			metric.WithDescription("Time between message creation and handler start (queue residence time)"),
 			metric.WithUnit("s"),
-			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0))
+			metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 300.0))
 		initGauges(meter)
 	}
 

--- a/distributed/claimer.go
+++ b/distributed/claimer.go
@@ -49,11 +49,11 @@
 //	sm := distributed.NewRedisStateManager(redisClient, distributed.WithCompletedTTL(48*time.Hour))
 //
 //	// Subscribe with middleware to emulate WorkerPool
-//	mongoEvent.Subscribe(ctx, handler,
-//	    event.WithMiddleware(
-//	        distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute),
-//	    ),
-//	)
+//	mw, err := distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute)
+//	if err != nil {
+//	    return err
+//	}
+//	mongoEvent.Subscribe(ctx, handler, event.WithMiddleware(mw))
 //
 // State TTL:
 //
@@ -69,15 +69,19 @@
 //
 //	// Group A workers
 //	smA := distributed.NewRedisStateManager(redis, distributed.WithPrefix("group-a:"))
-//	eventA.Subscribe(ctx, handlerA, event.WithMiddleware(
-//	    distributed.WorkerPoolMiddleware[T](smA, ttl),
-//	))
+//	mwA, err := distributed.WorkerPoolMiddleware[T](smA, ttl)
+//	if err != nil {
+//	    return err
+//	}
+//	eventA.Subscribe(ctx, handlerA, event.WithMiddleware(mwA))
 //
 //	// Group B workers
 //	smB := distributed.NewRedisStateManager(redis, distributed.WithPrefix("group-b:"))
-//	eventB.Subscribe(ctx, handlerB, event.WithMiddleware(
-//	    distributed.WorkerPoolMiddleware[T](smB, ttl),
-//	))
+//	mwB, err := distributed.WorkerPoolMiddleware[T](smB, ttl)
+//	if err != nil {
+//	    return err
+//	}
+//	eventB.Subscribe(ctx, handlerB, event.WithMiddleware(mwB))
 package distributed
 
 import (

--- a/distributed/distributed_test.go
+++ b/distributed/distributed_test.go
@@ -337,7 +337,13 @@ func (f *faultyCoord) ClearPayload(ctx context.Context, id string) error {
 // countingSender counts Send calls and implements the Publisher (event.Sender) interface.
 type countingSender struct{ n atomic.Int32 }
 
-func (s *countingSender) Send(_ context.Context, _, _ string, _ []byte, _ map[string]string) error {
+func (s *countingSender) Send(_ context.Context, eventName, _ string, payload []byte, _ map[string]string) error {
+	if eventName == "" {
+		return errors.New("Send: empty eventName")
+	}
+	if payload == nil {
+		return errors.New("Send: nil payload")
+	}
 	s.n.Add(1)
 	return nil
 }

--- a/distributed/memory.go
+++ b/distributed/memory.go
@@ -53,11 +53,11 @@ type stateEntry struct {
 //	)
 //
 //	// Use with middleware
-//	event.Subscribe(ctx, handler,
-//	    event.WithMiddleware(
-//	        distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute),
-//	    ),
-//	)
+//	mw, err := distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute)
+//	if err != nil {
+//	    return err
+//	}
+//	event.Subscribe(ctx, handler, event.WithMiddleware(mw))
 type MemoryStateManager struct {
 	mu            sync.RWMutex
 	states        map[string]*stateEntry
@@ -81,11 +81,11 @@ type MemoryStateManager struct {
 //	sm := distributed.NewMemoryStateManager()
 //	defer sm.Close()
 //
-//	event.Subscribe(ctx, handler,
-//	    event.WithMiddleware(
-//	        distributed.WorkerPoolMiddleware[Order](sm, ttl),
-//	    ),
-//	)
+//	mw, err := distributed.WorkerPoolMiddleware[Order](sm, ttl)
+//	if err != nil {
+//	    return err
+//	}
+//	event.Subscribe(ctx, handler, event.WithMiddleware(mw))
 func NewMemoryStateManager(opts ...Option) *MemoryStateManager {
 	o := defaultStateOptions()
 	for _, opt := range opts {

--- a/distributed/middleware.go
+++ b/distributed/middleware.go
@@ -2,6 +2,7 @@ package distributed
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -15,6 +16,7 @@ type poolOptions struct {
 	storePayload   *bool // nil = unset; resolved at WorkerPoolMiddleware call time
 	maxPayloadSize int   // 0 = no limit
 	logger         *slog.Logger
+	err            error // first validation error from an option
 }
 
 // WithPayloadRecovery explicitly enables payload storage for recovery.
@@ -44,11 +46,12 @@ func WithPayloadRecovery() PoolOption {
 // support is resolved once at construction time rather than lazily on
 // the first message.
 //
-// If b is nil the option is a no-op; use [WithPayloadRecovery] to enable
-// payload storage explicitly when no bus is available.
+// Passing a nil Bus causes [WorkerPoolMiddleware] to return an error.
+// Use [WithPayloadRecovery] to enable payload storage when no Bus is available.
 func WithBus(b *event.Bus) PoolOption {
 	return func(o *poolOptions) {
 		if b == nil {
+			o.err = errors.New("distributed: WithBus requires a non-nil Bus")
 			return
 		}
 		store := !b.SupportsRedelivery()
@@ -104,17 +107,19 @@ func WithMaxPayloadSize(size int) PoolOption {
 //   - coord: A Coordinator implementation (RedisStateManager for distributed)
 //   - stateTTL: How long to hold the state (should exceed handler timeout)
 //
+// Returns an error if coord is nil or any option is invalid (e.g. WithBus(nil)).
+//
 // Example:
 //
 //	// Redis state manager for distributed deployments
 //	sm := distributed.NewRedisStateManager(redisClient)
 //
 //	// Subscribe with worker emulation
-//	event.Subscribe(ctx, handler,
-//	    event.WithMiddleware(
-//	        distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute),
-//	    ),
-//	)
+//	mw, err := distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute)
+//	if err != nil {
+//	    return err
+//	}
+//	event.Subscribe(ctx, handler, event.WithMiddleware(mw))
 //
 // State TTL Guidelines:
 //
@@ -149,10 +154,17 @@ func WithMaxPayloadSize(size int) PoolOption {
 //
 //	orderEvent.Subscribe(ctx, collectAnalytics,
 //	    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smB, ttl)))
-func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts ...PoolOption) event.Middleware[T] {
+func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts ...PoolOption) (event.Middleware[T], error) {
+	if coord == nil {
+		return nil, errors.New("distributed: WorkerPoolMiddleware requires a non-nil Coordinator")
+	}
+
 	o := &poolOptions{}
 	for _, opt := range opts {
 		opt(o)
+	}
+	if o.err != nil {
+		return nil, o.err
 	}
 
 	// Check if coordinator also implements PayloadStore
@@ -301,5 +313,5 @@ func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts
 
 			return handlerErr
 		}
-	}
+	}, nil
 }

--- a/distributed/middleware.go
+++ b/distributed/middleware.go
@@ -149,11 +149,17 @@ func WithMaxPayloadSize(size int) PoolOption {
 //	smB := distributed.NewRedisStateManager(redis,
 //	    distributed.WithPrefix("analytics:"))
 //
-//	orderEvent.Subscribe(ctx, processOrder,
-//	    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smA, ttl)))
+//	mwA, err := distributed.WorkerPoolMiddleware[Order](smA, ttl)
+//	if err != nil {
+//	    return err
+//	}
+//	orderEvent.Subscribe(ctx, processOrder, event.WithMiddleware(mwA))
 //
-//	orderEvent.Subscribe(ctx, collectAnalytics,
-//	    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smB, ttl)))
+//	mwB, err := distributed.WorkerPoolMiddleware[Order](smB, ttl)
+//	if err != nil {
+//	    return err
+//	}
+//	orderEvent.Subscribe(ctx, collectAnalytics, event.WithMiddleware(mwB))
 func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts ...PoolOption) (event.Middleware[T], error) {
 	if coord == nil {
 		return nil, errors.New("distributed: WorkerPoolMiddleware requires a non-nil Coordinator")

--- a/distributed/middleware.go
+++ b/distributed/middleware.go
@@ -14,6 +14,7 @@ type PoolOption func(*poolOptions)
 type poolOptions struct {
 	storePayload   *bool // nil = unset; resolved at WorkerPoolMiddleware call time
 	maxPayloadSize int   // 0 = no limit
+	logger         *slog.Logger
 }
 
 // WithPayloadRecovery explicitly enables payload storage for recovery.
@@ -43,14 +44,25 @@ func WithPayloadRecovery() PoolOption {
 // support is resolved once at construction time rather than lazily on
 // the first message.
 //
-// Panics if b is nil.
+// If b is nil the option is a no-op; use [WithPayloadRecovery] to enable
+// payload storage explicitly when no bus is available.
 func WithBus(b *event.Bus) PoolOption {
-	if b == nil {
-		panic("distributed: WithBus requires a non-nil Bus")
-	}
 	return func(o *poolOptions) {
+		if b == nil {
+			return
+		}
 		store := !b.SupportsRedelivery()
 		o.storePayload = &store
+	}
+}
+
+// WithPoolLogger sets the logger used for construction-time warnings emitted
+// by WorkerPoolMiddleware. Defaults to slog.Default() when not set.
+func WithPoolLogger(l *slog.Logger) PoolOption {
+	return func(o *poolOptions) {
+		if l != nil {
+			o.logger = l
+		}
 	}
 }
 
@@ -150,6 +162,11 @@ func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts
 	// WithBus or WithPayloadRecovery set o.storePayload explicitly.
 	// If neither is provided, default to false (no payload storage) and warn
 	// so callers know they may need to act.
+	logger := o.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	storePayload := false
 	if o.storePayload != nil {
 		storePayload = *o.storePayload
@@ -157,7 +174,7 @@ func WorkerPoolMiddleware[T any](coord Coordinator, stateTTL time.Duration, opts
 		// Coordinator supports payload storage but no bus or explicit option was
 		// provided — warn once at construction time so the issue is visible
 		// before any messages flow.
-		slog.Warn("distributed.WorkerPoolMiddleware: coordinator supports payload recovery but redelivery support is unknown; use WithBus(bus) or WithPayloadRecovery() to enable payload storage")
+		logger.Warn("distributed.WorkerPoolMiddleware: coordinator supports payload recovery but redelivery support is unknown; use WithBus(bus) or WithPayloadRecovery() to enable payload storage")
 	}
 
 	return func(next event.Handler[T]) event.Handler[T] {

--- a/distributed/middleware_test.go
+++ b/distributed/middleware_test.go
@@ -67,11 +67,22 @@ func (h *testHandler[T]) handle(ctx context.Context, ev event.Event[T], data T) 
 	return h.err
 }
 
+// mustMW unwraps the (Middleware, error) return of WorkerPoolMiddleware in tests
+// that expect construction to succeed. It can be called as
+// mustMW(WorkerPoolMiddleware[T](...)) because Go unpacks multi-return
+// values when they are the sole argument to a function call.
+func mustMW[T any](mw event.Middleware[T], err error) event.Middleware[T] {
+	if err != nil {
+		panic("WorkerPoolMiddleware: unexpected error: " + err.Error())
+	}
+	return mw
+}
+
 func TestMiddleware_NoEventID_PassesThrough(t *testing.T) {
 	coord := &mockCoordinator{acquireResult: true}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute))
 	wrapped := mw(handler.handle)
 
 	// Context without event ID - should pass through to handler
@@ -92,7 +103,7 @@ func TestMiddleware_AcquireFails_FailOpen(t *testing.T) {
 	coord := &mockCoordinator{acquireErr: errors.New("redis down")}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute))
 	wrapped := mw(handler.handle)
 
 	ctx := event.ContextWithEventID(context.Background(), "msg-1")
@@ -109,7 +120,7 @@ func TestMiddleware_NotAcquired_Skips(t *testing.T) {
 	coord := &mockCoordinator{acquireResult: false}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute))
 	wrapped := mw(handler.handle)
 
 	ctx := event.ContextWithEventID(context.Background(), "msg-1")
@@ -126,7 +137,7 @@ func TestMiddleware_Acquired_CallsHandlerAndMarksProcessed(t *testing.T) {
 	coord := &mockCoordinator{acquireResult: true}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute))
 	wrapped := mw(handler.handle)
 
 	ctx := event.ContextWithEventID(context.Background(), "msg-1")
@@ -150,7 +161,7 @@ func TestMiddleware_HandlerError_ResetsState(t *testing.T) {
 	handlerErr := errors.New("processing failed")
 	handler := &testHandler[string]{err: handlerErr}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute)
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute))
 	wrapped := mw(handler.handle)
 
 	ctx := event.ContextWithEventID(context.Background(), "msg-1")
@@ -172,7 +183,7 @@ func TestMiddleware_NoPayloadInContext_NoStore(t *testing.T) {
 	}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery()))
 	wrapped := mw(handler.handle)
 
 	// Context with event ID but NO raw payload
@@ -200,7 +211,7 @@ func TestMiddleware_PayloadStored_ClearedOnSuccess(t *testing.T) {
 	}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery()))
 	wrapped := mw(handler.handle)
 
 	// Context with event ID AND raw payload
@@ -233,7 +244,7 @@ func TestMiddleware_PayloadStored_NotClearedOnHandlerError(t *testing.T) {
 	handlerErr := errors.New("processing failed")
 	handler := &testHandler[string]{err: handlerErr}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery()))
 	wrapped := mw(handler.handle)
 
 	ctx := event.ContextWithEventID(context.Background(), "msg-1")
@@ -265,7 +276,7 @@ func TestMiddleware_StorePayloadFails_NoClearOnSuccess(t *testing.T) {
 	}
 	handler := &testHandler[string]{}
 
-	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery()))
 	wrapped := mw(handler.handle)
 
 	// With raw payload in context, StorePayload is called but fails
@@ -292,10 +303,10 @@ func TestMiddleware_MaxPayloadSize(t *testing.T) {
 	handler := &testHandler[string]{}
 
 	// Set max payload size very small (10 bytes)
-	mw := WorkerPoolMiddleware[string](coord, time.Minute,
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute,
 		WithPayloadRecovery(),
 		WithMaxPayloadSize(10),
-	)
+	))
 	wrapped := mw(handler.handle)
 
 	// Payload exceeds 10 bytes → skipped
@@ -316,13 +327,28 @@ func TestMiddleware_MaxPayloadSize(t *testing.T) {
 	}
 }
 
+func TestWorkerPoolMiddleware_NilCoord_ReturnsError(t *testing.T) {
+	_, err := WorkerPoolMiddleware[string](nil, time.Minute)
+	if err == nil {
+		t.Fatal("expected error for nil coordinator")
+	}
+}
+
+func TestWorkerPoolMiddleware_WithBusNil_ReturnsError(t *testing.T) {
+	coord := &mockCoordinator{acquireResult: true}
+	_, err := WorkerPoolMiddleware[string](coord, time.Minute, WithBus(nil))
+	if err == nil {
+		t.Fatal("expected error when WithBus receives a nil bus")
+	}
+}
+
 func TestMiddleware_CoordWithoutPayloadStore(t *testing.T) {
 	// Plain coordinator without PayloadStore
 	coord := &mockCoordinator{acquireResult: true}
 	handler := &testHandler[string]{}
 
 	// Even with WithPayloadRecovery, should work fine (just no payload storage)
-	mw := WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery())
+	mw := mustMW(WorkerPoolMiddleware[string](coord, time.Minute, WithPayloadRecovery()))
 	wrapped := mw(handler.handle)
 
 	ctx := event.ContextWithEventID(context.Background(), "msg-1")

--- a/distributed/recovery.go
+++ b/distributed/recovery.go
@@ -356,6 +356,17 @@ func (r *RecoveryRunner) recoverPayloadEntries(ctx context.Context, ps PayloadSt
 		// Track all entries seen by Phase 1 to exclude from Phase 2
 		handled[entry.MessageID] = struct{}{}
 
+		// Guard against entries written before EventName was added to MessageData.
+		// Sending to an empty event name produces a confusing downstream error.
+		if entry.Data.EventName == "" {
+			if r.logger != nil {
+				r.logger.Warn("stale payload missing event name, skipping re-publish",
+					"message_id", entry.MessageID)
+			}
+			r.metrics.recordSkipped(ctx, "missing_event_name", "")
+			continue
+		}
+
 		// Re-publish with a new event ID so WorkerPool can acquire fresh state
 		newID := event.NewID()
 		if err := r.pub.Send(ctx, entry.Data.EventName, newID, entry.Data.Payload, entry.Data.Metadata); err != nil {

--- a/distributed/redis.go
+++ b/distributed/redis.go
@@ -72,11 +72,11 @@ type redisPayloadValue struct {
 //	)
 //
 //	// Use with middleware
-//	event.Subscribe(ctx, handler,
-//	    event.WithMiddleware(
-//	        distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute),
-//	    ),
-//	)
+//	mw, err := distributed.WorkerPoolMiddleware[Order](sm, 5*time.Minute)
+//	if err != nil {
+//	    return err
+//	}
+//	event.Subscribe(ctx, handler, event.WithMiddleware(mw))
 type RedisStateManager struct {
 	client        redis.Cmdable
 	prefix        string

--- a/outbox/postgres.go
+++ b/outbox/postgres.go
@@ -32,29 +32,6 @@ func WithTable(table string) PostgresStoreOption {
 	}
 }
 
-// PostgresStore implements Store for PostgreSQL.
-//
-// PostgresStore uses PostgreSQL's transactional capabilities for reliable
-// message storage. It supports concurrent relay instances using
-// SELECT FOR UPDATE SKIP LOCKED to prevent duplicate processing.
-//
-// Required Schema:
-//
-//	CREATE TABLE event_outbox (
-//	    id           BIGSERIAL PRIMARY KEY,
-//	    event_name   VARCHAR(255) NOT NULL,
-//	    event_id     VARCHAR(36) NOT NULL,
-//	    payload      BYTEA NOT NULL,
-//	    metadata     JSONB,
-//	    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
-//	    published_at TIMESTAMP,
-//	    status       VARCHAR(20) NOT NULL DEFAULT 'pending',
-//	    retry_count  INT NOT NULL DEFAULT 0,
-//	    last_error   TEXT,
-//	    priority     INT NOT NULL DEFAULT 0
-//	);
-//	CREATE INDEX idx_outbox_pending ON event_outbox(status, priority DESC, created_at)
-//	    WHERE status IN ('pending', 'failed');
 // WithNotifyChannel sets the PostgreSQL NOTIFY channel name emitted on each Insert.
 // Listeners using pq.NewListener can subscribe to this channel to be woken up
 // immediately when new messages arrive instead of relying solely on polling.

--- a/outbox/postgres.go
+++ b/outbox/postgres.go
@@ -325,7 +325,9 @@ func (s *PostgresStore) scanMessages(rows *sql.Rows) ([]*Message, error) {
 		}
 
 		if metadataJSON != nil {
-			json.Unmarshal(metadataJSON, &msg.Metadata)
+			if err := json.Unmarshal(metadataJSON, &msg.Metadata); err != nil {
+				return nil, fmt.Errorf("unmarshal metadata for id=%d: %w", msg.ID, err)
+			}
 		}
 
 		msg.Status = StatusPending

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -287,6 +287,8 @@ func (r *Relay) Start(ctx context.Context) error {
 		}
 	}
 
+	// nil channel blocks forever in the select below — the ticker and cleanup
+	// cases handle polling when no listener is configured.
 	var notifyC <-chan *pq.Notification
 	if r.listener != nil {
 		notifyC = r.listener.Notify
@@ -388,6 +390,11 @@ func (r *Relay) publishPending(ctx context.Context) (failures int) {
 			r.log().Error("failed to mark message as published",
 				"id", msg.ID,
 				"error", err)
+			// Count as failure: the transport received the message but the outbox
+			// record stays pending, so it will be re-published on the next poll.
+			// This is observable via the failures counter and avoids silent duplicates.
+			failures++
+			continue
 		}
 
 		r.log().Debug("published outbox message",


### PR DESCRIPTION
## Summary

Fixes three robustness issues identified in review:

**`distributed/recovery.go`** — Guard against stale payload entries with an empty `EventName`. These can exist if the entry was written before `EventName` was added to `MessageData`. Calling `r.pub.Send` with an empty event name produces a confusing downstream error; the entry is now skipped with a warning log and a `recordSkipped` metric.

**`outbox/postgres.go`** — `scanMessages` was silently discarding errors from `json.Unmarshal` on the metadata JSONB column. A corrupted column now returns an error with the row ID, consistent with how other scan errors are handled.

**`outbox/relay.go`** — In the `GetPending` fallback path (non-`ProcessPending` stores), a `MarkPublished` failure was logged but not counted in `failures`. The message stays pending and will be re-published on the next poll tick (at-least-once duplicate), which is expected — but the failure counter should reflect this so operators can observe the divergence. Also adds a comment explaining why a nil `notifyC` is intentional in the select.

## Test plan

- [ ] `go test -race ./distributed/... ./outbox/...` passes
- [ ] `go build ./...` passes