### PR TITLE
docs: fix stale endpoint references, type marshaling, and API examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,12 @@ func New(opts ...Option) *Client {
 - HTTP API: `monitor/http` - REST handler using protoJSON
 - gRPC API: `monitor/grpc` - gRPC service implementation
 - Shared protobuf definitions in `monitor/proto`
+- `monitor/DEBUGGING.md` — operational runbook for debugging stuck events, consumer lag, and coverage gaps
+- `StuckPendingProvider` optional interface on monitor stores: `StuckPendingCount` and `StuckPendingEntries` methods
+- `WithStuckPendingProvider(p StuckPendingStatsProvider)` option on the HTTP handler enables stuck-pending stats in `/v1/system`
+- `WithDLQAlertHook(fn DLQAlertFunc, threshold int64)` option fires a callback when DLQ pending count exceeds threshold during each system refresh
+- `/v1/monitor/coverage/{event_id}` endpoint — cross-references live topology with monitor entries to show subscription coverage gaps
+- `DLQProvider` and `SchedulerProvider` optional interfaces in `monitor/http/federation.go` for system view federation
 
 **Schema Registry (schema/)** - Publisher-defined event configuration with subscriber auto-sync:
 - Publishers define event configuration (timeouts, retries, feature flags)

--- a/README.md
+++ b/README.md
@@ -397,11 +397,12 @@ coord, _ := distributed.NewRedisStateManager(redisClient,
 )
 
 // Subscribe with WorkerPool emulation
-mongoEvent.Subscribe(ctx, handler,
-    event.WithMiddleware(
-        distributed.WorkerPoolMiddleware[Order](coord, 5*time.Minute),
-    ),
-)
+// WorkerPoolMiddleware returns (event.Middleware[T], error) — check the error.
+mw, err := distributed.WorkerPoolMiddleware[Order](coord, 5*time.Minute)
+if err != nil {
+    log.Fatal(err)
+}
+mongoEvent.Subscribe(ctx, handler, event.WithMiddleware(mw))
 ```
 
 ### Payload Recovery
@@ -438,10 +439,17 @@ Use separate coordinators with different prefixes per group:
 smA, _ := distributed.NewRedisStateManager(redis, distributed.WithPrefix("processors:"))
 smB, _ := distributed.NewRedisStateManager(redis, distributed.WithPrefix("analytics:"))
 
-orderEvent.Subscribe(ctx, processOrder,
-    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smA, ttl)))
-orderEvent.Subscribe(ctx, collectAnalytics,
-    event.WithMiddleware(distributed.WorkerPoolMiddleware[Order](smB, ttl)))
+// WorkerPoolMiddleware returns (event.Middleware[T], error) — check the error.
+mwA, err := distributed.WorkerPoolMiddleware[Order](smA, ttl)
+if err != nil {
+    log.Fatal(err)
+}
+mwB, err := distributed.WorkerPoolMiddleware[Order](smB, ttl)
+if err != nil {
+    log.Fatal(err)
+}
+orderEvent.Subscribe(ctx, processOrder, event.WithMiddleware(mwA))
+orderEvent.Subscribe(ctx, collectAnalytics, event.WithMiddleware(mwB))
 ```
 
 ### Coordinator Backends
@@ -629,7 +637,9 @@ Define event configuration centrally:
 ```go
 import "github.com/rbaliyan/event/v3/schema"
 
-provider, _ := schema.NewPostgresProvider(db, nil)
+// The second argument is a publish function called when schema changes are made.
+// Pass nil only if your application never needs schema-change notifications.
+provider, _ := schema.NewPostgresProvider(db, nil /* publisher */)
 defer provider.Close()
 
 bus, _ := event.NewBus("order-service",
@@ -688,11 +698,27 @@ Use **event-dlq** for failed message management:
 ```go
 import dlq "github.com/rbaliyan/event-dlq"
 
-store := dlq.NewPostgresStore(db)
-manager := dlq.NewManager(store, transport)
+// NewPostgresStore and NewManager both return errors — check them.
+// See github.com/rbaliyan/event-dlq for full API reference.
+store, err := dlq.NewPostgresStore(db)
+if err != nil {
+    log.Fatal(err)
+}
+manager, err := dlq.NewManager(store, transport)
+if err != nil {
+    log.Fatal(err)
+}
 
-// Store failed message
-manager.Store(ctx, "order.created", msgID, payload, metadata, err, retryCount, "order-service")
+// Store failed message (Store takes a StoreParams struct, not positional args)
+manager.Store(ctx, dlq.StoreParams{
+    EventName:  "order.created",
+    OriginalID: msgID,
+    Payload:    payload,
+    Metadata:   metadata,
+    Err:        failErr,
+    RetryCount: retryCount,
+    Source:     "order-service",
+})
 
 // Replay failed messages
 replayed, _ := manager.Replay(ctx, dlq.Filter{
@@ -712,18 +738,26 @@ Use **event-scheduler** for delayed delivery:
 ```go
 import scheduler "github.com/rbaliyan/event-scheduler"
 
-sched := scheduler.NewRedisScheduler(redisClient, transport,
+// NewRedisScheduler returns (*RedisScheduler, error).
+sched, err := scheduler.NewRedisScheduler(redisClient, transport,
     scheduler.WithPollInterval(100*time.Millisecond),
 )
-defer sched.Close(ctx)
+if err != nil {
+    log.Fatal(err)
+}
 
 go sched.Start(ctx)
 
-// Schedule for future delivery
-sched.Schedule(ctx, "order.reminder", payload, time.Now().Add(24*time.Hour))
+// Schedule for future delivery using a Message struct.
+// Set ID for cancellation support; leave empty for auto-generated ID.
+sched.Schedule(ctx, scheduler.Message{
+    ID:          "reminder-123",
+    EventName:   "order.reminder",
+    Payload:     payload,
+    ScheduledAt: time.Now().Add(24 * time.Hour),
+})
 
-// Schedule with ID for cancellation
-sched.ScheduleWithID(ctx, "reminder-123", "order.reminder", payload, deliverAt)
+// Cancel a scheduled message
 sched.Cancel(ctx, "reminder-123")
 ```
 
@@ -761,14 +795,21 @@ Use **event-extras/saga** for distributed transactions:
 ```go
 import "github.com/rbaliyan/event-extras/saga"
 
-orderSaga := saga.New("order-creation",
+// saga.New takes a name, a []saga.Step slice, and functional options. It returns (*Saga, error).
+// See github.com/rbaliyan/event-extras/saga for full API reference.
+steps := []saga.Step{
     &CreateOrderStep{orderService},
     &ReserveInventoryStep{inventoryService},
     &ProcessPaymentStep{paymentService},
-).
-    WithStore(saga.NewRedisStore(redisClient)).
-    WithBackoff(&backoff.Exponential{Initial: time.Second, Max: 30*time.Second}).
-    WithMaxRetries(3)
+}
+orderSaga, err := saga.New("order-creation", steps,
+    saga.WithStore(saga.NewRedisStore(redisClient)),
+    saga.WithBackoff(&backoff.Exponential{Initial: time.Second, Max: 30 * time.Second}),
+    saga.WithMaxRetries(3),
+)
+if err != nil {
+    log.Fatal(err)
+}
 
 // Execute saga
 sagaID := uuid.New().String()

--- a/monitor/DEBUGGING.md
+++ b/monitor/DEBUGGING.md
@@ -50,13 +50,15 @@ Monitor middleware (updates to "completed" or "failed" AFTER handler returns)
 
 ### Key Timing Constants
 
-| Constant | Default | Meaning |
+The values below are **example values chosen by the operator** — they are not library defaults. Configure them to match your SLOs and handler runtimes.
+
+| Constant | Example Value | Meaning |
 |---|---|---|
 | `claimInterval` | 2 minutes | How often a pod sweeps for orphaned PEL messages |
 | `claimMinIdle` | 5 minutes | Minimum age before an unclaimed message is stolen |
 | `stuckPendingThreshold` | 6 minutes | Age at which a "pending" monitor entry is flagged as stuck |
 
-The 5-minute window between a pod crashing and the PEL being reclaimed means a monitor entry can appear stuck for up to ~5 minutes after a crash, then silently recover when another pod claims and processes the message.
+With example values above, a pod crash means a monitor entry can appear stuck for up to ~5 minutes, then silently recover when another pod claims and processes the message.
 
 ### Delivery Modes
 
@@ -138,7 +140,6 @@ Cross-references recorded monitor entries with the **live in-process subscriptio
 ```
 GET /v1/topology                    # All buses and events
 GET /v1/topology/{bus_name}         # Single bus
-GET /v1/topology/{bus_name}/{event} # Single event
 ```
 
 Shows the live in-process subscription graph: bus names, event names, subscription IDs, worker groups, delivery modes.
@@ -171,7 +172,7 @@ A non-zero `count` means pods crashed after recording "pending" but before compl
 
 ```
 GET /v1/workers          # All worker leases
-GET /v1/workers/{id}     # Single worker by subscription ID
+GET /v1/workers/{id}     # Single worker by message_id (the worker's claim ID)
 GET /v1/workers/count    # Count active workers
 ```
 
@@ -259,22 +260,24 @@ Look at `consumer_lag[]`:
       "consumer_group": "mybus-case_record.created-workflow",
       "lag": 1500,
       "pending_messages": 3,
-      "oldest_pending": "4m30s"
+      "oldest_pending": 270000000000
     }
   ]
 }
 ```
 
+`oldest_pending` is serialized as an int64 nanosecond count (e.g. `270000000000` = 4m30s). The field is omitted from the JSON output when the value is unknown (nil).
+
 | Field | Concern threshold | Meaning |
 |---|---|---|
 | `lag` | > a few hundred | Unconsumed messages in the stream |
 | `pending_messages` | > 0 | Delivered but not ACKed (in-flight or crashed) |
-| `oldest_pending` | > `claimMinIdle` (5 min) | A pod claimed this message and has not ACKed it — likely crashed |
+| `oldest_pending` | > operator-configured `claimMinIdle` | A pod claimed this message and has not ACKed it — likely crashed |
 
 ### Step 2: Identify the bottleneck
 
 - **High lag, low pending**: handlers are too slow or there aren't enough pods. Scale horizontally — each pod in the worker group is a consumer.
-- **High pending, old oldest_pending**: pod crashed and the PEL is not yet reclaimed. Wait for `claimMinIdle` (5 min) and check again. If it persists, check stuck pending (next section).
+- **High pending, old oldest_pending**: pod crashed and the PEL is not yet reclaimed. Wait for the configured `claimMinIdle` duration and check again. If it persists, check stuck pending (next section).
 - **High lag, zero pending**: the consumer group has no active consumers. All pods may be down.
 
 ### Step 3: Direct Redis inspection
@@ -305,7 +308,7 @@ The monitor middleware records "pending" **before** the handler runs. If a pod c
 
 1. The monitor entry stays `pending` forever (nothing updates it).
 2. The Redis PEL still holds the message.
-3. After `claimMinIdle` (5 min), another pod claims the message and processes it.
+3. After the configured `claimMinIdle` duration, another pod claims the message and processes it.
 4. **The original "pending" entry is never updated** because `Record()` uses `$setOnInsert` for WorkerPool mode — a new completion entry cannot overwrite the old pod's pending entry.
 
 This means a stuck pending entry does **not** always mean the event was lost. The new pod's completion is a separate `(event_id, "")` upsert that conflicts with the orphaned entry. Check whether a completion entry exists with the same `event_id` and `worker_group`.
@@ -581,7 +584,7 @@ XPENDING evt.mybus.case_record.created mybus-case_record.created-workflow
 XPENDING evt.mybus.case_record.created mybus-case_record.created-workflow - + 10
 ```
 
-The `idle` time in the detailed output shows how long since the message was last delivered. Messages idle longer than `claimMinIdle` (5 min) will be auto-claimed by the next pod that runs a claim sweep.
+The `idle` time in the detailed output shows how long since the message was last delivered. Messages idle longer than the configured `claimMinIdle` duration will be auto-claimed by the next pod that runs a claim sweep.
 
 ### Active consumers in a group
 


### PR DESCRIPTION
## Summary

- **monitor/DEBUGGING.md**: Remove non-existent `/v1/topology/{bus_name}/{event}` endpoint; fix `/v1/workers/{id}` key field (`message_id`, not `subscription_id`); show `oldest_pending` as int64 nanoseconds (not string); clarify timing constants are operator-configured examples, not library defaults
- **README.md**: Fix `WorkerPoolMiddleware` call sites to two-line form (returns `(Middleware, error)`); fix saga/scheduler/dlq examples to match current API signatures; clarify `schema.NewPostgresProvider` publisher argument
- **CLAUDE.md**: Add missing monitor items — `DEBUGGING.md` runbook, `StuckPendingProvider`, `WithStuckPendingProvider`, `WithDLQAlertHook`, `/v1/monitor/coverage/{event_id}`, `DLQProvider`/`SchedulerProvider`

## Test plan

- [ ] No code changes — documentation only
- [ ] Verify examples in README compile against current module versions