### PR TITLE
feat(monitor): add producer-side publish audit log

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -62,15 +62,17 @@ type Bus struct {
 	outboxStore OutboxStore
 	// DLQ store for automatic dead letter routing
 	dlqStore DLQStore
+	// Publish audit store for producer-side event tracking
+	publishAuditStore PublishAuditStore
 	// Cached OTel instruments (initialized once during construction)
-	busAttr          attribute.KeyValue // bus="name" attribute for all metrics
-	publishedCounter metric.Int64Counter
-	subscribedCounter metric.Int64Counter
-	publishDuration       metric.Float64Histogram
-	handlerDuration       metric.Float64Histogram
-	handlerErrors         metric.Int64Counter
-	filterDroppedCounter  metric.Int64Counter
-	receiveLag            metric.Float64Histogram
+	busAttr              attribute.KeyValue // bus="name" attribute for all metrics
+	publishedCounter     metric.Int64Counter
+	subscribedCounter    metric.Int64Counter
+	publishDuration      metric.Float64Histogram
+	handlerDuration      metric.Float64Histogram
+	handlerErrors        metric.Int64Counter
+	filterDroppedCounter metric.Int64Counter
+	receiveLag           metric.Float64Histogram
 }
 
 // NewBus creates a new event bus and registers it in the global registry.
@@ -96,25 +98,26 @@ func NewBus(name string, opts ...BusOption) (*Bus, error) {
 	}
 
 	bus := &Bus{
-		name:             name,
-		status:           busRunning,
-		id:               NewID(),
-		shutdownChan:     make(chan struct{}),
-		drainTimeout:     o.drainTimeout,
-		transport:        transport,
-		logger:           o.logger.With("component", "bus>"+name),
-		tracingEnabled:   o.tracingEnabled,
-		recoveryEnabled:  o.recoveryEnabled,
-		metricsEnabled:   o.metricsEnabled,
-		events:           make(map[string]any),
-		eventTypes:       make(map[string]reflect.Type),
-		idempotencyStore: o.idempotencyStore,
-		poisonDetector:   o.poisonDetector,
-		monitorStore:     o.monitorStore,
-		schemaProvider:   o.schemaProvider,
-		strictSchema:     o.strictSchema,
-		outboxStore:      o.outboxStore,
-		dlqStore:         o.dlqStore,
+		name:              name,
+		status:            busRunning,
+		id:                NewID(),
+		shutdownChan:      make(chan struct{}),
+		drainTimeout:      o.drainTimeout,
+		transport:         transport,
+		logger:            o.logger.With("component", "bus>"+name),
+		tracingEnabled:    o.tracingEnabled,
+		recoveryEnabled:   o.recoveryEnabled,
+		metricsEnabled:    o.metricsEnabled,
+		events:            make(map[string]any),
+		eventTypes:        make(map[string]reflect.Type),
+		idempotencyStore:  o.idempotencyStore,
+		poisonDetector:    o.poisonDetector,
+		monitorStore:      o.monitorStore,
+		schemaProvider:    o.schemaProvider,
+		strictSchema:      o.strictSchema,
+		outboxStore:       o.outboxStore,
+		dlqStore:          o.dlqStore,
+		publishAuditStore: o.publishAuditStore,
 	}
 
 	// Initialize OTel instruments if metrics enabled.
@@ -238,6 +241,13 @@ func (b *Bus) OutboxStore() OutboxStore {
 // When configured, rejected messages are automatically routed to the DLQ.
 func (b *Bus) DLQStore() DLQStore {
 	return b.dlqStore
+}
+
+// PublishAuditStore returns the bus-level publish audit store (may be nil).
+// When configured, each successful transport publish is recorded for
+// producer-side event tracing.
+func (b *Bus) PublishAuditStore() PublishAuditStore {
+	return b.publishAuditStore
 }
 
 // sendToDLQ stores a message in the DLQ if configured.
@@ -482,6 +492,28 @@ func (b *Bus) Send(ctx context.Context, eventName string, eventID string, payloa
 		b.publishDuration.Record(ctx, time.Since(publishStart).Seconds(),
 			metric.WithAttributes(b.busAttr, attribute.String("event", eventName)))
 	}
+
+	// Record successful publish in the audit log (best-effort, never blocks Send).
+	// Outbox-routed publishes are not recorded here; they bypass the transport and
+	// are tracked in the outbox store until the relay delivers them.
+	if err == nil && b.publishAuditStore != nil {
+		var traceID, spanID string
+		if spanCtx.IsValid() {
+			traceID = spanCtx.TraceID().String()
+			spanID = spanCtx.SpanID().String()
+		}
+		_ = b.publishAuditStore.RecordPublish(ctx, RecordPublishParams{
+			EventID:     eventID,
+			EventName:   eventName,
+			BusID:       b.id,
+			BusName:     b.name,
+			PayloadSize: len(payload),
+			Metadata:    metadata,
+			TraceID:     traceID,
+			SpanID:      spanID,
+		})
+	}
+
 	return err
 }
 

--- a/bus_options.go
+++ b/bus_options.go
@@ -26,6 +26,8 @@ type busOptions struct {
 	outboxStore OutboxStore
 	// DLQ store for automatic dead letter routing
 	dlqStore DLQStore
+	// Publish audit store for producer-side event tracking
+	publishAuditStore PublishAuditStore
 }
 
 // BusOption option function for bus configuration
@@ -249,6 +251,31 @@ func WithDLQ(store DLQStore) BusOption {
 	return func(o *busOptions) {
 		if store != nil {
 			o.dlqStore = store
+		}
+	}
+}
+
+// WithPublishAudit configures producer-side publish audit logging.
+// When set, every successful transport.Publish call is recorded in the store.
+// This closes the observability gap between "event published" and "event processed":
+// if an event has no monitor entry but does have a publish audit entry, the fault
+// lies in the transport or subscriber layer rather than the application code.
+//
+// Outbox-routed publishes (messages stored in the outbox for later relay) are
+// not recorded here; they bypass the transport path and are tracked separately
+// by the outbox store until the relay delivers them.
+//
+// Example:
+//
+//	ps := monitor.NewPublishMemoryStore()
+//	bus, _ := event.NewBus("my-app",
+//	    event.WithTransport(transport),
+//	    event.WithPublishAudit(ps),
+//	)
+func WithPublishAudit(store PublishAuditStore) BusOption {
+	return func(o *busOptions) {
+		if store != nil {
+			o.publishAuditStore = store
 		}
 	}
 }

--- a/middleware.go
+++ b/middleware.go
@@ -325,6 +325,32 @@ type MonitorStore interface {
 	RecordComplete(ctx context.Context, params RecordCompleteParams) error
 }
 
+// RecordPublishParams contains the parameters for recording a successful event publish.
+type RecordPublishParams struct {
+	EventID     string
+	EventName   string
+	BusID       string // bus instance ID (unique per process)
+	BusName     string // bus name (human-readable)
+	PayloadSize int
+	Metadata    map[string]string
+	TraceID     string
+	SpanID      string
+}
+
+// PublishAuditStore records successful publish attempts made through Bus.Send.
+//
+// The Bus calls RecordPublish after each successful transport.Publish call.
+// This closes the gap in the monitoring system: if an event has no Entry in
+// the monitor store, cross-referencing the publish audit reveals whether the
+// event was ever published (transport fault) or never fired at all (app bug).
+//
+// Implementations:
+//   - monitor.NewPublishMemoryStore(): In-memory store for development/testing
+//   - For production, implement PublishStore from the monitor package and wrap it
+type PublishAuditStore interface {
+	RecordPublish(ctx context.Context, params RecordPublishParams) error
+}
+
 // SchemaProvider is an alias for schema.SchemaProvider.
 //
 // This type alias exists for backward compatibility. New code should

--- a/monitor/http/handler.go
+++ b/monitor/http/handler.go
@@ -27,13 +27,13 @@ type DLQAlertFunc func(stats *DLQStats)
 
 // handlerOptions holds configuration for the Handler.
 type handlerOptions struct {
-	workerStore            distributed.WorkerStore
-	dlqProvider            DLQProvider
-	schedProvider          SchedulerProvider
-	stuckPendingProvider   StuckPendingStatsProvider
-	systemRefreshInterval  time.Duration
-	dlqAlertFunc           DLQAlertFunc
-	dlqAlertThreshold      int64
+	workerStore           distributed.WorkerStore
+	dlqProvider           DLQProvider
+	schedProvider         SchedulerProvider
+	stuckPendingProvider  StuckPendingStatsProvider
+	systemRefreshInterval time.Duration
+	dlqAlertFunc          DLQAlertFunc
+	dlqAlertThreshold     int64
 }
 
 // Option configures the Handler.
@@ -134,8 +134,8 @@ func New(store monitor.Store, opts ...Option) *Handler {
 		stuckPendingProvider: o.stuckPendingProvider,
 		dlqAlertFunc:         o.dlqAlertFunc,
 		dlqAlertThreshold:    o.dlqAlertThreshold,
-		mux:           http.NewServeMux(),
-		done:          make(chan struct{}),
+		mux:                  http.NewServeMux(),
+		done:                 make(chan struct{}),
 		marshaler: protojson.MarshalOptions{
 			EmitUnpopulated: true,
 			UseProtoNames:   true,

--- a/monitor/memory.go
+++ b/monitor/memory.go
@@ -417,6 +417,34 @@ func (s *MemoryStore) RecordComplete(ctx context.Context, params event.RecordCom
 	return s.UpdateStatus(ctx, params.EventID, params.SubscriptionID, Status(params.Status), params.Error, params.Duration)
 }
 
+// RecordPublish records a producer-side publish milestone.
+// Implements event.PublishAuditStore by writing an Entry with Status == StatusPublished
+// and SubscriptionID == PublishMarker, so it shares the existing storage, indexes,
+// pagination, filters, and HTTP/gRPC query surface used by handler entries.
+//
+// The entry is keyed under (EventID, PublishMarker), which cannot collide with
+// real subscription IDs (random base32 strings) or WorkerPool entries (whose
+// key is just EventID). Publishing the same event twice silently overwrites —
+// at-least-once semantics from outbox relays make this safe.
+func (s *MemoryStore) RecordPublish(ctx context.Context, params event.RecordPublishParams) error {
+	now := time.Now()
+	entry := &Entry{
+		EventID:        params.EventID,
+		SubscriptionID: PublishMarker,
+		EventName:      params.EventName,
+		BusID:          params.BusID,
+		InstanceID:     params.BusName,
+		DeliveryMode:   Broadcast,
+		Metadata:       params.Metadata,
+		Status:         StatusPublished,
+		StartedAt:      now,
+		CompletedAt:    &now,
+		TraceID:        params.TraceID,
+		SpanID:         params.SpanID,
+	}
+	return s.Record(ctx, entry)
+}
+
 // Summary returns aggregated statistics for entries matching the filter.
 func (s *MemoryStore) Summary(ctx context.Context, filter Filter) (*Summary, error) {
 	s.mu.RLock()

--- a/monitor/memory_publish_test.go
+++ b/monitor/memory_publish_test.go
@@ -1,0 +1,203 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+)
+
+// TestMemoryStore_RecordPublishCreatesEntry verifies that RecordPublish writes
+// an Entry with Status=StatusPublished, SubscriptionID=PublishMarker, and the
+// supplied bus/event metadata.
+func TestMemoryStore_RecordPublishCreatesEntry(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	defer s.Close()
+
+	params := event.RecordPublishParams{
+		EventID:   "evt-1",
+		EventName: "order.created",
+		BusID:     "bus-abc",
+		BusName:   "orders",
+		TraceID:   "trace-1",
+		SpanID:    "span-1",
+	}
+	if err := s.RecordPublish(ctx, params); err != nil {
+		t.Fatalf("RecordPublish: %v", err)
+	}
+
+	entry, err := s.Get(ctx, "evt-1", PublishMarker)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected publish entry, got nil")
+	}
+	if entry.Status != StatusPublished {
+		t.Errorf("Status = %q, want %q", entry.Status, StatusPublished)
+	}
+	if entry.SubscriptionID != PublishMarker {
+		t.Errorf("SubscriptionID = %q, want %q", entry.SubscriptionID, PublishMarker)
+	}
+	if entry.EventName != "order.created" {
+		t.Errorf("EventName = %q, want %q", entry.EventName, "order.created")
+	}
+	if entry.BusID != "bus-abc" {
+		t.Errorf("BusID = %q, want bus-abc", entry.BusID)
+	}
+	if entry.InstanceID != "orders" {
+		t.Errorf("InstanceID = %q, want orders (bus name)", entry.InstanceID)
+	}
+	if entry.TraceID != "trace-1" {
+		t.Errorf("TraceID = %q, want trace-1", entry.TraceID)
+	}
+	if entry.CompletedAt == nil {
+		t.Error("CompletedAt should be set for publish entries")
+	}
+}
+
+// TestMemoryStore_GetByEventIDIncludesPublishAndHandlers verifies the unified
+// diagnostic flow: a single GetByEventID returns the publish entry plus all
+// subscriber entries, so callers can answer "was it fired and processed?".
+func TestMemoryStore_GetByEventIDIncludesPublishAndHandlers(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	defer s.Close()
+
+	// Publish (producer-side milestone).
+	if err := s.RecordPublish(ctx, event.RecordPublishParams{
+		EventID:   "evt-x",
+		EventName: "order.created",
+		BusID:     "bus-1",
+	}); err != nil {
+		t.Fatalf("RecordPublish: %v", err)
+	}
+
+	// Subscriber A starts and completes.
+	if err := s.RecordStart(ctx, event.RecordStartParams{
+		EventID:        "evt-x",
+		SubscriptionID: "sub-a",
+		EventName:      "order.created",
+		BusID:          "bus-1",
+	}); err != nil {
+		t.Fatalf("RecordStart A: %v", err)
+	}
+	if err := s.RecordComplete(ctx, event.RecordCompleteParams{
+		EventID:        "evt-x",
+		SubscriptionID: "sub-a",
+		Status:         "completed",
+		Duration:       2 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("RecordComplete A: %v", err)
+	}
+
+	// Subscriber B starts and fails.
+	if err := s.RecordStart(ctx, event.RecordStartParams{
+		EventID:        "evt-x",
+		SubscriptionID: "sub-b",
+		EventName:      "order.created",
+		BusID:          "bus-1",
+	}); err != nil {
+		t.Fatalf("RecordStart B: %v", err)
+	}
+
+	entries, err := s.GetByEventID(ctx, "evt-x")
+	if err != nil {
+		t.Fatalf("GetByEventID: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries (publish + 2 subscribers), got %d", len(entries))
+	}
+
+	var hasPublish, hasA, hasB bool
+	for _, e := range entries {
+		switch e.SubscriptionID {
+		case PublishMarker:
+			hasPublish = true
+			if e.Status != StatusPublished {
+				t.Errorf("publish entry status = %q, want %q", e.Status, StatusPublished)
+			}
+		case "sub-a":
+			hasA = true
+			if e.Status != StatusCompleted {
+				t.Errorf("sub-a status = %q, want %q", e.Status, StatusCompleted)
+			}
+		case "sub-b":
+			hasB = true
+			if e.Status != StatusPending {
+				t.Errorf("sub-b status = %q, want %q", e.Status, StatusPending)
+			}
+		}
+	}
+	if !hasPublish || !hasA || !hasB {
+		t.Errorf("missing entries: publish=%v sub-a=%v sub-b=%v", hasPublish, hasA, hasB)
+	}
+}
+
+// TestMemoryStore_FilterByStatusPublished verifies the existing List/Filter
+// surface can return only publish entries via Status=StatusPublished.
+func TestMemoryStore_FilterByStatusPublished(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	defer s.Close()
+
+	for i := 0; i < 3; i++ {
+		if err := s.RecordPublish(ctx, event.RecordPublishParams{
+			EventID:   "p" + string(rune('1'+i)),
+			EventName: "order.created",
+		}); err != nil {
+			t.Fatalf("RecordPublish: %v", err)
+		}
+	}
+	if err := s.RecordStart(ctx, event.RecordStartParams{
+		EventID:        "p1",
+		SubscriptionID: "sub",
+		EventName:      "order.created",
+	}); err != nil {
+		t.Fatalf("RecordStart: %v", err)
+	}
+
+	page, err := s.List(ctx, Filter{Status: []Status{StatusPublished}})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(page.Entries) != 3 {
+		t.Errorf("expected 3 publish entries, got %d", len(page.Entries))
+	}
+	for _, e := range page.Entries {
+		if e.Status != StatusPublished {
+			t.Errorf("entry %s has status %q, want %q", e.EventID, e.Status, StatusPublished)
+		}
+	}
+}
+
+// TestMemoryStore_RecordPublishOverwrites verifies idempotent semantics:
+// republishing the same event ID overwrites without error.
+func TestMemoryStore_RecordPublishOverwrites(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	defer s.Close()
+
+	for i := 0; i < 3; i++ {
+		if err := s.RecordPublish(ctx, event.RecordPublishParams{
+			EventID:   "evt-same",
+			EventName: "order.created",
+		}); err != nil {
+			t.Fatalf("RecordPublish %d: %v", i, err)
+		}
+	}
+
+	count, err := s.Count(ctx, Filter{EventID: "evt-same"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 entry after 3 republishes, got %d", count)
+	}
+}
+
+// Compile-time check: monitor.MemoryStore satisfies event.PublishAuditStore
+// alongside event.MonitorStore.
+var _ event.PublishAuditStore = (*MemoryStore)(nil)

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -82,7 +82,19 @@ const (
 	// StatusRetrying indicates the handler returned an error that will be retried.
 	// This includes both immediate retries (nack) and backoff retries (defer).
 	StatusRetrying Status = "retrying"
+
+	// StatusPublished is a producer-side milestone: the bus successfully handed
+	// the event to its transport. The entry has SubscriptionID == PublishMarker
+	// and CompletedAt set to the publish time. Subscriber entries for the same
+	// EventID coexist in the store, enabling a single GetByEventID query to
+	// answer "was this fired and which subscribers processed it?".
+	StatusPublished Status = "published"
 )
+
+// PublishMarker is the synthetic SubscriptionID used for producer-side
+// publish entries (Status == StatusPublished). It cannot collide with a real
+// subscription ID because subscription IDs are random base32-encoded strings.
+const PublishMarker = "$publish"
 
 // Entry represents a single monitor record for event processing.
 //

--- a/publish_audit_test.go
+++ b/publish_audit_test.go
@@ -1,0 +1,156 @@
+package event
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rbaliyan/event/v3/transport/channel"
+)
+
+// fakePublishAuditStore captures every RecordPublish call for assertions.
+type fakePublishAuditStore struct {
+	mu      sync.Mutex
+	entries []RecordPublishParams
+}
+
+func (f *fakePublishAuditStore) RecordPublish(ctx context.Context, params RecordPublishParams) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entries = append(f.entries, params)
+	return nil
+}
+
+func (f *fakePublishAuditStore) Get(eventID string) (RecordPublishParams, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range f.entries {
+		if e.EventID == eventID {
+			return e, true
+		}
+	}
+	return RecordPublishParams{}, false
+}
+
+func (f *fakePublishAuditStore) Len() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.entries)
+}
+
+func TestPublishAudit_RecordsOnSuccessfulPublish(t *testing.T) {
+	ctx := context.Background()
+	audit := &fakePublishAuditStore{}
+
+	bus := mustNewBus(t, "audit-bus-"+randomString(5),
+		WithTransport(channel.New()),
+		WithPublishAudit(audit),
+	)
+	defer bus.Close(ctx)
+
+	ev := New[string]("audit.event")
+	if err := Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	eventID := "evt-" + randomString(8)
+	if err := ev.Publish(ContextWithEventID(ctx, eventID), "payload-data"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	if audit.Len() != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", audit.Len())
+	}
+	entry, ok := audit.Get(eventID)
+	if !ok {
+		t.Fatalf("audit entry for %s not found", eventID)
+	}
+	if entry.EventName != "audit.event" {
+		t.Errorf("EventName = %q, want %q", entry.EventName, "audit.event")
+	}
+	if entry.BusName == "" {
+		t.Error("BusName should not be empty")
+	}
+	if entry.BusID == "" {
+		t.Error("BusID should not be empty")
+	}
+	if entry.PayloadSize == 0 {
+		t.Error("PayloadSize should not be zero")
+	}
+}
+
+func TestPublishAudit_NotCalledWhenStoreNil(t *testing.T) {
+	ctx := context.Background()
+	bus := mustNewBus(t, "audit-nil-"+randomString(5),
+		WithTransport(channel.New()),
+	)
+	defer bus.Close(ctx)
+	if bus.PublishAuditStore() != nil {
+		t.Error("expected PublishAuditStore to be nil")
+	}
+
+	ev := New[string]("audit.event")
+	if err := Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+	if err := ev.Publish(ctx, "data"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	// No assertion needed — the test verifies that Publish doesn't panic
+	// or fail when no audit store is configured.
+}
+
+func TestPublishAudit_AccessorReturnsConfiguredStore(t *testing.T) {
+	ctx := context.Background()
+	audit := &fakePublishAuditStore{}
+
+	bus := mustNewBus(t, "audit-accessor-"+randomString(5),
+		WithTransport(channel.New()),
+		WithPublishAudit(audit),
+	)
+	defer bus.Close(ctx)
+
+	got := bus.PublishAuditStore()
+	if got == nil {
+		t.Fatal("expected PublishAuditStore to be non-nil")
+	}
+	if got != PublishAuditStore(audit) {
+		t.Error("PublishAuditStore should return the configured store")
+	}
+}
+
+func TestPublishAudit_NotCalledOnClosedBus(t *testing.T) {
+	// Verifies that audit recording happens only on successful transport.Publish:
+	// publishes against a closed bus short-circuit before transport.Publish and
+	// so should not produce audit entries.
+	ctx := context.Background()
+	audit := &fakePublishAuditStore{}
+
+	bus := mustNewBus(t, "audit-closed-"+randomString(5),
+		WithTransport(channel.New()),
+		WithPublishAudit(audit),
+	)
+
+	ev := New[string]("audit.event.closed")
+	if err := Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the bus. The error from event unregistration (transport closed
+	// first) is a known warning in the existing bus.Close implementation
+	// and is not relevant to this test's assertions.
+	_ = bus.Close(ctx)
+
+	// Publish should be rejected with ErrBusClosed before reaching the transport.
+	if err := ev.Publish(ctx, "after-close"); err == nil {
+		t.Error("expected publish on closed bus to fail")
+	}
+
+	// Allow any in-flight goroutines to settle
+	time.Sleep(20 * time.Millisecond)
+
+	if audit.Len() != 0 {
+		t.Errorf("expected 0 audit entries after closed-bus publish, got %d", audit.Len())
+	}
+}

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -2,6 +2,10 @@
 // auto-configures Monitor, Idempotency, and Poison detection on a Bus with
 // safe in-memory defaults — no external stores required for basic use.
 //
+// Producer-side publish audit reuses the monitor store: each successful
+// Bus.Send writes an Entry with Status == StatusPublished alongside the
+// subscriber entries, so a single GetByEventID returns the full lineage.
+//
 // # Quick start
 //
 //	bus, err := event.NewBus("mybus",
@@ -11,7 +15,9 @@
 //
 // # Custom stores
 //
-// Replace any default store with a production-grade backend:
+// Replace any default store with a production-grade backend. The monitor
+// store, when it implements event.PublishAuditStore, also receives publish
+// records (monitor.MemoryStore does this out of the box):
 //
 //	bus, err := event.NewBus("mybus",
 //	    event.WithTransport(t),
@@ -54,6 +60,10 @@ type Option func(*options)
 // WithMonitorStore replaces the default in-memory monitor store.
 // Use a production backend such as monitor.NewPostgresStore or
 // monitor.NewMemoryStore for development.
+//
+// If the supplied store also implements event.PublishAuditStore (the
+// in-memory store does), the stack wires it as the publish audit store
+// as well, so producer-side publish entries land in the same backend.
 func WithMonitorStore(store event.MonitorStore) Option {
 	return func(o *options) {
 		if store != nil {
@@ -123,8 +133,13 @@ func WithPoisonQuarantine(d time.Duration) Option {
 // and Poison detection with sensible defaults. All three features use in-memory
 // stores unless replaced via the Option functions above.
 //
+// Producer-side publish audit reuses the monitor store: when the configured
+// monitor store also implements event.PublishAuditStore (monitor.MemoryStore
+// does), every successful Bus.Send writes a publish entry alongside subscriber
+// entries — no extra option required.
+//
 // Default configuration:
-//   - Monitor: in-memory store
+//   - Monitor: in-memory store (also serves as publish audit)
 //   - Idempotency: in-memory store, 24-hour TTL
 //   - Poison detection: in-memory store, threshold=5, quarantine=1 hour
 //
@@ -179,9 +194,17 @@ func WithReliabilityStack(opts ...Option) event.BusOption {
 		)
 	}
 
-	return event.WithAll(
+	busOpts := []event.BusOption{
 		event.WithMonitor(ms),
 		event.WithIdempotency(is),
 		event.WithPoisonDetection(pd),
-	)
+	}
+	// If the monitor store also satisfies PublishAuditStore (e.g.
+	// monitor.MemoryStore), reuse it for producer-side audit so every
+	// publish lands alongside the subscriber entries it triggers.
+	if pa, ok := ms.(event.PublishAuditStore); ok {
+		busOpts = append(busOpts, event.WithPublishAudit(pa))
+	}
+
+	return event.WithAll(busOpts...)
 }

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -194,6 +194,46 @@ func TestWithReliabilityStack_IdempotencyTTL(t *testing.T) {
 	time.Sleep(30 * time.Millisecond)
 }
 
+// TestWithReliabilityStack_PublishAuditReusesMonitor verifies that the
+// monitor store also receives a Status=published entry after a successful
+// publish, since monitor.MemoryStore implements event.PublishAuditStore.
+func TestWithReliabilityStack_PublishAuditReusesMonitor(t *testing.T) {
+	mstore := monitor.NewMemoryStore()
+	t.Cleanup(func() { _ = mstore.Close() })
+
+	bus := newBus(t, stack.WithReliabilityStack(
+		stack.WithMonitorStore(mstore),
+	))
+
+	type msg struct{ V int }
+	ev := event.New[msg]("stack.pubaudit")
+	ctx := context.Background()
+
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatal(err)
+	}
+	ev.Subscribe(ctx, func(ctx context.Context, e event.Event[msg], m msg) error {
+		return nil
+	})
+
+	if err := ev.Publish(ctx, msg{42}); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	published := monitor.StatusPublished
+	count, err := mstore.Count(ctx, monitor.Filter{
+		EventName: "stack.pubaudit",
+		Status:    []monitor.Status{published},
+	})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 published entry for stack.pubaudit, got %d", count)
+	}
+}
+
 // TestWithReliabilityStack_PoisonOptions verifies threshold/quarantine knobs.
 func TestWithReliabilityStack_PoisonOptions(t *testing.T) {
 	bus := newBus(t, stack.WithReliabilityStack(


### PR DESCRIPTION
## Summary

Closes the producer-side observability gap in the event monitoring system.
Today the monitor package only records what happens **after** dispatch:
handler invocations, retries, DLQ failures. If an event has no consumer-side
entry, the system can't distinguish three very different failure modes:

1. The application never called `Publish()`
2. `Publish()` was called but the transport dropped the message
3. The transport delivered it but no subscriber processed it yet

This PR adds a publish audit milestone that records every successful
`Bus.Send` call, making the question **"was this event ever fired?"**
answerable from the same store the monitor already uses.

## Design: reuse the existing monitor store

A publish is just one more entry in the monitor store, with a new status:

```
Entry{
  EventID:        "evt-abc",
  SubscriptionID: PublishMarker,        // = "$publish" — synthetic, can't collide
  Status:         StatusPublished,      // new status value
  StartedAt:      <publish time>,
  CompletedAt:    <publish time>,
  EventName, BusID, BusName, TraceID, SpanID, ...
}
```

So all existing infrastructure works:
- `GetByEventID(evt)` returns publish + every subscriber entry — the diagnostic flow
- `List(Filter{Status: [StatusPublished]})` lists all publishes in a window
- The HTTP handler at `/v1/monitor/entries?status=published` works unchanged
- gRPC, pagination, filters, retention — all unchanged
- The same protobuf wire format is reused

No new store type, no new query interface, no new HTTP endpoints.

## What's added

- `event.PublishAuditStore` — minimal write-side interface (`RecordPublish`) called by `Bus.Send`
- `event.RecordPublishParams` — parameter struct
- `event.WithPublishAudit(store)` — bus option
- `monitor.StatusPublished` and `monitor.PublishMarker` constants
- `monitor.MemoryStore.RecordPublish` — writes a Status=published entry; same store, same map
- `stack.WithReliabilityStack` — when the configured monitor store satisfies `PublishAuditStore` (memory store does), the stack auto-wires it as the publish audit store too

## Behavior notes

- Recording is best-effort: errors from `RecordPublish` are dropped to keep `Send` non-blocking.
- Outbox-routed publishes are **not** recorded here; they bypass `transport.Publish` and are tracked by the outbox store until the relay delivers them. This is documented on `WithPublishAudit` and in the package comment.
- For implementations of `MonitorStore` that don't yet implement `PublishAuditStore` (e.g. existing PostgreSQL store, event-mongodb), the bus simply doesn't record publish entries until they're updated. No breaking change.

## Diagnostic flow

```
monitor.Get(event_id, monitor.PublishMarker)
  → nil      : never fired (app bug or outbox route)
  → present  : fired; correlate the other entries for the same event_id

monitor.GetByEventID(event_id)
  → [publish_entry, sub_a_entry, sub_b_entry, ...]
  → empty: never fired
  → only publish: fired but no subscriber processed yet (transport/lag issue)
  → publish + subs: fired and processed; check Status of each
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./...` — all 38 packages pass
- [x] `gofmt` clean for all touched files
- [x] New tests:
  - [x] `TestMemoryStore_RecordPublishCreatesEntry` — write + readback
  - [x] `TestMemoryStore_GetByEventIDIncludesPublishAndHandlers` — unified diagnostic flow
  - [x] `TestMemoryStore_FilterByStatusPublished` — existing Filter surface works
  - [x] `TestMemoryStore_RecordPublishOverwrites` — idempotent semantics
  - [x] Bus-side: records on success, no-op when nil, accessor returns store, no record on closed bus
  - [x] Stack: monitor store auto-wired as publish audit store