### PR TITLE
chore: bump Go to 1.26.3 and golangci-lint to 2.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.8.0
+          version: v2.11.4
           args: --tests=false
 
   codeql:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.25"
+go = "1.26.3"
 just = "latest"
 protoc = "29.3"
 "go:golang.org/x/vuln/cmd/govulncheck" = "latest"

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -342,7 +342,7 @@ func RequireNotNil(value any, name string) error {
 	// This handles cases like var db *sql.DB = nil
 	v := reflect.ValueOf(value)
 	kind := v.Kind()
-	if (kind == reflect.Ptr || kind == reflect.Interface ||
+	if (kind == reflect.Pointer || kind == reflect.Interface ||
 		kind == reflect.Map || kind == reflect.Slice ||
 		kind == reflect.Chan || kind == reflect.Func) && v.IsNil() {
 		return fmt.Errorf("%s must not be nil: %w", name, ErrInvalidArgument)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rbaliyan/event/v3
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20250520111509-a70c2aa677fa


### PR DESCRIPTION
## Summary
- Bump `go.mod` from `1.25.9` to `1.26.3` to address Go 1.25 vulnerabilities (and GO-2026-4971 fixed in 1.26.3)
- Bump `.mise.toml` Go from `1.25` → `1.26.3`
- Bump `golangci-lint-action` `version: v2.8.0` → `v2.11.4` in `.github/workflows/ci.yml` (Go 1.26 compatible)
- Replace `reflect.Ptr` with `reflect.Pointer` in `errors/errors.go` to satisfy the new `govet inline` check in golangci-lint 2.11.4 (`reflect.Ptr` is the legacy alias)

CI workflows already pin Go via `go-version-file: go.mod`.

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run --tests=false` passes (0 issues)
- [x] `go test -race ./...` passes (all 38 packages)
- [x] `govulncheck ./...` reports no vulnerabilities
- [ ] CI green (non-fuzz)