### PR TITLE
feat(schema/http): add REST handler for schema registry

### DIFF
--- a/schema/http/handler.go
+++ b/schema/http/handler.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rbaliyan/event/v3/schema"
@@ -37,7 +38,10 @@ import (
 type Handler struct {
 	provider schema.SchemaProvider
 	mux      *http.ServeMux
+	mu       sync.Mutex // serializes concurrent PUT requests
 }
+
+var _ http.Handler = (*Handler)(nil)
 
 // New creates a Handler backed by the given provider.
 func New(provider schema.SchemaProvider) *Handler {
@@ -69,7 +73,7 @@ func (h *Handler) handleSchemas(w http.ResponseWriter, r *http.Request) {
 	if schemas == nil {
 		schemas = []*schema.EventSchema{}
 	}
-	h.writeJSON(w, map[string]any{"schemas": schemas})
+	h.writeJSON(w, http.StatusOK, map[string]any{"schemas": schemas})
 }
 
 // handleSchemaByName handles GET, PUT, DELETE /v1/schemas/{name}.
@@ -102,7 +106,7 @@ func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, name string)
 		h.writeError(w, http.StatusNotFound, "schema not found")
 		return
 	}
-	h.writeJSON(w, s)
+	h.writeJSON(w, http.StatusOK, s)
 }
 
 // schemaInput is the request body for PUT /v1/schemas/{name}.
@@ -126,7 +130,10 @@ func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request, name string)
 		return
 	}
 
-	// Determine next version
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Determine next version: Get+Set must be atomic to prevent TOCTOU under concurrent PUTs.
 	existing, err := h.provider.Get(r.Context(), name)
 	if err != nil {
 		h.writeError(w, http.StatusInternalServerError, err.Error())
@@ -160,15 +167,13 @@ func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request, name string)
 		return
 	}
 
-	// Return the stored schema (with timestamps filled in by provider)
+	// Return the stored schema (with timestamps filled in by provider).
 	stored, err := h.provider.Get(r.Context(), name)
 	if err != nil || stored == nil {
-		// Fall back to what we built
-		h.writeJSON(w, s)
+		h.writeJSON(w, http.StatusOK, s)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
-	h.writeJSON(w, stored)
+	h.writeJSON(w, http.StatusOK, stored)
 }
 
 func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, name string) {
@@ -179,13 +184,14 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, name stri
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
+func (h *Handler) writeJSON(w http.ResponseWriter, code int, v any) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		h.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
 	w.Write(data) //nolint:errcheck
 }
 

--- a/schema/http/handler.go
+++ b/schema/http/handler.go
@@ -1,0 +1,196 @@
+// Package http provides an HTTP handler for the schema registry.
+//
+// Mount New(provider) on your HTTP server to expose CRUD operations on
+// event schemas. The handler uses plain JSON with no external dependencies.
+//
+// Routes:
+//
+//	GET    /v1/schemas            — list all schemas
+//	GET    /v1/schemas/{name}     — get a schema by event name
+//	PUT    /v1/schemas/{name}     — create or update a schema
+//	DELETE /v1/schemas/{name}     — delete a schema
+//
+// Version management is automatic: the server assigns version=1 on first
+// creation and increments by 1 on each update. Callers do not supply a version.
+//
+// Duration fields (sub_timeout, retry_backoff) are Go time.Duration values
+// serialized as nanosecond integers in JSON.
+//
+// Example:
+//
+//	provider := schema.NewMemoryProvider()
+//	h := schemahttp.New(provider)
+//	http.Handle("/", h)
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rbaliyan/event/v3/schema"
+)
+
+// Handler is an HTTP handler for schema CRUD operations.
+type Handler struct {
+	provider schema.SchemaProvider
+	mux      *http.ServeMux
+}
+
+// New creates a Handler backed by the given provider.
+func New(provider schema.SchemaProvider) *Handler {
+	h := &Handler{
+		provider: provider,
+		mux:      http.NewServeMux(),
+	}
+	h.mux.HandleFunc("/v1/schemas", h.handleSchemas)
+	h.mux.HandleFunc("/v1/schemas/", h.handleSchemaByName)
+	return h
+}
+
+// ServeHTTP implements http.Handler.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mux.ServeHTTP(w, r)
+}
+
+// handleSchemas handles GET /v1/schemas (list).
+func (h *Handler) handleSchemas(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	schemas, err := h.provider.List(r.Context())
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if schemas == nil {
+		schemas = []*schema.EventSchema{}
+	}
+	h.writeJSON(w, map[string]any{"schemas": schemas})
+}
+
+// handleSchemaByName handles GET, PUT, DELETE /v1/schemas/{name}.
+func (h *Handler) handleSchemaByName(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.URL.Path, "/v1/schemas/")
+	if name == "" {
+		h.writeError(w, http.StatusBadRequest, "schema name required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGet(w, r, name)
+	case http.MethodPut:
+		h.handlePut(w, r, name)
+	case http.MethodDelete:
+		h.handleDelete(w, r, name)
+	default:
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handleGet(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.provider.Get(r.Context(), name)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if s == nil {
+		h.writeError(w, http.StatusNotFound, "schema not found")
+		return
+	}
+	h.writeJSON(w, s)
+}
+
+// schemaInput is the request body for PUT /v1/schemas/{name}.
+// Name and Version are excluded — Name comes from the URL path and
+// Version is managed server-side (auto-incremented on each update).
+type schemaInput struct {
+	Description       string            `json:"description,omitempty"`
+	SubTimeout        time.Duration     `json:"sub_timeout,omitempty"`
+	MaxRetries        int               `json:"max_retries,omitempty"`
+	RetryBackoff      time.Duration     `json:"retry_backoff,omitempty"`
+	EnableMonitor     bool              `json:"enable_monitor"`
+	EnableIdempotency bool              `json:"enable_idempotency"`
+	EnablePoison      bool              `json:"enable_poison"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
+}
+
+func (h *Handler) handlePut(w http.ResponseWriter, r *http.Request, name string) {
+	var input schemaInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	// Determine next version
+	existing, err := h.provider.Get(r.Context(), name)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	version := 1
+	if existing != nil {
+		version = existing.Version + 1
+	}
+
+	s := &schema.EventSchema{
+		Name:              name,
+		Version:           version,
+		Description:       input.Description,
+		SubTimeout:        input.SubTimeout,
+		MaxRetries:        input.MaxRetries,
+		RetryBackoff:      input.RetryBackoff,
+		EnableMonitor:     input.EnableMonitor,
+		EnableIdempotency: input.EnableIdempotency,
+		EnablePoison:      input.EnablePoison,
+		Metadata:          input.Metadata,
+	}
+
+	if err := h.provider.Set(r.Context(), s); err != nil {
+		if errors.Is(err, schema.ErrEmptyName) || errors.Is(err, schema.ErrInvalidVersion) {
+			h.writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Return the stored schema (with timestamps filled in by provider)
+	stored, err := h.provider.Get(r.Context(), name)
+	if err != nil || stored == nil {
+		// Fall back to what we built
+		h.writeJSON(w, s)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	h.writeJSON(w, stored)
+}
+
+func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request, name string) {
+	if err := h.provider.Delete(r.Context(), name); err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data) //nolint:errcheck
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/schema/http/handler_test.go
+++ b/schema/http/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -223,5 +224,59 @@ func TestPut_MetadataRoundtrip(t *testing.T) {
 
 	if s.Metadata["owner"] != "payments-team" {
 		t.Errorf("metadata owner: want payments-team, got %s", s.Metadata["owner"])
+	}
+}
+
+// TestPut_ServerFieldsIgnored verifies that version supplied in the PUT body is ignored.
+func TestPut_ServerFieldsIgnored(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{
+		"version":            999,
+		"enable_monitor":     false,
+		"enable_idempotency": false,
+		"enable_poison":      false,
+	}
+	w := do(t, h, http.MethodPut, "/v1/schemas/server.fields", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200, got %d body: %s", w.Code, w.Body)
+	}
+
+	var s schema.EventSchema
+	decodeJSON(t, w, &s)
+	if s.Version != 1 {
+		t.Errorf("version: want 1 (server-assigned), got %d", s.Version)
+	}
+}
+
+// TestPut_ConcurrentVersionIncrement verifies that concurrent PUTs serialize version increments.
+func TestPut_ConcurrentVersionIncrement(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{"enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
+
+	// Seed version 1.
+	w := do(t, h, http.MethodPut, "/v1/schemas/concurrent.event", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("seed PUT: want 200, got %d", w.Code)
+	}
+
+	const workers = 10
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			do(t, h, http.MethodPut, "/v1/schemas/concurrent.event", body)
+		}()
+	}
+	wg.Wait()
+
+	// After 1 seed + 10 concurrent PUTs, version must be exactly 11.
+	w = do(t, h, http.MethodGet, "/v1/schemas/concurrent.event", nil)
+	var s schema.EventSchema
+	decodeJSON(t, w, &s)
+	if s.Version != workers+1 {
+		t.Errorf("version: want %d, got %d (concurrent increment lost)", workers+1, s.Version)
 	}
 }

--- a/schema/http/handler_test.go
+++ b/schema/http/handler_test.go
@@ -1,0 +1,227 @@
+package http_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/schema"
+	schemahttp "github.com/rbaliyan/event/v3/schema/http"
+)
+
+func newHandler(t *testing.T) (*schemahttp.Handler, *schema.MemoryProvider) {
+	t.Helper()
+	provider := schema.NewMemoryProvider()
+	t.Cleanup(func() { _ = provider.Close() })
+	return schemahttp.New(provider), provider
+}
+
+func do(t *testing.T, h http.Handler, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func decodeJSON(t *testing.T, w *httptest.ResponseRecorder, v any) {
+	t.Helper()
+	if err := json.NewDecoder(w.Body).Decode(v); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, w.Body.String())
+	}
+}
+
+// TestList_Empty verifies an empty provider returns an empty schemas array.
+func TestList_Empty(t *testing.T) {
+	h, _ := newHandler(t)
+	w := do(t, h, http.MethodGet, "/v1/schemas", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+
+	var result struct {
+		Schemas []any `json:"schemas"`
+	}
+	decodeJSON(t, w, &result)
+	if len(result.Schemas) != 0 {
+		t.Errorf("expected empty schemas, got %d", len(result.Schemas))
+	}
+}
+
+// TestPutAndGet verifies creating and retrieving a schema.
+func TestPutAndGet(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{
+		"description":        "Order creation event",
+		"sub_timeout":        int64(30 * time.Second),
+		"max_retries":        3,
+		"enable_monitor":     true,
+		"enable_idempotency": false,
+		"enable_poison":      false,
+	}
+	w := do(t, h, http.MethodPut, "/v1/schemas/orders.created", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT: want 200, got %d body: %s", w.Code, w.Body)
+	}
+
+	var created schema.EventSchema
+	decodeJSON(t, w, &created)
+	if created.Name != "orders.created" {
+		t.Errorf("name: want orders.created, got %s", created.Name)
+	}
+	if created.Version != 1 {
+		t.Errorf("version: want 1, got %d", created.Version)
+	}
+	if created.MaxRetries != 3 {
+		t.Errorf("max_retries: want 3, got %d", created.MaxRetries)
+	}
+	if !created.EnableMonitor {
+		t.Error("expected enable_monitor=true")
+	}
+
+	// Now GET it
+	w = do(t, h, http.MethodGet, "/v1/schemas/orders.created", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET: want 200, got %d", w.Code)
+	}
+	var got schema.EventSchema
+	decodeJSON(t, w, &got)
+	if got.Name != "orders.created" || got.Version != 1 {
+		t.Errorf("GET: unexpected schema %+v", got)
+	}
+}
+
+// TestPut_AutoIncrementVersion verifies version is auto-incremented on update.
+func TestPut_AutoIncrementVersion(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{"description": "v1", "enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
+	do(t, h, http.MethodPut, "/v1/schemas/test.event", body)
+
+	body["description"] = "v2"
+	w := do(t, h, http.MethodPut, "/v1/schemas/test.event", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("second PUT: want 200, got %d", w.Code)
+	}
+
+	var s schema.EventSchema
+	decodeJSON(t, w, &s)
+	if s.Version != 2 {
+		t.Errorf("version: want 2, got %d", s.Version)
+	}
+}
+
+// TestList_WithSchemas verifies the list endpoint returns all schemas.
+func TestList_WithSchemas(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{"enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
+	do(t, h, http.MethodPut, "/v1/schemas/event.a", body)
+	do(t, h, http.MethodPut, "/v1/schemas/event.b", body)
+
+	w := do(t, h, http.MethodGet, "/v1/schemas", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("LIST: want 200, got %d", w.Code)
+	}
+
+	var result struct {
+		Schemas []schema.EventSchema `json:"schemas"`
+	}
+	decodeJSON(t, w, &result)
+	if len(result.Schemas) != 2 {
+		t.Errorf("want 2 schemas, got %d", len(result.Schemas))
+	}
+}
+
+// TestDelete verifies deletion removes a schema.
+func TestDelete(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{"enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
+	do(t, h, http.MethodPut, "/v1/schemas/deleteme", body)
+
+	w := do(t, h, http.MethodDelete, "/v1/schemas/deleteme", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: want 204, got %d", w.Code)
+	}
+
+	// Now GET should 404
+	w = do(t, h, http.MethodGet, "/v1/schemas/deleteme", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("GET after DELETE: want 404, got %d", w.Code)
+	}
+}
+
+// TestGet_NotFound verifies 404 for missing schemas.
+func TestGet_NotFound(t *testing.T) {
+	h, _ := newHandler(t)
+	w := do(t, h, http.MethodGet, "/v1/schemas/nonexistent", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
+// TestPut_InvalidJSON verifies 400 for malformed bodies.
+func TestPut_InvalidJSON(t *testing.T) {
+	h, _ := newHandler(t)
+	req := httptest.NewRequest(http.MethodPut, "/v1/schemas/test", bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+// TestMethodNotAllowed verifies 405 for wrong HTTP methods.
+func TestMethodNotAllowed(t *testing.T) {
+	h, _ := newHandler(t)
+	w := do(t, h, http.MethodPost, "/v1/schemas", nil)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", w.Code)
+	}
+}
+
+// TestPut_MissingName verifies 400 for /v1/schemas/ with no name.
+func TestPut_MissingName(t *testing.T) {
+	h, _ := newHandler(t)
+	w := do(t, h, http.MethodPut, "/v1/schemas/", map[string]any{})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+// TestPut_MetadataRoundtrip verifies metadata is preserved.
+func TestPut_MetadataRoundtrip(t *testing.T) {
+	h, _ := newHandler(t)
+
+	body := map[string]any{
+		"enable_monitor":     false,
+		"enable_idempotency": false,
+		"enable_poison":      false,
+		"metadata":           map[string]string{"owner": "payments-team", "sla": "99.9"},
+	}
+	do(t, h, http.MethodPut, "/v1/schemas/payments.charged", body)
+
+	w := do(t, h, http.MethodGet, "/v1/schemas/payments.charged", nil)
+	var s schema.EventSchema
+	decodeJSON(t, w, &s)
+
+	if s.Metadata["owner"] != "payments-team" {
+		t.Errorf("metadata owner: want payments-team, got %s", s.Metadata["owner"])
+	}
+}


### PR DESCRIPTION
## Summary

New package `schema/http` exposes the schema registry over HTTP. Implements `http.Handler` — callers mount it on their own server with whatever auth middleware they require.

## Endpoints

| Method | Path | Description |
|---|---|---|
| `GET` | `/v1/schemas` | List all schemas |
| `GET` | `/v1/schemas/{name}` | Fetch schema by name |
| `PUT` | `/v1/schemas/{name}` | Create or update schema (version auto-incremented) |
| `DELETE` | `/v1/schemas/{name}` | Delete schema by name |

## Design notes

- Version is **always auto-incremented server-side** on PUT; callers never supply a version number. The internal `schemaInput` type used for PUT deserialization excludes `Name`, `Version`, and server-managed timestamps.
- Durations are encoded as nanoseconds (`int64`) matching Go's `time.Duration` JSON convention.
- No extra dependencies — uses `encoding/json` and `net/http` from stdlib only.
- Returns `404` for missing schemas on GET and DELETE; `405` for wrong methods.

## Test plan

- [ ] `GET /v1/schemas` returns empty list when no schemas registered
- [ ] `PUT /v1/schemas/{name}` creates a new schema with version 1
- [ ] Second `PUT` increments version
- [ ] `GET /v1/schemas/{name}` returns the current schema
- [ ] `DELETE /v1/schemas/{name}` removes the schema; subsequent GET returns 404
- [ ] PUT with unknown store field returns 400
- [ ] Wrong HTTP method returns 405