### PR TITLE
fix(transport): broadcast no longer replays retained stream on restart

### DIFF
--- a/option.go
+++ b/option.go
@@ -442,6 +442,16 @@ func AsWorker[T any]() SubscribeOption[T] {
 // AsBroadcast configures the subscription for Broadcast delivery mode.
 // All subscribers receive every message. This is the default mode.
 //
+// Restart-safety note for distributed transports (Redis Streams, Kafka,
+// NATS JetStream): broadcast subscribers are implemented with a fresh
+// per-Subscribe consumer group, which means the group has no continuity
+// across pod restarts and there is no automatic recovery of pending
+// (unacked) messages. Long-lived services that need broadcast semantics
+// AND restart resilience should use AsWorker + WithWorkerGroup(stableID)
+// with stableID stable per replica (e.g. the pod IP or hostname): each
+// stable group still receives every message, and the offset/PEL survive
+// restarts.
+//
 // Example:
 //
 //	orderEvent.Subscribe(ctx, handler, event.AsBroadcast[Order]())

--- a/transport/kafka/kafka.go
+++ b/transport/kafka/kafka.go
@@ -270,7 +270,13 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 			groupID = t.groupID + "-" + name
 		}
 	} else {
-		// Broadcast: unique group per subscriber (fan-out)
+		// Broadcast: unique group per subscriber (fan-out).
+		// The random group has no continuity across pod restarts: with
+		// sarama.Config.Consumer.Offsets.Initial set to OffsetOldest the
+		// restarted subscriber will replay the full retained log. Callers
+		// should either set Consumer.Offsets.Initial = sarama.OffsetNewest
+		// or use AsWorker + WithWorkerGroup(stableID) for a durable group
+		// whose committed offset survives restarts.
 		groupID = t.groupID + "-" + name + "-" + transport.NewID()
 	}
 

--- a/transport/nats/nats.go
+++ b/transport/nats/nats.go
@@ -291,10 +291,21 @@ func (t *JetStreamTransport) Subscribe(ctx context.Context, name string, opts ..
 			DeliverPolicy: deliverPolicy,
 		}
 	} else {
-		// Broadcast: ephemeral consumer per subscriber (fan-out)
+		// Broadcast: ephemeral consumer per subscriber (fan-out).
+		//
+		// Ephemeral consumers have no continuity across restarts, so the
+		// default StartFromBeginning (DeliverAllPolicy) would cause every
+		// reconnect to replay the full retained stream — a large fan-out of
+		// stale events. Default to DeliverNewPolicy; callers that need
+		// broadcast-with-replay should use a durable consumer via
+		// AsWorker + WithWorkerGroup so the offset survives restarts.
+		bcastPolicy := deliverPolicy
+		if subOpts.StartFrom == transport.StartFromBeginning {
+			bcastPolicy = jetstream.DeliverNewPolicy
+		}
 		consumerConfig = jetstream.ConsumerConfig{
 			AckPolicy:     jetstream.AckExplicitPolicy,
-			DeliverPolicy: deliverPolicy,
+			DeliverPolicy: bcastPolicy,
 		}
 	}
 

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -271,16 +271,6 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 	streamName := t.streamName(name)
 	subID := transport.NewID()
 
-	// Determine start position for Redis stream
-	// "0" = from beginning, "$" = from latest (new messages only)
-	startID := "0"
-	if subOpts.StartFrom == transport.StartFromLatest {
-		startID = "$"
-	} else if subOpts.StartFrom == transport.StartFromTimestamp && !subOpts.StartTime.IsZero() {
-		// Redis stream IDs are millisecond timestamps
-		startID = fmt.Sprintf("%d-0", subOpts.StartTime.UnixMilli())
-	}
-
 	var groupID string
 	var needsGroupCreate bool
 	if subOpts.DeliveryMode == transport.WorkerPool {
@@ -297,6 +287,28 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 		// Broadcast: unique consumer group per subscriber (fan-out)
 		groupID = t.groupID + "-" + subID
 		needsGroupCreate = true
+	}
+
+	// Determine start position for Redis stream.
+	//   "0" = read from the earliest message currently in the stream
+	//   "$" = read only messages added after the group is created
+	//
+	// Broadcast subscribers mint a random consumer group per Subscribe call;
+	// the group has no continuity across pod restarts. With startID="0" a
+	// restarted broadcast subscriber would replay every retained message on
+	// the stream — typically a large fan-out of stale events. Broadcast
+	// subscribers therefore default to "$"; callers needing replay semantics
+	// should use a stable group via AsWorker + WithWorkerGroup so the offset
+	// survives restarts.
+	startID := "0"
+	if subOpts.DeliveryMode == transport.Broadcast {
+		startID = "$"
+	}
+	if subOpts.StartFrom == transport.StartFromLatest {
+		startID = "$"
+	} else if subOpts.StartFrom == transport.StartFromTimestamp && !subOpts.StartTime.IsZero() {
+		// Redis stream IDs are millisecond timestamps
+		startID = fmt.Sprintf("%d-0", subOpts.StartTime.UnixMilli())
 	}
 
 	// Create consumer group if needed (named worker groups or broadcast)

--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -443,6 +443,82 @@ func TestTransportSubscribe(t *testing.T) {
 		}
 	})
 
+	t.Run("broadcast mode starts at latest to avoid restart replay", func(t *testing.T) {
+		// Broadcast subscribers mint a fresh per-Subscribe group, so a default
+		// startID of "0" would replay the retained stream on every restart.
+		// They must be created with startID="$".
+		mock := newMockRedisClient()
+		tr2, _ := New(mock)
+		defer tr2.Close(context.Background())
+
+		tr2.RegisterEvent(ctx, "broadcast-startid")
+		sub, _ := tr2.Subscribe(ctx, "broadcast-startid")
+		defer sub.Close(context.Background())
+
+		rs := sub.(*subscription)
+		mock.mu.Lock()
+		got := mock.groups[rs.stream][rs.group]
+		mock.mu.Unlock()
+		if got != "$" {
+			t.Errorf("expected broadcast group to be created at $, got %q", got)
+		}
+	})
+
+	t.Run("worker pool with stable group starts from beginning", func(t *testing.T) {
+		// Stable worker groups survive restarts via BUSYGROUP, so it is safe
+		// (and useful) to read from the beginning on first creation.
+		mock := newMockRedisClient()
+		tr2, _ := New(mock)
+		defer tr2.Close(context.Background())
+
+		tr2.RegisterEvent(ctx, "worker-startid")
+		sub, _ := tr2.Subscribe(ctx, "worker-startid",
+			transport.WithDeliveryMode(transport.WorkerPool),
+			transport.WithWorkerGroup("g1"))
+		defer sub.Close(context.Background())
+
+		rs := sub.(*subscription)
+		mock.mu.Lock()
+		got := mock.groups[rs.stream][rs.group]
+		mock.mu.Unlock()
+		if got != "0" {
+			t.Errorf("expected worker-group to be created at 0, got %q", got)
+		}
+	})
+
+	t.Run("broadcast honours explicit StartFromLatest and timestamp", func(t *testing.T) {
+		mock := newMockRedisClient()
+		tr2, _ := New(mock)
+		defer tr2.Close(context.Background())
+
+		tr2.RegisterEvent(ctx, "broadcast-explicit")
+
+		subLatest, _ := tr2.Subscribe(ctx, "broadcast-explicit",
+			transport.WithStartFrom(transport.StartFromLatest))
+		defer subLatest.Close(context.Background())
+
+		ts := time.Now().Add(-1 * time.Hour)
+		subTime, _ := tr2.Subscribe(ctx, "broadcast-explicit",
+			transport.WithStartFrom(transport.StartFromTimestamp),
+			transport.WithStartTime(ts))
+		defer subTime.Close(context.Background())
+
+		rsLatest := subLatest.(*subscription)
+		rsTime := subTime.(*subscription)
+		mock.mu.Lock()
+		gotLatest := mock.groups[rsLatest.stream][rsLatest.group]
+		gotTime := mock.groups[rsTime.stream][rsTime.group]
+		mock.mu.Unlock()
+
+		if gotLatest != "$" {
+			t.Errorf("StartFromLatest: expected $, got %q", gotLatest)
+		}
+		wantTime := fmt.Sprintf("%d-0", ts.UnixMilli())
+		if gotTime != wantTime {
+			t.Errorf("StartFromTimestamp: expected %q, got %q", wantTime, gotTime)
+		}
+	})
+
 	t.Run("worker groups use separate consumer groups", func(t *testing.T) {
 		tr2, _ := New(newMockRedisClient(), WithConsumerGroup("test-bus"))
 		defer tr2.Close(context.Background())

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -185,6 +185,13 @@ type StartPosition int
 const (
 	// StartFromBeginning processes all available historical messages.
 	// Use this for event sourcing or when you need complete history.
+	//
+	// For Broadcast subscribers on the Redis transport this position is
+	// ignored: broadcast groups are minted fresh per Subscribe and have no
+	// continuity across restarts, so reading "from the beginning of what is
+	// currently retained" would replay the entire retained window on every
+	// restart. Broadcast subscribers always effectively start at the latest
+	// offset; use WorkerPool + WithWorkerGroup for replay semantics.
 	StartFromBeginning StartPosition = iota
 
 	// StartFromLatest only receives messages published after subscription.


### PR DESCRIPTION
## Summary

Broadcast subscribers on Redis Streams and NATS JetStream mint a fresh consumer group / ephemeral consumer per `Subscribe` call. The previous defaults (Redis `startID=\"0\"`, JetStream `DeliverAllPolicy`) meant a restarted broadcast subscriber would replay every retained message on the stream — operationally severe for non-idempotent handlers, since each pod restart re-invokes the handler for every event still inside the retention window.

This PR makes broadcast subscribers default to *from now on*:

- **Redis**: `startID=\"$\"` when `DeliveryMode == Broadcast` (was `\"0\"` unless `StartFromLatest`/`StartFromTimestamp` were set explicitly).
- **NATS JetStream**: `DeliverNewPolicy` for ephemeral broadcast consumers when `StartFrom` is the zero value (was `DeliverAllPolicy`).

Explicit `StartFromLatest` and `StartFromTimestamp` still work unchanged in both transports.

Callers that need broadcast-with-replay semantics should switch to `AsWorker + WithWorkerGroup(stableID)`: different worker groups each receive every message (the same broadcast semantic) while their offset and PEL survive restarts via the durable group / `BUSYGROUP` reattach path. `AsBroadcast` and `StartFromBeginning` docstrings updated to point users at this alternative.

Kafka carries the same restart-replay shape but the library does not own `sarama.Config.Consumer.Offsets.Initial` — the caller does. `kafka.go` now documents this at the broadcast group construction site, recommending `OffsetNewest` or a stable worker group.

## Breaking change

Broadcast subscribers that relied on the previous \"default `StartFrom` replays retained messages on Subscribe\" behaviour will now start reading from new messages only. Set `WithStartFrom(StartFromTimestamp)` with an explicit anchor if the historical replay was intentional, or migrate to `AsWorker + WithWorkerGroup` for restart-safe replay.

Public API surface is unchanged — function signatures and exported types are untouched.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New subtests in `transport/redis/redis_test.go`:
  - broadcast group is created at `\"$\"`
  - named worker group is still created at `\"0\"`
  - explicit `StartFromLatest` / `StartFromTimestamp` continue to honour their semantics in broadcast mode
- [ ] Manual smoke test on a real Redis: publish into a stream with retention, restart a broadcast subscriber, confirm no replay
- [ ] Manual smoke test on a real NATS JetStream: same scenario with an ephemeral consumer