### PR TITLE
feat(monitor): stuck-pending detection, coverage endpoint, redis lag age

### DIFF
--- a/bus_gauges.go
+++ b/bus_gauges.go
@@ -90,7 +90,9 @@ func initGauges(meter metric.Meter) {
 								)
 								observer.ObserveInt64(lagGauge, lag.Lag, attrs)
 								observer.ObserveInt64(pendingGauge, lag.PendingMessages, attrs)
-								observer.ObserveFloat64(oldestPendingGauge, lag.OldestPending.Seconds(), attrs)
+								if lag.OldestPending != nil {
+									observer.ObserveFloat64(oldestPendingGauge, lag.OldestPending.Seconds(), attrs)
+								}
 							}
 						}
 					}

--- a/bus_metrics_test.go
+++ b/bus_metrics_test.go
@@ -190,7 +190,7 @@ func TestConsumerLagGauges(t *testing.T) {
 				ConsumerGroup:   "processor",
 				Lag:             42,
 				PendingMessages: 5,
-				OldestPending:   10 * time.Second,
+				OldestPending:   durationPtr(10 * time.Second),
 			},
 		},
 	}
@@ -456,3 +456,5 @@ func TestFilterDropCounter(t *testing.T) {
 		t.Errorf("filter_dropped_total = %d, want 2", got)
 	}
 }
+
+func durationPtr(d time.Duration) *time.Duration { return &d }

--- a/monitor/DEBUGGING.md
+++ b/monitor/DEBUGGING.md
@@ -1,0 +1,704 @@
+# Event Monitor Debugging Guide
+
+This guide explains how to diagnose event delivery failures, consumer lag, stuck processing, and coverage gaps using the monitoring APIs and raw backend queries.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Monitoring API Reference](#monitoring-api-reference)
+3. [Scenario: Subscriber Did Not Process an Event](#scenario-subscriber-did-not-process-an-event)
+4. [Scenario: Consumer Lag Is Growing](#scenario-consumer-lag-is-growing)
+5. [Scenario: Stuck Pending Entries](#scenario-stuck-pending-entries)
+6. [Scenario: Coverage Gaps](#scenario-coverage-gaps)
+7. [Scenario: Dead Letter Queue Buildup](#scenario-dead-letter-queue-buildup)
+8. [System View Interpretation](#system-view-interpretation)
+9. [MongoDB Direct Queries](#mongodb-direct-queries)
+10. [Redis Direct Queries](#redis-direct-queries)
+11. [Transport-Specific Notes](#transport-specific-notes)
+
+---
+
+## Architecture Overview
+
+### Event Flow
+
+```
+Source (MongoDB Change Stream)
+  │
+  ▼
+Bridge dedup (one pod wins via MongoDB CAS on _event_worker_state)
+  │
+  ▼
+Redis Streams (XADD to evt.{busName}.{eventName} stream)
+  │
+  ▼
+Consumer Groups (one per worker group)
+  │  ├─ group "workflow"  → competes among pods
+  │  ├─ group "signals"   → competes among pods (independent from "workflow")
+  │  └─ group "mailbox"   → competes among pods (independent from all others)
+  ▼
+Monitor middleware (records "pending" BEFORE handler runs)
+  │
+  ▼
+Handler
+  │
+  ▼
+Monitor middleware (updates to "completed" or "failed" AFTER handler returns)
+```
+
+### Key Timing Constants
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `claimInterval` | 2 minutes | How often a pod sweeps for orphaned PEL messages |
+| `claimMinIdle` | 5 minutes | Minimum age before an unclaimed message is stolen |
+| `stuckPendingThreshold` | 6 minutes | Age at which a "pending" monitor entry is flagged as stuck |
+
+The 5-minute window between a pod crashing and the PEL being reclaimed means a monitor entry can appear stuck for up to ~5 minutes after a crash, then silently recover when another pod claims and processes the message.
+
+### Delivery Modes
+
+| Mode | Behavior | Monitor entry key |
+|---|---|---|
+| **Broadcast** | Every subscriber receives every message | `(event_id, subscription_id)` |
+| **WorkerPool** | Only one subscriber per worker group receives each message | `(event_id, "")` — subscription_id is empty, matched by worker_group |
+
+---
+
+## Monitoring API Reference
+
+All endpoints are served by the handler returned by `monitorhttp.New(store, opts...)`. Mount it on your HTTP server, e.g. at `/events`.
+
+### Monitor Entries
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/monitor/entries` | List entries (paginated, filterable) |
+| `GET` | `/v1/monitor/entries/{event_id}` | All entries for a specific event |
+| `GET` | `/v1/monitor/entries/{event_id}/{subscription_id}` | Single entry by composite key |
+| `GET` | `/v1/monitor/entries/count` | Count entries matching filter |
+| `DELETE` | `/v1/monitor/entries?older_than=24h` | Delete entries older than age |
+
+#### Filter Query Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `event_id` | string | Exact match on event ID |
+| `event_name` | string | Exact match on event name |
+| `subscription_id` | string | Exact match on subscription ID |
+| `bus_id` | string | Filter by bus name |
+| `instance_id` | string | Filter by pod/instance ID |
+| `worker_group` | string | Filter by worker group |
+| `delivery_mode` | string | `broadcast` or `worker_pool` |
+| `status` | string (repeatable) | `pending`, `completed`, `failed`, `retrying` |
+| `has_error` | bool | `true` to show only entries with errors |
+| `start_time` | RFC3339 | Filter entries started after this time |
+| `end_time` | RFC3339 | Filter entries started before this time |
+| `min_duration` | Go duration | Minimum processing time (e.g. `500ms`) |
+| `min_retries` | int | Minimum retry count |
+| `limit` | int | Page size (default 100, max 1000) |
+| `cursor` | string | Pagination cursor from previous response |
+| `order_desc` | bool | Return newest first |
+
+### Summary
+
+```
+GET /v1/monitor/summary
+GET /v1/monitor/summary?start_time=2025-01-01T00:00:00Z&end_time=2025-01-02T00:00:00Z
+```
+
+Returns aggregated statistics: counts by status, by event name (with error rate), by instance ID, average duration, time range of stored data.
+
+### Coverage
+
+```
+GET /v1/monitor/coverage/{event_id}
+```
+
+Cross-references recorded monitor entries with the **live in-process subscription topology**. For a given event ID, shows which subscriptions have an entry and which do not. Useful for confirming that every expected subscriber processed the event.
+
+**Response fields:**
+
+| Field | Description |
+|---|---|
+| `event_id` | The queried event ID |
+| `topology_as_of` | Timestamp when the topology snapshot was taken |
+| `coverage[]` | One entry per subscription in the current topology |
+| `coverage[].has_entry` | Whether a monitor entry exists for this subscription |
+| `coverage[].entry` | The entry if present (status, duration, error, etc.) |
+| `missing_count` | Number of subscriptions with no recorded entry |
+| `present_count` | Number of subscriptions with a recorded entry |
+
+**Caveat:** subscription IDs are regenerated on pod restart. Historical entries with old IDs will not match the current topology. Use the `worker_group` to correlate worker pool entries.
+
+### Topology
+
+```
+GET /v1/topology                    # All buses and events
+GET /v1/topology/{bus_name}         # Single bus
+GET /v1/topology/{bus_name}/{event} # Single event
+```
+
+Shows the live in-process subscription graph: bus names, event names, subscription IDs, worker groups, delivery modes.
+
+### System View
+
+```
+GET /v1/system          # Full system snapshot (cached)
+GET /v1/system/health   # Aggregated health status only
+```
+
+Returns all system data in one call: topology, DLQ stats, scheduler stats, stuck-pending detection, bus health, consumer lag per stream, and 24-hour summary. Backed by a configurable background refresh (default 10 seconds).
+
+**`stuck_pending` field (if provider configured):**
+
+```json
+{
+  "stuck_pending": {
+    "count": 3,
+    "threshold": "6m0s",
+    "oldest_at": "2025-01-01T12:00:00Z",
+    "samples": [...]
+  }
+}
+```
+
+A non-zero `count` means pods crashed after recording "pending" but before completing processing. Each sample shows the event ID, event name, worker group, and the instance that last owned it.
+
+### Worker Pool State
+
+```
+GET /v1/workers          # All worker leases
+GET /v1/workers/{id}     # Single worker by subscription ID
+GET /v1/workers/count    # Count active workers
+```
+
+Available when `WithWorkerStore` is configured. Shows which pod holds which worker lease, when it was acquired, and when it expires. Use to diagnose split-brain or stale lease scenarios.
+
+---
+
+## Scenario: Subscriber Did Not Process an Event
+
+**Symptoms:** A downstream effect (e.g., a task created, an email sent) did not happen after a database change.
+
+### Step 1: Find the event ID
+
+If you know when the source document changed, use MongoDB to find the event ID. All events published via the monitor middleware have a unique `event_id`. If you have the trace ID from the originating request, correlate via `trace_id`.
+
+```
+GET /v1/monitor/entries?event_name=<name>&start_time=<RFC3339>&end_time=<RFC3339>
+```
+
+Or if you have the event ID directly:
+
+```
+GET /v1/monitor/entries/{event_id}
+```
+
+### Step 2: Check coverage
+
+```
+GET /v1/monitor/coverage/{event_id}
+```
+
+- `missing_count > 0` → at least one subscriber has no recorded entry.
+- Check the `delivery_mode` of missing entries: `worker_pool` entries are matched by worker group, so verify the `worker_group` field matches.
+
+### Step 3: Check the entry status
+
+| Status | Meaning | Action |
+|---|---|---|
+| `completed` | Handler ran and returned nil | Check downstream logic — event was processed but effect may have failed elsewhere |
+| `failed` | Handler returned a non-retryable error | Check `entry.error` field; look at DLQ |
+| `retrying` | Handler failed but will retry | Wait or check retry count / DLQ threshold |
+| `pending` | Handler started but not completed | Either in-flight, or the pod crashed (see Stuck Pending section) |
+| *(missing)* | No entry for this subscription | Handler was never invoked — check transport delivery |
+
+### Step 4: If no entry exists for a subscriber
+
+A missing entry means the monitor middleware never fired for that subscription. Possible causes:
+
+1. **Bridge dedup lost the race** — the event was published to Redis by a different pod, and this pod's bridge dedup saw the deduplicated `ignore`. Check the bridge dedup worker state collection:
+
+   ```javascript
+   db._event_worker_state.findOne({_id: "<event_id>"})
+   ```
+
+2. **Redis consumer group lag** — the message is in the stream but not yet delivered to this worker group. Check consumer lag:
+
+   ```
+   GET /v1/system
+   # Look at consumer_lag[] for the relevant stream and group
+   ```
+
+3. **Pod was down** — the consumer group had no active consumers when the message arrived. When a pod comes back, it will claim the message from the PEL (after `claimMinIdle`).
+
+4. **Wrong worker group** — the subscriber registered under a different group name. Cross-check `GET /v1/topology` against `GET /v1/workers`.
+
+---
+
+## Scenario: Consumer Lag Is Growing
+
+**Symptoms:** Events are published but subscribers are falling behind. The system view shows increasing `lag` on one or more streams.
+
+### Step 1: Check the system view
+
+```
+GET /v1/system
+```
+
+Look at `consumer_lag[]`:
+
+```json
+{
+  "consumer_lag": [
+    {
+      "event": "case_record.created",
+      "consumer_group": "mybus-case_record.created-workflow",
+      "lag": 1500,
+      "pending_messages": 3,
+      "oldest_pending": "4m30s"
+    }
+  ]
+}
+```
+
+| Field | Concern threshold | Meaning |
+|---|---|---|
+| `lag` | > a few hundred | Unconsumed messages in the stream |
+| `pending_messages` | > 0 | Delivered but not ACKed (in-flight or crashed) |
+| `oldest_pending` | > `claimMinIdle` (5 min) | A pod claimed this message and has not ACKed it — likely crashed |
+
+### Step 2: Identify the bottleneck
+
+- **High lag, low pending**: handlers are too slow or there aren't enough pods. Scale horizontally — each pod in the worker group is a consumer.
+- **High pending, old oldest_pending**: pod crashed and the PEL is not yet reclaimed. Wait for `claimMinIdle` (5 min) and check again. If it persists, check stuck pending (next section).
+- **High lag, zero pending**: the consumer group has no active consumers. All pods may be down.
+
+### Step 3: Direct Redis inspection
+
+```bash
+# Stream length
+XLEN evt.mybus.case_record.created
+
+# Consumer group summary
+XPENDING evt.mybus.case_record.created mybus-case_record.created-workflow
+
+# Detailed PEL (messages stuck for > 5 min)
+XPENDING evt.mybus.case_record.created mybus-case_record.created-workflow - + 10
+
+# Info on all groups
+XINFO GROUPS evt.mybus.case_record.created
+```
+
+---
+
+## Scenario: Stuck Pending Entries
+
+**Symptoms:** `GET /v1/system` shows `stuck_pending.count > 0`, or a manual query returns entries in `pending` status with `started_at` much older than expected processing time.
+
+### What "stuck pending" means
+
+The monitor middleware records "pending" **before** the handler runs. If a pod crashes after recording "pending" but before completing the handler:
+
+1. The monitor entry stays `pending` forever (nothing updates it).
+2. The Redis PEL still holds the message.
+3. After `claimMinIdle` (5 min), another pod claims the message and processes it.
+4. **The original "pending" entry is never updated** because `Record()` uses `$setOnInsert` for WorkerPool mode — a new completion entry cannot overwrite the old pod's pending entry.
+
+This means a stuck pending entry does **not** always mean the event was lost. The new pod's completion is a separate `(event_id, "")` upsert that conflicts with the orphaned entry. Check whether a completion entry exists with the same `event_id` and `worker_group`.
+
+### Step 1: Query stuck pending entries
+
+```
+GET /v1/monitor/entries?status=pending&min_duration=6m
+```
+
+Or query MongoDB directly (see [MongoDB Direct Queries](#mongodb-direct-queries)).
+
+### Step 2: For each stuck entry
+
+1. Check `instance_id` — which pod last owned it.
+2. Check `worker_group` — which subscriber group is affected.
+3. Look for a completed entry on the same event: 
+   ```
+   GET /v1/monitor/entries/{event_id}
+   ```
+   If a `completed` entry exists with the same `worker_group`, the event **was** processed by another pod — the stuck pending is just the orphaned entry from the crashed pod.
+4. If no completed entry exists, the message is still in the PEL waiting to be reclaimed. Verify via Redis:
+   ```bash
+   XPENDING evt.mybus.{event_name} {consumer_group} - + 1 {consumer_name}
+   ```
+
+### Step 3: Resolution
+
+| Situation | Action |
+|---|---|
+| Completed entry exists for same event + worker_group | No action needed; orphaned pending entry will age out on next `DeleteOlderThan` run |
+| No completed entry; message still in Redis PEL | Wait for reclaim, or manually trigger `XCLAIM` |
+| No completed entry; message not in Redis PEL | Message was ACKed without monitor update (rare race) — investigate handler logs |
+| Pod is still running but slow | Check handler duration via `min_duration` filter; look for resource exhaustion |
+
+---
+
+## Scenario: Coverage Gaps
+
+**Symptoms:** You expect subscriber X to process every message of event Y, but some events have no record for X.
+
+### Understanding coverage
+
+The coverage endpoint cross-references the **live subscription topology** (which subscriptions currently exist in this process) with **historical monitor entries** (which subscriptions recorded processing the event).
+
+A "missing" entry means one of:
+
+1. **The event was published before this subscriber existed** — if the subscription was added in a recent deploy, old events predate it.
+2. **The subscriber's consumer group had no active consumers** — the pod was down when the message arrived.
+3. **The worker group name changed** — group renames create a new consumer group; the new group starts from `$` (latest) by default.
+4. **The event was not forwarded to this transport** — if using bridge mode, verify the bridge dedup pod published to Redis.
+
+### Checking group membership
+
+```bash
+XINFO CONSUMERS evt.mybus.{event_name} {consumer_group}
+```
+
+This shows all consumers in the group, their pending count, and last interaction time. If there are no consumers, the group is empty.
+
+---
+
+## Scenario: Dead Letter Queue Buildup
+
+**Symptoms:** `GET /v1/system` shows `dlq.pending_messages > 0`, or growing.
+
+### Step 1: Check DLQ stats
+
+```
+GET /v1/system
+# Look at dlq field:
+{
+  "dlq": {
+    "total_messages": 42,
+    "pending_messages": 15,
+    "messages_by_event": { "case_record.created": 10, "call.updated": 5 },
+    "messages_by_error": { "context deadline exceeded": 12, "connection refused": 3 }
+  }
+}
+```
+
+### Step 2: Investigate the error
+
+The `messages_by_error` map groups messages by the last error string. Common patterns:
+
+| Error pattern | Likely cause |
+|---|---|
+| `context deadline exceeded` | Handler timeout — increase timeout or optimize handler |
+| `connection refused` | Downstream service unavailable during handler |
+| `duplicate key` | Idempotency violation — handler not idempotent; fix or add idempotency middleware |
+| application-specific | Bug in handler business logic |
+
+### Step 3: Retry or drain
+
+DLQ management depends on the DLQ implementation. Use the DLQ library's own API to retry individual messages or drain the queue after fixing the underlying issue.
+
+---
+
+## System View Interpretation
+
+```json
+GET /v1/system
+
+{
+  "topology": [...],           // All buses, events, subscriptions in this process
+  "health": {                  // Aggregated health: healthy/degraded/unhealthy
+    "status": "degraded",
+    "components": {
+      "bus:mybus": {"status": "healthy"},
+      "dlq": {"status": "degraded", "message": "15 pending messages"}
+    }
+  },
+  "bus_health": {              // Per-bus ping latency and status
+    "mybus": {"code": "healthy", "latency_ms": 2}
+  },
+  "consumer_lag": [...],       // Per-stream, per-group lag and PEL info
+  "dlq": {...},                // DLQ stats (if DLQProvider configured)
+  "scheduler": {...},          // Scheduler stats (if SchedulerProvider configured)
+  "stuck_pending": {           // Entries stuck in "pending" beyond threshold
+    "count": 0,
+    "threshold": "6m0s"
+  },
+  "summary": {                 // 24h aggregated monitor stats
+    "total_entries": 12500,
+    "by_status": {"completed": 12400, "failed": 80, "retrying": 20},
+    "by_event_name": {
+      "case_record.created": {
+        "total": 500, "completed": 490, "failed": 10,
+        "error_rate": 0.02, "avg_duration_ms": 45
+      }
+    }
+  },
+  "collected_at": "2025-01-01T12:00:00Z"
+}
+```
+
+**Health status rules:**
+- `healthy` — all components healthy
+- `degraded` — at least one component degraded (system is functional but impaired)
+- `unhealthy` — at least one component unhealthy (requests may fail)
+
+`GET /v1/system/health` returns 200 for healthy/degraded and 503 for unhealthy.
+
+---
+
+## MongoDB Direct Queries
+
+The monitor collection is typically named `_event_monitor`. Adjust the collection name to match your configuration.
+
+### Find all entries for an event
+
+```javascript
+db._event_monitor.find({ event_id: "<event_id>" }).sort({ started_at: 1 })
+```
+
+### Find all failed events in the last hour
+
+```javascript
+db._event_monitor.find({
+  status: "failed",
+  started_at: { $gte: new Date(Date.now() - 3600000) }
+}).sort({ started_at: -1 }).limit(20)
+```
+
+### Find stuck pending entries (older than 6 minutes)
+
+```javascript
+var cutoff = new Date(Date.now() - 6 * 60 * 1000);
+db._event_monitor.find({
+  status: "pending",
+  started_at: { $lt: cutoff }
+}).sort({ started_at: 1 })
+```
+
+This query uses the `{status: 1, started_at: 1}` index prefix — it does not scan the collection.
+
+### Events with high retry counts
+
+```javascript
+db._event_monitor.find({ retry_count: { $gte: 3 } }).sort({ retry_count: -1 }).limit(20)
+```
+
+### Error rate by event name (last 24 hours)
+
+```javascript
+db._event_monitor.aggregate([
+  { $match: { started_at: { $gte: new Date(Date.now() - 86400000) } } },
+  { $group: {
+      _id: "$event_name",
+      total: { $sum: 1 },
+      failed: { $sum: { $cond: [{ $eq: ["$status", "failed"] }, 1, 0] } }
+  }},
+  { $project: {
+      total: 1,
+      failed: 1,
+      error_rate: { $divide: ["$failed", "$total"] }
+  }},
+  { $sort: { error_rate: -1 } }
+])
+```
+
+### Slow events (processing time > 5 seconds)
+
+```javascript
+db._event_monitor.find({ duration_ms: { $gte: 5000 } }).sort({ duration_ms: -1 }).limit(20)
+```
+
+### Coverage check for an event via MongoDB
+
+```javascript
+// Find all subscriptions that processed a specific event
+db._event_monitor.find(
+  { event_id: "<event_id>" },
+  { subscription_id: 1, worker_group: 1, status: 1, instance_id: 1, delivery_mode: 1 }
+)
+```
+
+### Check worker state (bridge dedup)
+
+```javascript
+// See which pod won the dedup race for an event
+db._event_worker_state.findOne({ _id: "<event_id>" })
+// Returns: { _id, instance_id, acquired_at, expires_at }
+```
+
+### Check resume tokens
+
+Resume tokens are stored in a separate collection (default: `_event_resume_tokens_{storeName}`):
+
+```javascript
+// List all resume tokens
+db._event_resume_tokens_GLOBAL.find({})
+
+// Delete token for a specific collection (forces restart from current oplog position)
+db._event_resume_tokens_GLOBAL.deleteMany({ _id: /orders/ })
+
+// Delete all tokens (next restart processes from current position for all collections)
+db._event_resume_tokens_GLOBAL.deleteMany({})
+```
+
+---
+
+## Redis Direct Queries
+
+Streams are named `evt.{busName}.{eventName}`. Consumer groups are named `{deploymentName}-{eventName}-{workerGroup}`.
+
+### List all event streams
+
+```bash
+KEYS evt.*
+```
+
+### Stream length
+
+```bash
+XLEN evt.mybus.case_record.created
+```
+
+### Consumer group summary
+
+```bash
+# Shows lag (unconsumed messages), pending (delivered but not ACKed), consumers count
+XINFO GROUPS evt.mybus.case_record.created
+```
+
+### Pending Entry List (PEL) — in-flight or orphaned messages
+
+```bash
+# Summary: count, min/max message IDs, consumer breakdown
+XPENDING evt.mybus.case_record.created mybus-case_record.created-workflow
+
+# Detailed: messages idle for at least 5 minutes
+XPENDING evt.mybus.case_record.created mybus-case_record.created-workflow - + 10
+```
+
+The `idle` time in the detailed output shows how long since the message was last delivered. Messages idle longer than `claimMinIdle` (5 min) will be auto-claimed by the next pod that runs a claim sweep.
+
+### Active consumers in a group
+
+```bash
+XINFO CONSUMERS evt.mybus.case_record.created mybus-case_record.created-workflow
+```
+
+Shows each consumer: name (pod identifier), pending count, idle time, inactive time.
+
+### Manually reclaim a stuck message
+
+```bash
+# Claim a stuck message to a specific consumer (use XAUTOCLAIM in production)
+XCLAIM evt.mybus.case_record.created mybus-case_record.created-workflow <new_consumer> 300000 <message_id>
+
+# Or use XAUTOCLAIM to claim all messages idle > 5 min
+XAUTOCLAIM evt.mybus.case_record.created mybus-case_record.created-workflow <consumer> 300000 0-0 COUNT 10
+```
+
+### Read the latest messages
+
+```bash
+# Last 10 messages from the stream
+XREVRANGE evt.mybus.case_record.created + - COUNT 10
+```
+
+### Check stream memory usage
+
+```bash
+XINFO STREAM evt.mybus.case_record.created FULL COUNT 0
+```
+
+---
+
+## Transport-Specific Notes
+
+### Bridge Mode (MongoDB Change Stream → Redis)
+
+In bridge mode, events originate as MongoDB change stream events and are forwarded to Redis Streams by exactly one pod (the bridge dedup winner). The bridge dedup uses MongoDB compare-and-swap on the `_event_worker_state` collection.
+
+**Key implication:** If the bridge pod crashes immediately after writing to Redis but before the change stream offset advances, the **next restart will re-read the same change** and try to publish again. The dedup worker state (CAS on `event_id`) prevents duplicate processing by downstream consumers, but the stream may have duplicate messages — the idempotency middleware handles this.
+
+**Debugging bridge failures:**
+
+1. Check if the event reached Redis: `XRANGE evt.mybus.{name} - + COUNT 5`
+2. If not in Redis, check the bridge dedup state: `db._event_worker_state.findOne({_id: "<event_id>"})`
+3. If the dedup state shows a different `instance_id` than expected, that pod won and published to Redis. Check its logs.
+4. If the dedup state is missing entirely, the bridge pod crashed before recording the win. The change stream will re-deliver on the next pod's watch loop (up to oplog retention window).
+
+### WorkerPool Mode via Redis Consumer Groups
+
+Each worker group gets its own Redis consumer group. Consumer group names follow the pattern:
+```
+{deploymentName}-{eventName}-{workerGroup}
+```
+
+**Different worker groups are completely independent**: if event `case_record.created` has worker groups `workflow` and `timeline`, every message is delivered to **both** groups (each group gets its own copy). Within each group, only one pod processes the message.
+
+**Debugging: "only some subscribers processed it"**
+- Identify which worker groups are registered via `GET /v1/topology`.
+- For each group, check `XINFO CONSUMERS` to confirm active consumers.
+- Query `GET /v1/monitor/entries/{event_id}` and filter by `worker_group`.
+
+### Monitor Entry for WorkerPool
+
+In WorkerPool mode, the monitor entry `subscription_id` field is stored as an empty string (`""`). Entries are keyed on `(event_id, "")` — meaning only **one** entry per event per worker group. If two pods race to record "pending", the first writer wins (`$setOnInsert`). The losing pod's instance_id is not recorded.
+
+This means:
+- You cannot tell from the monitor entry which specific pod ultimately completed the handler.
+- The `instance_id` in the entry reflects the pod that first recorded "pending", which may be different from the pod that completed processing (in crash/reclaim scenarios).
+- For broadcast mode, `subscription_id` is a UUID regenerated on pod restart, so historical entries may not match the current topology.
+
+### Reading Monitor Entry Fields
+
+| Field | Notes |
+|---|---|
+| `event_id` | Unique ID for the published event (set by publisher) |
+| `subscription_id` | UUID for the subscription (empty for WorkerPool) |
+| `subscriber_name` | Handler display name |
+| `event_name` | Registered event name |
+| `bus_id` | Bus name |
+| `instance_id` | Pod hostname or instance identifier |
+| `delivery_mode` | `broadcast` or `worker_pool` |
+| `worker_group` | Worker group name (worker pool only) |
+| `status` | `pending` / `completed` / `failed` / `retrying` |
+| `error` | Last error message (if status is failed or retrying) |
+| `retry_count` | Number of retries attempted |
+| `started_at` | When processing began (when "pending" was recorded) |
+| `completed_at` | When processing ended (nil for pending) |
+| `duration_ms` | Handler duration in milliseconds |
+| `trace_id` | OpenTelemetry trace ID for correlation |
+| `span_id` | OpenTelemetry span ID for correlation |
+
+---
+
+## Quick Diagnostic Checklist
+
+Use this checklist when a subscriber appears to have missed an event:
+
+```
+□ Find the event_id (from logs, trace, or monitor query by event_name + time range)
+□ GET /v1/monitor/coverage/{event_id} — any missing_count?
+□ For missing entries:
+  □ Is the subscription in GET /v1/topology?
+  □ GET /v1/system — any consumer_lag for the affected stream?
+  □ GET /v1/system — any stuck_pending?
+  □ XINFO CONSUMERS {stream} {group} — are consumers active?
+  □ XPENDING {stream} {group} — is the message stuck in PEL?
+□ For pending entries older than 6 min:
+  □ Does a completed entry exist with the same event_id + worker_group?
+  □ If yes: orphaned from crashed pod, event was processed
+  □ If no: check Redis PEL and pod health
+□ For failed entries:
+  □ Check entry.error field
+  □ Check GET /v1/system dlq.messages_by_event for DLQ accumulation
+□ If event never reached Redis (no PEL, no consumer lag):
+  □ Check bridge dedup: db._event_worker_state.findOne({_id: event_id})
+  □ Check MongoDB change stream lag: db._event_resume_tokens_* for stale tokens
+  □ Check mongodb_stream_reconnections_total metric for history_lost events
+```

--- a/monitor/http/coverage.go
+++ b/monitor/http/coverage.go
@@ -55,11 +55,15 @@ func (h *Handler) handleCoverage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Index recorded entries by subscription_id for O(1) lookup.
+	// Index recorded entries for O(1) lookup in the topology walk below.
 	entryBySubID := make(map[string]*monitor.Entry, len(entries))
+	entryByGroup := make(map[string]*monitor.Entry)
 	eventNames := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
 		entryBySubID[e.SubscriptionID] = e
+		if e.DeliveryMode == monitor.WorkerPool {
+			entryByGroup[e.WorkerGroup] = e
+		}
 		eventNames[e.EventName] = struct{}{}
 	}
 
@@ -96,13 +100,10 @@ func (h *Handler) handleCoverage(w http.ResponseWriter, r *http.Request) {
 					ce.HasEntry = true
 					ce.Entry = e
 				} else if sub.DeliveryMode == transport.WorkerPool {
-					// WorkerPool entries store empty subscription_id — match on worker_group.
-					for _, e := range entries {
-						if e.DeliveryMode == monitor.WorkerPool && e.WorkerGroup == sub.WorkerGroup {
-							ce.HasEntry = true
-							ce.Entry = e
-							break
-						}
+					// WorkerPool entries store empty subscription_id — match by worker_group.
+					if e, ok := entryByGroup[sub.WorkerGroup]; ok {
+						ce.HasEntry = true
+						ce.Entry = e
 					}
 				}
 

--- a/monitor/http/coverage.go
+++ b/monitor/http/coverage.go
@@ -1,0 +1,130 @@
+package http
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/monitor"
+	"github.com/rbaliyan/event/v3/transport"
+)
+
+// SubscriptionCoverageEntry describes one subscription's delivery status for an event_id.
+type SubscriptionCoverageEntry struct {
+	SubscriptionID string         `json:"subscription_id"`
+	SubscriberName string         `json:"subscriber_name,omitempty"`
+	WorkerGroup    string         `json:"worker_group,omitempty"`
+	DeliveryMode   string         `json:"delivery_mode"`
+	HasEntry       bool           `json:"has_entry"`
+	Entry          *monitor.Entry `json:"entry,omitempty"`
+}
+
+// EventCoverageResponse is returned by GET /v1/monitor/coverage/{event_id}.
+// It cross-references recorded monitor entries with the current in-process
+// subscription topology to show which subscriptions processed the event and
+// which have no record (either not yet delivered or never published to that group).
+//
+// Caveat: subscription IDs are regenerated on pod restart. Historical entries
+// with old IDs will not match the current topology. TopologyAsOf records when
+// the snapshot was taken for context.
+type EventCoverageResponse struct {
+	EventID      string                      `json:"event_id"`
+	TopologyAsOf time.Time                   `json:"topology_as_of"`
+	Coverage     []SubscriptionCoverageEntry `json:"coverage"`
+	MissingCount int                         `json:"missing_count"`
+	PresentCount int                         `json:"present_count"`
+}
+
+// handleCoverage handles GET /v1/monitor/coverage/{event_id}.
+func (h *Handler) handleCoverage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	eventID := strings.TrimPrefix(r.URL.Path, "/v1/monitor/coverage/")
+	if eventID == "" {
+		h.writeError(w, http.StatusBadRequest, "event_id is required")
+		return
+	}
+
+	entries, err := h.store.GetByEventID(r.Context(), eventID)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Index recorded entries by subscription_id for O(1) lookup.
+	entryBySubID := make(map[string]*monitor.Entry, len(entries))
+	eventNames := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		entryBySubID[e.SubscriptionID] = e
+		eventNames[e.EventName] = struct{}{}
+	}
+
+	now := time.Now()
+	topology := event.Topology()
+
+	// Walk topology to find subscriptions for the event names seen in entries.
+	// For WorkerPool mode, the monitor records an empty subscription_id so we
+	// match by worker_group across all WorkerPool entries for the same event.
+	var coverage []SubscriptionCoverageEntry
+	seen := make(map[string]struct{}) // deduplicate by subscription_id
+
+	for _, busInfo := range topology {
+		for _, evInfo := range busInfo.Events {
+			if _, ok := eventNames[evInfo.Name]; !ok {
+				continue
+			}
+			for _, sub := range evInfo.Subscriptions {
+				if _, already := seen[sub.SubscriptionID]; already {
+					continue
+				}
+				seen[sub.SubscriptionID] = struct{}{}
+
+				// monitor.DeliveryMode and transport.DeliveryMode share the same
+				// underlying int constants; cast to use monitor's String() method.
+				ce := SubscriptionCoverageEntry{
+					SubscriptionID: sub.SubscriptionID,
+					SubscriberName: sub.SubscriberName,
+					WorkerGroup:    sub.WorkerGroup,
+					DeliveryMode:   monitor.DeliveryMode(sub.DeliveryMode).String(),
+				}
+
+				if e, ok := entryBySubID[sub.SubscriptionID]; ok {
+					ce.HasEntry = true
+					ce.Entry = e
+				} else if sub.DeliveryMode == transport.WorkerPool {
+					// WorkerPool entries store empty subscription_id — match on worker_group.
+					for _, e := range entries {
+						if e.DeliveryMode == monitor.WorkerPool && e.WorkerGroup == sub.WorkerGroup {
+							ce.HasEntry = true
+							ce.Entry = e
+							break
+						}
+					}
+				}
+
+				coverage = append(coverage, ce)
+			}
+		}
+	}
+
+	missing, present := 0, 0
+	for _, c := range coverage {
+		if c.HasEntry {
+			present++
+		} else {
+			missing++
+		}
+	}
+
+	h.writeJSON(w, &EventCoverageResponse{
+		EventID:      eventID,
+		TopologyAsOf: now,
+		Coverage:     coverage,
+		MissingCount: missing,
+		PresentCount: present,
+	})
+}

--- a/monitor/http/coverage_test.go
+++ b/monitor/http/coverage_test.go
@@ -1,0 +1,237 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/monitor"
+	"github.com/rbaliyan/event/v3/transport"
+	"github.com/rbaliyan/event/v3/transport/channel"
+)
+
+// setupCoverageBus registers a bus with one broadcast and one worker-pool
+// subscription, returns the live topology entry for the event, and a cleanup func.
+func setupCoverageBus(t *testing.T, busName, evName string) (event.EventInfo, func()) {
+	t.Helper()
+	tr := channel.New()
+	bus, err := event.NewBus(busName, event.WithTransport(tr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ev := event.New[string](evName)
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+	noop := func(_ context.Context, _ event.Event[string], _ string) error { return nil }
+	if err := ev.Subscribe(ctx, noop); err != nil {
+		t.Fatal(err)
+	}
+	if err := ev.Subscribe(ctx, noop, event.WithWorkerGroup[string]("testgroup")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the topology entry for this event.
+	var evInfo event.EventInfo
+	for _, bi := range event.Topology() {
+		if bi.Name == busName {
+			for _, ei := range bi.Events {
+				if ei.Name == evName {
+					evInfo = ei
+				}
+			}
+		}
+	}
+
+	cleanup := func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = bus.Close(closeCtx)
+	}
+	return evInfo, cleanup
+}
+
+func TestHandleCoverage_BroadcastMatch(t *testing.T) {
+	busName := "cov-broadcast-" + t.Name()
+	evName := "coverage.broadcast"
+	ctx := context.Background()
+
+	evInfo, cleanup := setupCoverageBus(t, busName, evName)
+	defer cleanup()
+
+	// Find the broadcast subscription ID from topology.
+	var broadcastSubID string
+	for _, sub := range evInfo.Subscriptions {
+		if sub.DeliveryMode == transport.Broadcast {
+			broadcastSubID = sub.SubscriptionID
+			break
+		}
+	}
+	if broadcastSubID == "" {
+		t.Fatal("no broadcast subscription found in topology")
+	}
+
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	eventID := "evt-broadcast-001"
+	_ = store.Record(ctx, &monitor.Entry{
+		EventID:        eventID,
+		SubscriptionID: broadcastSubID,
+		EventName:      evName,
+		BusID:          busName,
+		DeliveryMode:   monitor.Broadcast,
+		Status:         monitor.StatusCompleted,
+		StartedAt:      time.Now(),
+	})
+
+	h := New(store, WithSystemRefreshInterval(0))
+	defer h.Close()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/monitor/coverage/"+eventID, nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var resp EventCoverageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.EventID != eventID {
+		t.Errorf("event_id: want %s, got %s", eventID, resp.EventID)
+	}
+	found := false
+	for _, c := range resp.Coverage {
+		if c.SubscriptionID == broadcastSubID {
+			if !c.HasEntry {
+				t.Errorf("broadcast sub %s: HasEntry=false", broadcastSubID)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("broadcast sub %s not present in coverage", broadcastSubID)
+	}
+}
+
+func TestHandleCoverage_WorkerPoolGroupMatch(t *testing.T) {
+	busName := "cov-wp-" + t.Name()
+	evName := "coverage.workergroup"
+	ctx := context.Background()
+
+	_, cleanup := setupCoverageBus(t, busName, evName)
+	defer cleanup()
+
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	eventID := "evt-wp-001"
+	// WorkerPool entries use empty subscription_id; coverage matches by worker_group.
+	_ = store.Record(ctx, &monitor.Entry{
+		EventID:      eventID,
+		EventName:    evName,
+		BusID:        busName,
+		WorkerGroup:  "testgroup",
+		DeliveryMode: monitor.WorkerPool,
+		Status:       monitor.StatusCompleted,
+		StartedAt:    time.Now(),
+	})
+
+	h := New(store, WithSystemRefreshInterval(0))
+	defer h.Close()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/monitor/coverage/"+eventID, nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var resp EventCoverageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range resp.Coverage {
+		if c.WorkerGroup == "testgroup" {
+			if !c.HasEntry {
+				t.Errorf("worker_group testgroup: HasEntry=false")
+			}
+			return
+		}
+	}
+	t.Error("worker_group testgroup not found in coverage response")
+}
+
+func TestHandleCoverage_MissingCount(t *testing.T) {
+	busName := "cov-missing-" + t.Name()
+	evName := "coverage.missing"
+	ctx := context.Background()
+
+	_, cleanup := setupCoverageBus(t, busName, evName)
+	defer cleanup()
+
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	eventID := "evt-missing-001"
+	// Seed with a phantom sub ID that exists in the store but not in topology.
+	_ = store.Record(ctx, &monitor.Entry{
+		EventID:        eventID,
+		SubscriptionID: "phantom-sub-id",
+		EventName:      evName,
+		BusID:          busName,
+		DeliveryMode:   monitor.Broadcast,
+		Status:         monitor.StatusCompleted,
+		StartedAt:      time.Now(),
+	})
+
+	h := New(store, WithSystemRefreshInterval(0))
+	defer h.Close()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/monitor/coverage/"+eventID, nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+	var resp EventCoverageResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.MissingCount == 0 {
+		t.Errorf("want missing_count > 0, got 0 (coverage: %+v)", resp.Coverage)
+	}
+}
+
+func TestHandleCoverage_EmptyEventID(t *testing.T) {
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	h := New(store, WithSystemRefreshInterval(0))
+	defer h.Close()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/monitor/coverage/", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestHandleCoverage_MethodNotAllowed(t *testing.T) {
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	h := New(store, WithSystemRefreshInterval(0))
+	defer h.Close()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/v1/monitor/coverage/evt-001", nil))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", w.Code)
+	}
+}

--- a/monitor/http/federation.go
+++ b/monitor/http/federation.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/rbaliyan/event/v3/health"
+	"github.com/rbaliyan/event/v3/monitor"
 )
 
 // DLQProvider supplies DLQ summary and health.
@@ -36,4 +37,21 @@ type SchedulerStats struct {
 	PendingMessages int64      `json:"pending_messages"`
 	StuckMessages   int64      `json:"stuck_messages,omitempty"`
 	NextDue         *time.Time `json:"next_due,omitempty"`
+}
+
+// StuckPendingStats contains statistics about monitor entries stuck in pending state.
+// A stuck entry has status=pending and started_at older than the configured threshold,
+// indicating the pod that claimed the message likely crashed before completing.
+type StuckPendingStats struct {
+	Count     int64            `json:"count"`
+	Threshold time.Duration    `json:"threshold"`
+	OldestAt  *time.Time       `json:"oldest_at,omitempty"`
+	Samples   []*monitor.Entry `json:"samples,omitempty"`
+}
+
+// StuckPendingProvider supplies stuck-pending detection for /v1/system.
+// Implementations should cache results externally; this is called on every
+// system view refresh (typically every 10–30 seconds).
+type StuckPendingProvider interface {
+	StuckPendingStats(ctx context.Context) (*StuckPendingStats, error)
 }

--- a/monitor/http/federation.go
+++ b/monitor/http/federation.go
@@ -49,9 +49,9 @@ type StuckPendingStats struct {
 	Samples   []*monitor.Entry `json:"samples,omitempty"`
 }
 
-// StuckPendingProvider supplies stuck-pending detection for /v1/system.
+// StuckPendingStatsProvider supplies stuck-pending detection for /v1/system.
 // Implementations should cache results externally; this is called on every
 // system view refresh (typically every 10–30 seconds).
-type StuckPendingProvider interface {
+type StuckPendingStatsProvider interface {
 	StuckPendingStats(ctx context.Context) (*StuckPendingStats, error)
 }

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -30,7 +30,7 @@ type handlerOptions struct {
 	workerStore            distributed.WorkerStore
 	dlqProvider            DLQProvider
 	schedProvider          SchedulerProvider
-	stuckPendingProvider   StuckPendingProvider
+	stuckPendingProvider   StuckPendingStatsProvider
 	systemRefreshInterval  time.Duration
 	dlqAlertFunc           DLQAlertFunc
 	dlqAlertThreshold      int64
@@ -90,7 +90,7 @@ func WithSystemRefreshInterval(d time.Duration) Option {
 // so it must be cheap — results should come from an indexed query or a cache.
 // A "stuck pending" entry has status=pending longer than the provider's configured
 // threshold, indicating the handling pod likely crashed before completing.
-func WithStuckPendingProvider(p StuckPendingProvider) Option {
+func WithStuckPendingProvider(p StuckPendingStatsProvider) Option {
 	return func(o *handlerOptions) {
 		o.stuckPendingProvider = p
 	}
@@ -102,7 +102,7 @@ type Handler struct {
 	workerStore          distributed.WorkerStore
 	dlqProvider          DLQProvider
 	schedProvider        SchedulerProvider
-	stuckPendingProvider StuckPendingProvider
+	stuckPendingProvider StuckPendingStatsProvider
 	dlqAlertFunc         DLQAlertFunc
 	dlqAlertThreshold    int64
 	mux                  *http.ServeMux
@@ -162,7 +162,6 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	h.mux.HandleFunc("/v1/topology", h.handleTopology)
 	h.mux.HandleFunc("/v1/topology/", h.handleTopologyWithPath)
 
-	// Register coverage endpoint: cross-reference monitor entries with topology
 	h.mux.HandleFunc("/v1/monitor/coverage/", h.handleCoverage)
 
 	// Register system view endpoints

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -27,12 +27,13 @@ type DLQAlertFunc func(stats *DLQStats)
 
 // handlerOptions holds configuration for the Handler.
 type handlerOptions struct {
-	workerStore           distributed.WorkerStore
-	dlqProvider           DLQProvider
-	schedProvider         SchedulerProvider
-	systemRefreshInterval time.Duration
-	dlqAlertFunc          DLQAlertFunc
-	dlqAlertThreshold     int64
+	workerStore            distributed.WorkerStore
+	dlqProvider            DLQProvider
+	schedProvider          SchedulerProvider
+	stuckPendingProvider   StuckPendingProvider
+	systemRefreshInterval  time.Duration
+	dlqAlertFunc           DLQAlertFunc
+	dlqAlertThreshold      int64
 }
 
 // Option configures the Handler.
@@ -84,17 +85,29 @@ func WithSystemRefreshInterval(d time.Duration) Option {
 	}
 }
 
+// WithStuckPendingProvider enables stuck-pending detection in /v1/system.
+// The provider is queried on every system view refresh (see WithSystemRefreshInterval)
+// so it must be cheap — results should come from an indexed query or a cache.
+// A "stuck pending" entry has status=pending longer than the provider's configured
+// threshold, indicating the handling pod likely crashed before completing.
+func WithStuckPendingProvider(p StuckPendingProvider) Option {
+	return func(o *handlerOptions) {
+		o.stuckPendingProvider = p
+	}
+}
+
 // Handler implements http.Handler for the monitor service using protoJSON.
 type Handler struct {
-	store             monitor.Store
-	workerStore       distributed.WorkerStore
-	dlqProvider       DLQProvider
-	schedProvider     SchedulerProvider
-	dlqAlertFunc      DLQAlertFunc
-	dlqAlertThreshold int64
-	mux               *http.ServeMux
-	marshaler         protojson.MarshalOptions
-	unmarshaler       protojson.UnmarshalOptions
+	store                monitor.Store
+	workerStore          distributed.WorkerStore
+	dlqProvider          DLQProvider
+	schedProvider        SchedulerProvider
+	stuckPendingProvider StuckPendingProvider
+	dlqAlertFunc         DLQAlertFunc
+	dlqAlertThreshold    int64
+	mux                  *http.ServeMux
+	marshaler            protojson.MarshalOptions
+	unmarshaler          protojson.UnmarshalOptions
 
 	// Background system view cache
 	systemView    atomic.Pointer[SystemView]
@@ -114,12 +127,13 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	}
 
 	h := &Handler{
-		store:             store,
-		workerStore:       o.workerStore,
-		dlqProvider:       o.dlqProvider,
-		schedProvider:     o.schedProvider,
-		dlqAlertFunc:      o.dlqAlertFunc,
-		dlqAlertThreshold: o.dlqAlertThreshold,
+		store:                store,
+		workerStore:          o.workerStore,
+		dlqProvider:          o.dlqProvider,
+		schedProvider:        o.schedProvider,
+		stuckPendingProvider: o.stuckPendingProvider,
+		dlqAlertFunc:         o.dlqAlertFunc,
+		dlqAlertThreshold:    o.dlqAlertThreshold,
 		mux:           http.NewServeMux(),
 		done:          make(chan struct{}),
 		marshaler: protojson.MarshalOptions{
@@ -147,6 +161,9 @@ func New(store monitor.Store, opts ...Option) *Handler {
 	// Register topology endpoints
 	h.mux.HandleFunc("/v1/topology", h.handleTopology)
 	h.mux.HandleFunc("/v1/topology/", h.handleTopologyWithPath)
+
+	// Register coverage endpoint: cross-reference monitor entries with topology
+	h.mux.HandleFunc("/v1/monitor/coverage/", h.handleCoverage)
 
 	// Register system view endpoints
 	h.mux.HandleFunc("/v1/system", h.handleSystemView)

--- a/monitor/http/system.go
+++ b/monitor/http/system.go
@@ -15,14 +15,15 @@ import (
 
 // SystemView is the unified response for GET /v1/system.
 type SystemView struct {
-	Topology    []event.BusInfo         `json:"topology"`
-	DLQ         *DLQStats               `json:"dlq,omitempty"`
-	Scheduler   *SchedulerStats         `json:"scheduler,omitempty"`
-	Health      *health.AggregateResult `json:"health"`
-	BusHealth   map[string]*event.Status `json:"bus_health,omitempty"`
-	ConsumerLag []event.ConsumerLag      `json:"consumer_lag,omitempty"`
-	Summary     *monitor.Summary         `json:"summary,omitempty"`
-	CollectedAt time.Time                `json:"collected_at"`
+	Topology     []event.BusInfo          `json:"topology"`
+	DLQ          *DLQStats                `json:"dlq,omitempty"`
+	Scheduler    *SchedulerStats          `json:"scheduler,omitempty"`
+	StuckPending *StuckPendingStats       `json:"stuck_pending,omitempty"`
+	Health       *health.AggregateResult  `json:"health"`
+	BusHealth    map[string]*event.Status `json:"bus_health,omitempty"`
+	ConsumerLag  []event.ConsumerLag      `json:"consumer_lag,omitempty"`
+	Summary      *monitor.Summary         `json:"summary,omitempty"`
+	CollectedAt  time.Time                `json:"collected_at"`
 }
 
 // runSystemRefresh periodically collects the system view in the background.
@@ -133,6 +134,25 @@ func (h *Handler) refreshSystemView(ctx context.Context) {
 				view.Summary = summary
 			} else {
 				slog.WarnContext(ctx, "summary query failed", "error", err)
+			}
+			mu.Unlock()
+		}()
+	}
+
+	// Stuck-pending detection: entries in pending state beyond the configured
+	// threshold indicate pods that crashed after claiming a message but before
+	// completing the handler. Uses an indexed query; results are cached in
+	// SystemView at the configured refresh interval (no per-request overhead).
+	if h.stuckPendingProvider != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stats, err := h.stuckPendingProvider.StuckPendingStats(ctx)
+			mu.Lock()
+			if err == nil {
+				view.StuckPending = stats
+			} else {
+				slog.WarnContext(ctx, "stuck pending query failed", "error", err)
 			}
 			mu.Unlock()
 		}()

--- a/monitor/http/system_test.go
+++ b/monitor/http/system_test.go
@@ -332,3 +332,55 @@ func TestCachedTopology(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
+
+// mockStuckPendingProvider is a test double for StuckPendingStatsProvider.
+type mockStuckPendingProvider struct {
+	stats *StuckPendingStats
+	err   error
+}
+
+func (m *mockStuckPendingProvider) StuckPendingStats(_ context.Context) (*StuckPendingStats, error) {
+	return m.stats, m.err
+}
+
+func TestHandleSystemView_StuckPending(t *testing.T) {
+	store := monitor.NewMemoryStore()
+	defer store.Close()
+
+	oldest := time.Now().Add(-10 * time.Minute)
+	provider := &mockStuckPendingProvider{
+		stats: &StuckPendingStats{
+			Count:     3,
+			Threshold: 6 * time.Minute,
+			OldestAt:  &oldest,
+		},
+	}
+
+	h := New(store,
+		WithSystemRefreshInterval(50*time.Millisecond),
+		WithStuckPendingProvider(provider),
+	)
+	defer h.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/system", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body)
+	}
+
+	var view SystemView
+	if err := json.NewDecoder(w.Body).Decode(&view); err != nil {
+		t.Fatal(err)
+	}
+	if view.StuckPending == nil {
+		t.Fatal("stuck_pending field is nil, want non-nil")
+	}
+	if view.StuckPending.Count != 3 {
+		t.Errorf("count: want 3, got %d", view.StuckPending.Count)
+	}
+	if view.StuckPending.OldestAt == nil {
+		t.Error("oldest_at: want non-nil")
+	}
+}

--- a/monitor/store.go
+++ b/monitor/store.go
@@ -114,6 +114,21 @@ type SummaryProvider interface {
 	Summary(ctx context.Context, filter Filter) (*Summary, error)
 }
 
+// StuckPendingProvider is an optional interface for stores that can efficiently
+// detect entries stuck in pending state beyond a threshold duration.
+// Implementations must have an index on (status, started_at) to avoid collection scans.
+type StuckPendingProvider interface {
+	// StuckPendingCount returns the number of entries with status=pending
+	// whose started_at is older than olderThan. Intended for /v1/system polling;
+	// callers must cache results — do not call on every HTTP request.
+	StuckPendingCount(ctx context.Context, olderThan time.Duration) (int64, error)
+
+	// StuckPendingEntries returns up to limit entries with status=pending older
+	// than olderThan, sorted ascending by started_at (oldest first).
+	// limit should be small (≤50) — this is for alerting samples, not auditing.
+	StuckPendingEntries(ctx context.Context, olderThan time.Duration, limit int) ([]*Entry, error)
+}
+
 // Summary contains aggregated statistics for monitor entries matching a filter.
 type Summary struct {
 	TotalEntries  int64                  `json:"total_entries"`

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -454,7 +454,7 @@ func (t *JetStreamTransport) ConsumerLag(ctx context.Context) ([]transport.Consu
 						duration := time.Since(streamInfo.State.FirstTime)
 						rate := float64(streamInfo.State.Msgs) / duration.Seconds()
 						if rate > 0 {
-							lag.OldestPending = time.Duration(float64(consumerInfo.NumPending) / rate * float64(time.Second))
+							d := time.Duration(float64(consumerInfo.NumPending) / rate * float64(time.Second)); lag.OldestPending = &d
 						}
 					}
 				}

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -496,7 +496,8 @@ func (t *Transport) ConsumerLag(ctx context.Context) ([]transport.ConsumerLag, e
 					if pending, pErr := t.client.XPending(ctx, streamName, group.Name).Result(); pErr == nil && pending.Lower != "" {
 						if parts := strings.SplitN(pending.Lower, "-", 2); len(parts) == 2 {
 							if ms, parseErr := strconv.ParseInt(parts[0], 10, 64); parseErr == nil {
-								lag.OldestPending = time.Since(time.UnixMilli(ms))
+								d := time.Since(time.UnixMilli(ms))
+								lag.OldestPending = &d
 							}
 						}
 					}

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -16,6 +16,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -479,12 +481,28 @@ func (t *Transport) ConsumerLag(ctx context.Context) ([]transport.ConsumerLag, e
 				}
 				matched = true
 
-				results[idx].lags = append(results[idx].lags, transport.ConsumerLag{
+				lag := transport.ConsumerLag{
 					Event:           name,
 					ConsumerGroup:   group.Name,
 					Lag:             group.Lag,
 					PendingMessages: group.Pending,
-				})
+				}
+
+				// Populate OldestPending from the XPending summary. This is a single
+				// O(1) Redis call per group that returns the oldest PEL entry ID,
+				// from which we extract the insertion timestamp. Only called when
+				// there are pending messages to avoid unnecessary round-trips.
+				if group.Pending > 0 {
+					if pending, pErr := t.client.XPending(ctx, streamName, group.Name).Result(); pErr == nil && pending.Lower != "" {
+						if parts := strings.SplitN(pending.Lower, "-", 2); len(parts) == 2 {
+							if ms, parseErr := strconv.ParseInt(parts[0], 10, 64); parseErr == nil {
+								lag.OldestPending = time.Since(time.UnixMilli(ms))
+							}
+						}
+					}
+				}
+
+				results[idx].lags = append(results[idx].lags, lag)
 			}
 
 			// Add overall stream info if no tracked groups found

--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -17,13 +17,14 @@ import (
 
 // mockRedisClient implements Client for testing
 type mockRedisClient struct {
-	mu       sync.Mutex
-	streams  map[string][]redis.XMessage
-	groups   map[string]map[string]string // stream -> group -> lastID
-	msgID    int
-	closed   bool
-	xaddErr  error
-	xreadErr error
+	mu             sync.Mutex
+	streams        map[string][]redis.XMessage
+	groups         map[string]map[string]string // stream -> group -> lastID
+	msgID          int
+	closed         bool
+	xaddErr        error
+	xreadErr       error
+	xpendingResult map[string]*redis.XPending // stream:group -> result (nil = use default)
 }
 
 func newMockRedisClient() *mockRedisClient {
@@ -159,12 +160,17 @@ func (m *mockRedisClient) Ping(ctx context.Context) *redis.StatusCmd {
 }
 
 func (m *mockRedisClient) XPending(ctx context.Context, stream, group string) *redis.XPendingCmd {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	cmd := redis.NewXPendingCmd(ctx)
-	cmd.SetVal(&redis.XPending{
-		Count:  0,
-		Lower:  "",
-		Higher: "",
-	})
+	key := stream + ":" + group
+	if m.xpendingResult != nil {
+		if r, ok := m.xpendingResult[key]; ok {
+			cmd.SetVal(r)
+			return cmd
+		}
+	}
+	cmd.SetVal(&redis.XPending{Count: 0, Lower: "", Higher: ""})
 	return cmd
 }
 
@@ -185,10 +191,17 @@ func (m *mockRedisClient) XInfoGroups(ctx context.Context, stream string) *redis
 	groups := make([]redis.XInfoGroup, 0)
 	if m.groups[stream] != nil {
 		for name := range m.groups[stream] {
+			pending := int64(0)
+			key := stream + ":" + name
+			if m.xpendingResult != nil {
+				if r, ok := m.xpendingResult[key]; ok {
+					pending = r.Count
+				}
+			}
 			groups = append(groups, redis.XInfoGroup{
 				Name:      name,
 				Consumers: 0,
-				Pending:   0,
+				Pending:   pending,
 				Lag:       0,
 			})
 		}
@@ -566,5 +579,56 @@ func TestTransportErrorHandler(t *testing.T) {
 
 	if capturedErr == nil {
 		t.Error("expected error handler to be called")
+	}
+}
+
+func TestConsumerLag_OldestPending(t *testing.T) {
+	client := newMockRedisClient()
+	tr, err := New(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	// RegisterEvent creates the stream and default consumer group.
+	tr.RegisterEvent(ctx, "lag-event")
+
+	// Inject a known XPending result with a stream entry ID whose millisecond
+	// prefix encodes a known past timestamp (2023-11-14T22:13:20Z).
+	knownMs := int64(1700000000000)
+	streamName := tr.streamName("lag-event")
+	groupKey := streamName + ":" + tr.groupID
+	client.mu.Lock()
+	if client.xpendingResult == nil {
+		client.xpendingResult = make(map[string]*redis.XPending)
+	}
+	client.xpendingResult[groupKey] = &redis.XPending{
+		Count: 1,
+		Lower: fmt.Sprintf("%d-0", knownMs),
+	}
+	client.mu.Unlock()
+
+	lags, err := tr.ConsumerLag(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found *transport.ConsumerLag
+	for i := range lags {
+		if lags[i].Event == "lag-event" {
+			found = &lags[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("no lag entry found for lag-event")
+	}
+	if found.OldestPending == nil {
+		t.Fatal("OldestPending is nil, want non-nil for pending > 0")
+	}
+	// The age should be roughly time.Since(time.UnixMilli(knownMs)) — at least several months.
+	if *found.OldestPending < time.Hour {
+		t.Errorf("OldestPending %v too small; expected age of known past timestamp", *found.OldestPending)
 	}
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -141,7 +141,7 @@ type ConsumerLag struct {
 	Event           string        `json:"event"`
 	ConsumerGroup   string        `json:"consumer_group,omitempty"`
 	Lag             int64         `json:"lag"`              // Number of unprocessed messages
-	OldestPending   time.Duration `json:"oldest_pending"`   // Age of oldest unacknowledged message
+	OldestPending   *time.Duration `json:"oldest_pending,omitempty"` // Age of oldest unacknowledged message; nil when unknown or zero pending
 	PendingMessages int64         `json:"pending_messages"` // Messages delivered but not yet acked
 }
 


### PR DESCRIPTION
## Summary

- **`StuckPendingProvider` interface** (`monitor/store.go`): optional interface stores implement to expose entries stuck in `pending` state beyond a configurable threshold. Requires an `(status, started_at)` index; designed to be called on a background refresh cycle, not per request.

- **`GET /v1/monitor/coverage/{event_id}`** (`monitor/http/coverage.go`): cross-references recorded monitor entries for an event with the live in-process subscription topology. Returns `has_entry` per subscription with `missing_count`/`present_count` totals. WorkerPool subscriptions (empty `subscription_id`) are matched by `worker_group`.

- **`WithStuckPendingProvider` option + `SystemView.StuckPending` field** (`monitor/http/handler.go`, `monitor/http/system.go`): plugs stuck-pending stats into `GET /v1/system` via a concurrent goroutine in the background refresh cycle.

- **`ConsumerLag.OldestPending`** (`transport/redis/redis.go`): populated via a single `XPENDING` summary call per consumer group (only when `pending > 0`). Parses the stream entry ID millisecond prefix to derive message age.

- **`monitor/DEBUGGING.md`**: end-to-end debugging guide covering API endpoints, common failure scenarios (missed delivery, consumer lag, stuck pending, coverage gaps, DLQ buildup), direct MongoDB/Redis query recipes, and a diagnostic checklist.

## Design notes

`StuckPendingProvider` is an optional interface (type-asserted, not embedded in `Store`) to keep backward compatibility with existing store implementations. The coverage endpoint walks `event.Topology()` at request time — no caching — since topology is cheap and must reflect the live process state.

The `OldestPending` field in `ConsumerLag` adds one `XPENDING` call per consumer group that has pending messages. `XPENDING` with no range is an O(1) Redis summary command.

## Test plan

- [ ] `GET /v1/monitor/coverage/{event_id}` returns correct `has_entry` for broadcast and worker pool subscriptions
- [ ] `GET /v1/system` includes `stuck_pending` when `WithStuckPendingProvider` is configured
- [ ] `ConsumerLag.OldestPending` is populated when PEL is non-empty, zero-valued otherwise
- [ ] Coverage endpoint returns `missing_count: 0` when all subscriptions have entries
- [ ] `WithStuckPendingProvider(nil)` is a no-op (provider not called)