### PR TITLE
feat(stack): add WithReliabilityStack and event.WithAll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,11 @@ func New(opts ...Option) *Client {
 - Subscribers auto-load schema on `Register()`
 - Schema flags control which middleware is applied
 - Providers: PostgreSQL, MongoDB, Redis, in-memory
+- HTTP API: `schema/http` - REST CRUD handler (list/get/put/delete, version auto-increment)
+
+**Reliability Stack (stack/)** - Convenience BusOption that wires Monitor + Idempotency + Poison detection:
+- `stack.WithReliabilityStack(...Option) event.BusOption` — in-memory defaults, all stores replaceable
+- `event.WithAll(opts ...BusOption) BusOption` — combiner for composing BusOptions from sub-packages
 
 ### V3 Design
 

--- a/bus_options.go
+++ b/bus_options.go
@@ -264,6 +264,26 @@ func WithDrainTimeout(d time.Duration) BusOption {
 	}
 }
 
+// WithAll combines multiple BusOptions into a single option. This is useful
+// when building helper functions outside the event package that compose
+// several bus options together, since busOptions is unexported.
+//
+// Example:
+//
+//	func WithMyDefaults() event.BusOption {
+//	    return event.WithAll(
+//	        event.WithTracing(true),
+//	        event.WithRecovery(true),
+//	    )
+//	}
+func WithAll(opts ...BusOption) BusOption {
+	return func(o *busOptions) {
+		for _, opt := range opts {
+			opt(o)
+		}
+	}
+}
+
 // newBusOptions creates options with defaults and applies provided options
 func newBusOptions(opts ...BusOption) *busOptions {
 	o := &busOptions{

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -1,0 +1,187 @@
+// Package stack provides WithReliabilityStack, a convenience option that
+// auto-configures Monitor, Idempotency, and Poison detection on a Bus with
+// safe in-memory defaults — no external stores required for basic use.
+//
+// # Quick start
+//
+//	bus, err := event.NewBus("mybus",
+//	    event.WithTransport(t),
+//	    stack.WithReliabilityStack(),
+//	)
+//
+// # Custom stores
+//
+// Replace any default store with a production-grade backend:
+//
+//	bus, err := event.NewBus("mybus",
+//	    event.WithTransport(t),
+//	    stack.WithReliabilityStack(
+//	        stack.WithMonitorStore(monitor.NewPostgresStore(db)),
+//	        stack.WithIdempotencyStore(idempotency.NewRedisStore(rdb, 24*time.Hour)),
+//	    ),
+//	)
+package stack
+
+import (
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/idempotency"
+	"github.com/rbaliyan/event/v3/monitor"
+	"github.com/rbaliyan/event/v3/poison"
+)
+
+const (
+	defaultIdempotencyTTL   = 24 * time.Hour
+	defaultPoisonThreshold  = 5
+	defaultPoisonQuarantine = time.Hour
+)
+
+// options holds the configuration for WithReliabilityStack.
+type options struct {
+	monitorStore     event.MonitorStore
+	idempotencyStore event.IdempotencyStore
+	poisonDetector   event.PoisonDetector
+	// Memory-store knobs (only used when the corresponding store is nil)
+	idempotencyTTL   time.Duration
+	poisonThreshold  int
+	poisonQuarantine time.Duration
+}
+
+// Option configures WithReliabilityStack.
+type Option func(*options)
+
+// WithMonitorStore replaces the default in-memory monitor store.
+// Use a production backend such as monitor.NewPostgresStore or
+// monitor.NewMemoryStore for development.
+func WithMonitorStore(store event.MonitorStore) Option {
+	return func(o *options) {
+		if store != nil {
+			o.monitorStore = store
+		}
+	}
+}
+
+// WithIdempotencyStore replaces the default in-memory idempotency store.
+// For distributed deployments use idempotency.NewRedisStore or
+// idempotency.NewPostgresStore.
+func WithIdempotencyStore(store event.IdempotencyStore) Option {
+	return func(o *options) {
+		if store != nil {
+			o.idempotencyStore = store
+		}
+	}
+}
+
+// WithPoisonDetector replaces the default in-memory poison detector.
+// For distributed deployments create a detector with a shared store
+// (e.g. poison.NewRedisStore).
+func WithPoisonDetector(detector event.PoisonDetector) Option {
+	return func(o *options) {
+		if detector != nil {
+			o.poisonDetector = detector
+		}
+	}
+}
+
+// WithIdempotencyTTL sets the TTL for the default in-memory idempotency store.
+// Has no effect when WithIdempotencyStore is also provided.
+// Default: 24 hours.
+func WithIdempotencyTTL(d time.Duration) Option {
+	return func(o *options) {
+		if d > 0 {
+			o.idempotencyTTL = d
+		}
+	}
+}
+
+// WithPoisonThreshold sets the failure count before a message is quarantined
+// by the default in-memory poison detector.
+// Has no effect when WithPoisonDetector is also provided.
+// Default: 5.
+func WithPoisonThreshold(n int) Option {
+	return func(o *options) {
+		if n > 0 {
+			o.poisonThreshold = n
+		}
+	}
+}
+
+// WithPoisonQuarantine sets how long quarantined messages are blocked
+// by the default in-memory poison detector.
+// Has no effect when WithPoisonDetector is also provided.
+// Default: 1 hour.
+func WithPoisonQuarantine(d time.Duration) Option {
+	return func(o *options) {
+		if d > 0 {
+			o.poisonQuarantine = d
+		}
+	}
+}
+
+// WithReliabilityStack returns a BusOption that enables Monitor, Idempotency,
+// and Poison detection with sensible defaults. All three features use in-memory
+// stores unless replaced via the Option functions above.
+//
+// Default configuration:
+//   - Monitor: in-memory store
+//   - Idempotency: in-memory store, 24-hour TTL
+//   - Poison detection: in-memory store, threshold=5, quarantine=1 hour
+//
+// Example (defaults):
+//
+//	bus, _ := event.NewBus("svc",
+//	    event.WithTransport(t),
+//	    stack.WithReliabilityStack(),
+//	)
+//
+// Example (production stores):
+//
+//	bus, _ := event.NewBus("svc",
+//	    event.WithTransport(t),
+//	    stack.WithReliabilityStack(
+//	        stack.WithMonitorStore(monitor.NewPostgresStore(db)),
+//	        stack.WithIdempotencyStore(idempotency.NewRedisStore(rdb, 24*time.Hour)),
+//	        stack.WithPoisonDetector(
+//	            poison.NewDetector(poison.NewRedisStore(rdb),
+//	                poison.WithThreshold(3),
+//	                poison.WithQuarantineTime(2*time.Hour),
+//	            ),
+//	        ),
+//	    ),
+//	)
+func WithReliabilityStack(opts ...Option) event.BusOption {
+	o := &options{
+		idempotencyTTL:   defaultIdempotencyTTL,
+		poisonThreshold:  defaultPoisonThreshold,
+		poisonQuarantine: defaultPoisonQuarantine,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	ms := o.monitorStore
+	if ms == nil {
+		ms = monitor.NewMemoryStore()
+	}
+
+	is := o.idempotencyStore
+	if is == nil {
+		is = idempotency.NewMemoryStore(o.idempotencyTTL)
+	}
+
+	pd := o.poisonDetector
+	if pd == nil {
+		pd = poison.NewDetector(
+			poison.NewMemoryStore(),
+			poison.WithThreshold(o.poisonThreshold),
+			poison.WithQuarantineTime(o.poisonQuarantine),
+		)
+	}
+
+	return event.WithAll(
+		event.WithMonitor(ms),
+		event.WithIdempotency(is),
+		event.WithPoisonDetection(pd),
+	)
+}

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -1,0 +1,219 @@
+package stack_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/idempotency"
+	"github.com/rbaliyan/event/v3/monitor"
+	"github.com/rbaliyan/event/v3/poison"
+	"github.com/rbaliyan/event/v3/stack"
+	"github.com/rbaliyan/event/v3/transport/channel"
+)
+
+func newBus(t *testing.T, opts ...event.BusOption) *event.Bus {
+	t.Helper()
+	tr := channel.New()
+	all := append([]event.BusOption{event.WithTransport(tr)}, opts...)
+	bus, err := event.NewBus(t.Name(), all...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = bus.Close(ctx)
+	})
+	return bus
+}
+
+// TestWithReliabilityStack_Defaults verifies the stack wires all three
+// middleware components when called with no options.
+func TestWithReliabilityStack_Defaults(t *testing.T) {
+	bus := newBus(t, stack.WithReliabilityStack())
+
+	type msg struct{ Value string }
+	ev := event.New[msg]("stack.defaults")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	var count atomic.Int32
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		count.Add(1)
+		return nil
+	})
+
+	if err := ev.Publish(ctx, msg{"hello"}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if count.Load() != 1 {
+		t.Fatalf("expected handler called once, got %d", count.Load())
+	}
+}
+
+// TestWithReliabilityStack_Idempotency verifies that duplicate message IDs
+// are dropped when the idempotency store is active.
+func TestWithReliabilityStack_Idempotency(t *testing.T) {
+	istore := idempotency.NewMemoryStore(time.Hour)
+	t.Cleanup(istore.Close)
+
+	bus := newBus(t, stack.WithReliabilityStack(
+		stack.WithIdempotencyStore(istore),
+	))
+
+	type msg struct{ V int }
+	ev := event.New[msg]("stack.idempotency")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	var count atomic.Int32
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		count.Add(1)
+		return nil
+	})
+
+	// First publish — should be handled
+	if err := ev.Publish(ctx, msg{1}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if count.Load() != 1 {
+		t.Fatalf("first delivery: expected 1, got %d", count.Load())
+	}
+}
+
+// TestWithReliabilityStack_PoisonDetection verifies that a repeatedly-failing
+// message is eventually quarantined and the handler stops being called.
+// Poison detection tracks failures per message ID, so we publish with the
+// same ID multiple times (simulating at-least-once redelivery).
+func TestWithReliabilityStack_PoisonDetection(t *testing.T) {
+	pstore := poison.NewMemoryStore()
+	detector := poison.NewDetector(pstore,
+		poison.WithThreshold(2),
+		poison.WithQuarantineTime(5*time.Second),
+	)
+
+	bus := newBus(t, stack.WithReliabilityStack(
+		stack.WithPoisonDetector(detector),
+	))
+
+	type msg struct{ V int }
+	ev := event.New[msg]("stack.poison")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	var count atomic.Int32
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		count.Add(1)
+		return errors.New("always fails")
+	})
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Publish with the same message ID to simulate at-least-once redelivery.
+	// Threshold=2: first two calls fail and accumulate; third call is quarantined and skipped.
+	msgCtx := event.ContextWithEventID(ctx, "poison-test-id-1")
+	for range 5 {
+		_ = ev.Publish(msgCtx, msg{1})
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Handler should be called at most threshold (2) times; third+ are quarantined.
+	if got := count.Load(); got > 2 {
+		t.Errorf("expected handler called at most 2 times (threshold), got %d", got)
+	}
+}
+
+// TestWithReliabilityStack_MonitorStore verifies that the custom monitor store
+// is used by checking that entries are recorded.
+func TestWithReliabilityStack_MonitorStore(t *testing.T) {
+	mstore := monitor.NewMemoryStore()
+	t.Cleanup(func() { _ = mstore.Close() })
+
+	bus := newBus(t, stack.WithReliabilityStack(
+		stack.WithMonitorStore(mstore),
+	))
+
+	type msg struct{ V int }
+	ev := event.New[msg]("stack.monitor")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		return nil
+	})
+
+	if err := ev.Publish(ctx, msg{42}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if mstore.Len() == 0 {
+		t.Error("expected at least one monitor entry, got none")
+	}
+}
+
+// TestWithReliabilityStack_IdempotencyTTL verifies the TTL option is accepted.
+func TestWithReliabilityStack_IdempotencyTTL(t *testing.T) {
+	bus := newBus(t, stack.WithReliabilityStack(
+		stack.WithIdempotencyTTL(30*time.Minute),
+	))
+
+	type msg struct{}
+	ev := event.New[msg]("stack.idempotencyTTL")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		return nil
+	})
+
+	if err := ev.Publish(ctx, msg{}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(30 * time.Millisecond)
+}
+
+// TestWithReliabilityStack_PoisonOptions verifies threshold/quarantine knobs.
+func TestWithReliabilityStack_PoisonOptions(t *testing.T) {
+	bus := newBus(t, stack.WithReliabilityStack(
+		stack.WithPoisonThreshold(3),
+		stack.WithPoisonQuarantine(2*time.Hour),
+	))
+
+	type msg struct{}
+	ev := event.New[msg]("stack.poisonOpts")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		return nil
+	})
+
+	if err := ev.Publish(ctx, msg{}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(30 * time.Millisecond)
+}


### PR DESCRIPTION
## Summary

- **`stack.WithReliabilityStack(...Option) event.BusOption`** — new sub-package that wires Monitor, Idempotency, and Poison detection onto a Bus in a single call with safe in-memory defaults. No external stores required for basic use.

- **`event.WithAll(opts ...BusOption) BusOption`** — added to `bus_options.go`; allows code outside the `event` package to compose multiple `BusOption`s into one, since `busOptions` is unexported. Required by `WithReliabilityStack` to return a single `BusOption`.

## Design

All three stores are replaceable via stack options:

| Option | Replaces |
|---|---|
| `WithMonitorStore(s)` | in-memory monitor store |
| `WithIdempotencyStore(s)` | in-memory idempotency store |
| `WithPoisonDetector(d)` | in-memory poison detector |

In-memory defaults are tunable without swapping stores:

| Option | Default |
|---|---|
| `WithIdempotencyTTL(d)` | 24h |
| `WithPoisonThreshold(n)` | 5 redeliveries |
| `WithPoisonQuarantine(d)` | 1h |

`WithAll` is a minimal combiner — it does not introduce any new abstraction, just applies a slice of `BusOption` funcs sequentially against the unexported `busOptions` struct.

## Test plan

- [ ] `WithReliabilityStack()` with no options applies all three middleware layers with in-memory defaults
- [ ] `WithMonitorStore`, `WithIdempotencyStore`, `WithPoisonDetector` replace the respective defaults
- [ ] `WithIdempotencyTTL`, `WithPoisonThreshold`, `WithPoisonQuarantine` apply when no custom store is given
- [ ] `WithAll` with an empty slice is a no-op
- [ ] `WithAll` applies options in order