### PR TITLE
feat(transport/redis): WithAutoRecreateGroup for NOGROUP self-healing

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,31 @@ When open, `Publish` returns `transport.ErrCircuitOpen` immediately instead of b
 
 The `CircuitBreaker` struct in the `transport` package is reusable and can be embedded by any transport implementation.
 
+### Auto-Recreate Consumer Group (Redis)
+
+Recover from `NOGROUP` errors when the consumer group (or its stream) disappears — Redis restart without persistence, `FLUSHDB`, manual `DEL`, failover to an empty replica, eviction under `maxmemory`. Without this option the consume loop spins with exponential backoff and never recovers without a process restart.
+
+```go
+transport, _ := redis.New(rdb,
+    // Enable per-mode. Broadcast is low blast radius (per-Subscribe throwaway
+    // group). WorkerPool is high blast radius (shared cluster-wide PEL is
+    // dropped on recreate) — opt in only when at-least-once gaps across Redis
+    // state loss are acceptable.
+    redis.WithAutoRecreateGroup(redis.RecreateBroadcast | redis.RecreateWorkerPool),
+
+    // Optional: observe recreate events (wire a metric counter or alert here).
+    redis.WithRecreateHandler(func(stream, group string, mode redis.RecreateMode) {
+        recreatesTotal.WithLabelValues(stream, group, mode.String()).Inc()
+    }),
+)
+```
+
+On `NOGROUP`, the group is recreated with `XGroupCreateMkStream` at the subscription's original start position (`$` for broadcast / `StartFromLatest`, `0` for worker-pool / `StartFromBeginning`, or the resolved Redis message ID for `StartFromTimestamp`). A `Warn`-level `consumer group recreated after NOGROUP` log is emitted on each recreate. Repeated recreate→`NOGROUP` cycles fall into exponential backoff so a flapping group does not hot-loop.
+
+The destroyed group's Pending Entries List is unrecoverable — at-least-once delivery is best-effort across Redis state loss. Messages published in the gap between destruction and recreate are not delivered to a broadcast subscription started at `$`.
+
+Disabled by default (`RecreateMode(0)`).
+
 ### Transport Migration
 
 Bridge an old and new transport during a migration with zero message loss:

--- a/transport/redis/options.go
+++ b/transport/redis/options.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -10,6 +11,93 @@ import (
 
 // Option configures the Redis transport
 type Option func(*Transport)
+
+// RecreateMode is a bitmask selecting which delivery modes auto-recover from
+// NOGROUP errors. See WithAutoRecreateGroup for details.
+type RecreateMode uint8
+
+const (
+	// RecreateBroadcast enables auto-recreate for broadcast subscriptions
+	// (per-Subscribe throwaway consumer groups). Low blast radius — broadcast
+	// groups have no continuity across pod restarts, so losing the Pending
+	// Entries List is moot.
+	RecreateBroadcast RecreateMode = 1 << iota
+
+	// RecreateWorkerPool enables auto-recreate for worker-pool subscriptions
+	// (shared consumer groups). High blast radius — recreating drops the
+	// entire group's Pending Entries List, so every worker in the cluster
+	// loses its in-flight messages. Opt in deliberately and only when
+	// at-least-once gaps across Redis state loss are acceptable.
+	RecreateWorkerPool
+
+	// RecreateAll is a shorthand combining both modes.
+	RecreateAll = RecreateBroadcast | RecreateWorkerPool
+)
+
+// String returns a human-readable representation of the mode bitmask. Used
+// for structured logging. The zero value returns "none"; unknown bits are
+// rendered as a hex literal (e.g. "RecreateMode(0x80)") so future flags
+// surface as raw bits if a case clause is not added.
+func (m RecreateMode) String() string {
+	switch m {
+	case 0:
+		return "none"
+	case RecreateBroadcast:
+		return "broadcast"
+	case RecreateWorkerPool:
+		return "worker_pool"
+	case RecreateAll:
+		return "all"
+	default:
+		return fmt.Sprintf("RecreateMode(0x%x)", uint8(m))
+	}
+}
+
+// WithAutoRecreateGroup enables automatic recovery from NOGROUP errors on
+// XREADGROUP. When a consumer group (or its stream) is missing — Redis
+// restart without persistence, FLUSHDB, manual DEL, failover to an empty
+// replica, eviction under maxmemory — the consume loop normally spins with
+// exponential backoff and never recovers without a process restart.
+//
+// With this option set, the group is recreated via XGroupCreateMkStream using
+// the subscription's original start position ($ for broadcast/latest, 0 for
+// worker-pool/beginning, or the originally-resolved Redis message ID
+// "<ms>-<seq>" for StartFromTimestamp).
+// A Warn-level "consumer group recreated after NOGROUP" log is emitted on
+// each successful recreate. If a WithRecreateHandler is configured, it is
+// invoked as well — wire it to a metric counter for alerting.
+//
+// The Pending Entries List of the destroyed group is unrecoverable —
+// at-least-once is best-effort across Redis state loss. Worker-pool groups
+// in particular are shared cluster-wide, so enabling RecreateWorkerPool
+// means every worker loses its in-flight PEL when the group is recreated.
+//
+// Messages published between the moment the group was destroyed and the
+// moment this consumer recreates it are not delivered to this subscription
+// when the original start position was "$" (broadcast / StartFromLatest).
+// For worker-pool subscriptions started from "0", any messages still in the
+// stream are replayed from the beginning of the retained window.
+//
+// The two modes are independent so callers can enable broadcast recovery
+// (low blast radius) without opting into worker-pool recovery (high blast
+// radius). Disabled by default (zero RecreateMode = no recreation).
+func WithAutoRecreateGroup(mode RecreateMode) Option {
+	return func(t *Transport) {
+		t.autoRecreate = mode
+	}
+}
+
+// WithRecreateHandler sets a callback invoked after each successful auto
+// recreate triggered by WithAutoRecreateGroup. Use this to plumb a metric
+// counter or alert. The callback runs on the consume goroutine and should
+// be non-blocking.
+func WithRecreateHandler(fn func(stream, group string, mode RecreateMode)) Option {
+	return func(t *Transport) {
+		if fn != nil {
+			t.onRecreate = fn
+		}
+	}
+}
 
 // WithCodec sets the codec for message serialization
 func WithCodec(c codec.Codec) Option {
@@ -140,4 +228,3 @@ func WithCircuitBreaker(threshold int, cooldown time.Duration) Option {
 		}
 	}
 }
-

--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -65,16 +65,18 @@ type Transport struct {
 	onError func(error)
 
 	// Stream configuration
-	streamPrefix  string
-	maxLen        int64         // Max stream length (0 = unlimited)
-	maxAge        time.Duration // Max message age for MINID trimming (0 = unlimited)
-	blockTime     time.Duration
-	sendTimeout   time.Duration // Timeout for sending to subscriber channel (backpressure)
-	claimInterval  time.Duration // Interval for claiming orphaned messages (0 = disabled)
-	claimMinIdle   time.Duration // Minimum idle time before claiming a message
-	claimBatchSize int64         // Max messages to claim per cycle (default 100)
+	streamPrefix   string
+	maxLen         int64         // Max stream length (0 = unlimited)
+	maxAge         time.Duration // Max message age for MINID trimming (0 = unlimited)
+	blockTime      time.Duration
+	sendTimeout    time.Duration             // Timeout for sending to subscriber channel (backpressure)
+	claimInterval  time.Duration             // Interval for claiming orphaned messages (0 = disabled)
+	claimMinIdle   time.Duration             // Minimum idle time before claiming a message
+	claimBatchSize int64                     // Max messages to claim per cycle (default 100)
 	cb             *transport.CircuitBreaker // Publish circuit breaker (nil = disabled)
 
+	autoRecreate RecreateMode                                  // Bitmask: which modes auto-recover from NOGROUP
+	onRecreate   func(stream, group string, mode RecreateMode) // Observability hook for recreate events
 }
 
 // redisEvent tracks event-specific state
@@ -96,7 +98,7 @@ type subscription struct {
 	claimMinIdle       time.Duration // Minimum idle time before claiming
 	claimBatchSize     int64         // Max messages to claim per cycle
 	isBroadcast        bool          // If true, consumer group is deleted on close
-
+	startID            string        // Original start position (used for NOGROUP recovery)
 }
 
 // Default configuration
@@ -349,6 +351,7 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 		claimMinIdle:   t.claimMinIdle,
 		claimBatchSize: t.claimBatchSize,
 		isBroadcast:    subOpts.DeliveryMode == transport.Broadcast,
+		startID:        startID,
 	}
 
 	// Start consuming in background with WaitGroup tracking
@@ -537,6 +540,44 @@ func (t *Transport) ConsumerLag(ctx context.Context) ([]transport.ConsumerLag, e
 	return lags, nil
 }
 
+// isNoGroupErr reports whether err is a Redis NOGROUP error (consumer group
+// or its stream missing). go-redis v9 surfaces server replies as untyped
+// proto.Error whose Error() string is the raw "NOGROUP <message>" payload,
+// so prefix matching is the canonical detection — errors.Is is not available
+// for this case. If go-redis exposes a typed sentinel in a future release,
+// switch to it.
+func isNoGroupErr(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "NOGROUP ")
+}
+
+// tryRecreateGroup attempts to recreate the subscription's consumer group at
+// its original start position. Returns true if the caller should retry the
+// read loop without backoff; false to fall through to the existing error log
+// and backoff path (recreate disabled for this mode, or recreate failed).
+func (t *Transport) tryRecreateGroup(ctx context.Context, s *subscription, logger *slog.Logger) bool {
+	mode := RecreateWorkerPool
+	if s.isBroadcast {
+		mode = RecreateBroadcast
+	}
+	if t.autoRecreate&mode == 0 {
+		return false
+	}
+
+	err := t.client.XGroupCreateMkStream(ctx, s.stream, s.group, s.startID).Err()
+	if err != nil && !strings.HasPrefix(err.Error(), "BUSYGROUP") {
+		logger.Warn("failed to recreate consumer group after NOGROUP",
+			"stream", s.stream, "group", s.group, "start_id", s.startID, "error", err)
+		return false
+	}
+
+	logger.Warn("consumer group recreated after NOGROUP",
+		"stream", s.stream, "group", s.group, "start_id", s.startID, "mode", mode)
+	if t.onRecreate != nil {
+		t.onRecreate(s.stream, s.group, mode)
+	}
+	return true
+}
+
 // subscription methods
 
 func (s *subscription) Close(ctx context.Context) error {
@@ -679,6 +720,31 @@ func (s *subscription) consumeLoop(ctx context.Context, blockTime time.Duration,
 			case <-ctx.Done():
 				return
 			default:
+			}
+			// NOGROUP recovery: the consumer group (or its stream) has vanished
+			// outside this process — Redis restart without persistence, FLUSHDB,
+			// failover to an empty replica, manual DEL, eviction. Recreate the
+			// group at the subscription's original start position if the operator
+			// opted in for this delivery mode.
+			//
+			// On successful recreate, apply the current backoff (and escalate it)
+			// before retrying so a flapping group — recreate → NOGROUP → recreate
+			// in a tight loop — falls into exponential backoff rather than hot-
+			// looping at full CPU. A subsequent successful read resets backoff.
+			if isNoGroupErr(err) && s.transport.tryRecreateGroup(ctx, s, logger) {
+				jitteredBackoff := transport.Jitter(readBackoff, 0.3)
+				select {
+				case <-s.ClosedCh():
+					return
+				case <-ctx.Done():
+					return
+				case <-time.After(jitteredBackoff):
+				}
+				readBackoff *= 2
+				if readBackoff > maxReadBackoff {
+					readBackoff = maxReadBackoff
+				}
+				continue
 			}
 			jitteredBackoff := transport.Jitter(readBackoff, 0.3)
 			logger.Error("read error, retrying with backoff", "error", err, "backoff", jitteredBackoff)

--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -37,6 +37,11 @@ type mockRedisClient struct {
 	xreadgroupActive              int32 // count of in-flight blocking XReadGroup calls (atomic)
 	destroyCalledWithActiveReader atomic.Bool
 	destroyCh                     map[string]chan struct{} // stream|group -> close on destroy
+
+	// xgroupCreateErr, when non-nil, is returned from XGroupCreateMkStream
+	// instead of creating the group. Used to exercise the recreate-fails
+	// fallback path.
+	xgroupCreateErr error
 }
 
 func newMockRedisClient() *mockRedisClient {
@@ -99,6 +104,10 @@ func (m *mockRedisClient) XGroupCreateMkStream(ctx context.Context, stream, grou
 	defer m.mu.Unlock()
 
 	cmd := redis.NewStatusCmd(ctx)
+	if m.xgroupCreateErr != nil {
+		cmd.SetErr(m.xgroupCreateErr)
+		return cmd
+	}
 	if m.groups[stream] == nil {
 		m.groups[stream] = make(map[string]string)
 	}
@@ -122,6 +131,16 @@ func (m *mockRedisClient) XReadGroup(ctx context.Context, a *redis.XReadGroupArg
 	}
 
 	stream := a.Streams[0]
+
+	// Real Redis returns NOGROUP immediately (regardless of BLOCK) if the
+	// group doesn't exist on the stream. Mimic that so tests can drive
+	// recovery paths by destroying groups out-of-band.
+	if _, ok := m.groups[stream][a.Group]; !ok {
+		m.mu.Unlock()
+		cmd.SetErr(errors.New("NOGROUP No such key '" + stream + "' or consumer group '" + a.Group + "' in XREADGROUP with GROUP option"))
+		return cmd
+	}
+
 	messages := m.streams[stream]
 
 	if len(messages) > 0 {
@@ -133,14 +152,15 @@ func (m *mockRedisClient) XReadGroup(ctx context.Context, a *redis.XReadGroupArg
 		return cmd
 	}
 
-	if !m.blockReadGroup {
+	// Block only if the caller asked for it AND the mock is configured to
+	// simulate parking. Non-blocking reads (Block <= 0) match Redis's
+	// non-blocking semantics and return redis.Nil for an empty stream.
+	if a.Block <= 0 || !m.blockReadGroup {
 		m.mu.Unlock()
 		cmd.SetErr(redis.Nil)
 		return cmd
 	}
 
-	// Blocking mode: park until ctx is canceled or the group is destroyed. This
-	// mirrors a real Redis BLOCK XREADGROUP that sits idle on a connection.
 	destroyCh := m.destroyChannel(stream, a.Group)
 	m.mu.Unlock()
 
@@ -775,8 +795,8 @@ func TestBroadcastCloseDoesNotRaceWithConsumeLoop(t *testing.T) {
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	tr, err := New(client, WithLogger(logger))
 	if err != nil {
@@ -816,5 +836,448 @@ func TestBroadcastCloseDoesNotRaceWithConsumeLoop(t *testing.T) {
 	}
 	if strings.Contains(logBuf.String(), "NOGROUP") {
 		t.Errorf("unexpected NOGROUP log during shutdown:\n%s", logBuf.String())
+	}
+}
+
+// safeBuffer is a sync-safe wrapper around bytes.Buffer for capturing slog
+// output from goroutines that race with test assertions.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForActiveReader polls until the mock has at least one in-flight blocking
+// XReadGroup, or fails the test on timeout.
+func waitForActiveReader(t *testing.T, m *mockRedisClient) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&m.xreadgroupActive) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("consume goroutine never entered blocking XReadGroup")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// pickBlockedGroup returns the group name that currently has a blocked
+// XReadGroup waiting on the given stream. Only the consume goroutine of the
+// subscription under test parks in blocking mode, so this targets the right
+// group even when the base groupID is also registered on the stream.
+func pickBlockedGroup(t *testing.T, m *mockRedisClient, stream string) string {
+	t.Helper()
+	prefix := stream + "|"
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k := range m.destroyCh {
+		if strings.HasPrefix(k, prefix) {
+			return strings.TrimPrefix(k, prefix)
+		}
+	}
+	t.Fatalf("no blocked reader on stream %q (groups: %v)", stream, m.groups[stream])
+	return ""
+}
+
+func TestAutoRecreateGroup_BroadcastRecoversFromNoGroup(t *testing.T) {
+	client := newMockRedisClient()
+	client.blockReadGroup = true
+
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var recreateCount atomic.Int32
+	var recreateMode atomic.Int32
+	tr, err := New(client,
+		WithLogger(logger),
+		WithAutoRecreateGroup(RecreateBroadcast),
+		WithRecreateHandler(func(_, _ string, mode RecreateMode) {
+			recreateCount.Add(1)
+			recreateMode.Store(int32(mode))
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+	sub, err := tr.Subscribe(ctx, "evt") // broadcast (default)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	waitForActiveReader(t, client)
+
+	streamName := "evt:evt"
+	groupName := pickBlockedGroup(t, client, streamName)
+
+	// Simulate Redis losing the group.
+	client.XGroupDestroy(context.Background(), streamName, groupName)
+
+	// Wait for the recreate callback to fire.
+	deadline := time.Now().Add(2 * time.Second)
+	for recreateCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("recreate handler never fired; logs:\n%s", logBuf.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if got := RecreateMode(recreateMode.Load()); got != RecreateBroadcast {
+		t.Errorf("recreate handler mode = %v, want %v", got, RecreateBroadcast)
+	}
+
+	// Group should be back.
+	client.mu.Lock()
+	_, exists := client.groups[streamName][groupName]
+	client.mu.Unlock()
+	if !exists {
+		t.Errorf("group %q not recreated on stream %q", groupName, streamName)
+	}
+
+	if strings.Contains(logBuf.String(), "read error, retrying with backoff") {
+		t.Errorf("unexpected error log after NOGROUP recovery:\n%s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "consumer group recreated after NOGROUP") {
+		t.Errorf("expected warn log on recreate; got:\n%s", logBuf.String())
+	}
+}
+
+func TestAutoRecreateGroup_WorkerPoolRecoversFromNoGroup(t *testing.T) {
+	client := newMockRedisClient()
+	client.blockReadGroup = true
+
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var recreateCount atomic.Int32
+	var recreateMode atomic.Int32
+	tr, err := New(client,
+		WithLogger(logger),
+		WithAutoRecreateGroup(RecreateWorkerPool),
+		WithRecreateHandler(func(_, _ string, mode RecreateMode) {
+			recreateCount.Add(1)
+			recreateMode.Store(int32(mode))
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+	sub, err := tr.Subscribe(ctx, "evt",
+		transport.WithDeliveryMode(transport.WorkerPool),
+		transport.WithWorkerGroup("g1"),
+	)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	waitForActiveReader(t, client)
+
+	streamName := "evt:evt"
+	groupName := pickBlockedGroup(t, client, streamName)
+
+	client.XGroupDestroy(context.Background(), streamName, groupName)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for recreateCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("recreate handler never fired; logs:\n%s", logBuf.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if got := RecreateMode(recreateMode.Load()); got != RecreateWorkerPool {
+		t.Errorf("recreate handler mode = %v, want %v", got, RecreateWorkerPool)
+	}
+
+	client.mu.Lock()
+	_, exists := client.groups[streamName][groupName]
+	client.mu.Unlock()
+	if !exists {
+		t.Errorf("worker group %q not recreated", groupName)
+	}
+}
+
+func TestAutoRecreateGroup_DisabledLeavesErrorLog(t *testing.T) {
+	client := newMockRedisClient()
+	client.blockReadGroup = true
+
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var recreateCount atomic.Int32
+	tr, err := New(client,
+		WithLogger(logger),
+		// No WithAutoRecreateGroup — default is zero (no recreation).
+		WithRecreateHandler(func(_, _ string, _ RecreateMode) {
+			recreateCount.Add(1)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+	sub, err := tr.Subscribe(ctx, "evt")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	waitForActiveReader(t, client)
+
+	streamName := "evt:evt"
+	groupName := pickBlockedGroup(t, client, streamName)
+
+	client.XGroupDestroy(context.Background(), streamName, groupName)
+
+	// Wait for the existing error-log + backoff path to log.
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(logBuf.String(), "read error, retrying with backoff") {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected error log never appeared; logs:\n%s", logBuf.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if recreateCount.Load() != 0 {
+		t.Errorf("recreate handler fired %d times with auto-recreate disabled", recreateCount.Load())
+	}
+
+	client.mu.Lock()
+	_, exists := client.groups[streamName][groupName]
+	client.mu.Unlock()
+	if exists {
+		t.Errorf("group %q was unexpectedly recreated with auto-recreate disabled", groupName)
+	}
+}
+
+func TestAutoRecreateGroup_WrongModeLeavesErrorLog(t *testing.T) {
+	// Worker-pool subscription, but only RecreateBroadcast is enabled. Recovery
+	// must NOT fire for the worker subscription.
+	client := newMockRedisClient()
+	client.blockReadGroup = true
+
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var recreateCount atomic.Int32
+	tr, err := New(client,
+		WithLogger(logger),
+		WithAutoRecreateGroup(RecreateBroadcast), // mismatch
+		WithRecreateHandler(func(_, _ string, _ RecreateMode) {
+			recreateCount.Add(1)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+	sub, err := tr.Subscribe(ctx, "evt",
+		transport.WithDeliveryMode(transport.WorkerPool),
+		transport.WithWorkerGroup("g1"),
+	)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	waitForActiveReader(t, client)
+
+	streamName := "evt:evt"
+	groupName := pickBlockedGroup(t, client, streamName)
+
+	client.XGroupDestroy(context.Background(), streamName, groupName)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(logBuf.String(), "read error, retrying with backoff") {
+		if time.Now().After(deadline) {
+			t.Fatalf("expected error log never appeared; logs:\n%s", logBuf.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if recreateCount.Load() != 0 {
+		t.Errorf("recreate fired with mismatched mode (got count=%d)", recreateCount.Load())
+	}
+}
+
+func TestRecreateMode_String(t *testing.T) {
+	cases := []struct {
+		mode RecreateMode
+		want string
+	}{
+		{0, "none"},
+		{RecreateBroadcast, "broadcast"},
+		{RecreateWorkerPool, "worker_pool"},
+		{RecreateAll, "all"},
+		{RecreateMode(0x80), "RecreateMode(0x80)"},
+	}
+	for _, c := range cases {
+		if got := c.mode.String(); got != c.want {
+			t.Errorf("RecreateMode(%d).String() = %q, want %q", c.mode, got, c.want)
+		}
+	}
+}
+
+// TestAutoRecreateGroup_RecreateFailsFallsBack verifies that when
+// XGroupCreateMkStream returns a non-BUSYGROUP error (e.g., Redis still
+// unreachable), the consume loop falls through to the existing error log +
+// exponential backoff path and the recreate handler is NOT invoked.
+func TestAutoRecreateGroup_RecreateFailsFallsBack(t *testing.T) {
+	client := newMockRedisClient()
+	client.blockReadGroup = true
+
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var recreateCount atomic.Int32
+	tr, err := New(client,
+		WithLogger(logger),
+		WithAutoRecreateGroup(RecreateBroadcast),
+		WithRecreateHandler(func(_, _ string, _ RecreateMode) {
+			recreateCount.Add(1)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+	sub, err := tr.Subscribe(ctx, "evt")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	waitForActiveReader(t, client)
+
+	streamName := "evt:evt"
+	groupName := pickBlockedGroup(t, client, streamName)
+
+	// Arm the mock so the recreate attempt fails with a non-BUSYGROUP error.
+	client.mu.Lock()
+	client.xgroupCreateErr = errors.New("ERR connection lost")
+	client.mu.Unlock()
+
+	client.XGroupDestroy(context.Background(), streamName, groupName)
+
+	// Wait for both the recreate-failure Warn and the fall-through ERROR log.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		s := logBuf.String()
+		if strings.Contains(s, "failed to recreate consumer group after NOGROUP") &&
+			strings.Contains(s, "read error, retrying with backoff") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected failure + fall-through logs never both appeared; logs:\n%s", s)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if recreateCount.Load() != 0 {
+		t.Errorf("recreate handler fired %d times despite recreate failure", recreateCount.Load())
+	}
+}
+
+// TestAutoRecreateGroup_BusyGroupTreatedAsSuccess verifies that a concurrent
+// sibling who already recreated the group (yielding BUSYGROUP on our retry)
+// is treated as success rather than a hard failure.
+func TestAutoRecreateGroup_BusyGroupTreatedAsSuccess(t *testing.T) {
+	client := newMockRedisClient()
+	client.blockReadGroup = true
+
+	logBuf := &safeBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var recreateCount atomic.Int32
+	tr, err := New(client,
+		WithLogger(logger),
+		WithAutoRecreateGroup(RecreateBroadcast),
+		WithRecreateHandler(func(_, _ string, _ RecreateMode) {
+			recreateCount.Add(1)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+	sub, err := tr.Subscribe(ctx, "evt")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	waitForActiveReader(t, client)
+
+	streamName := "evt:evt"
+	groupName := pickBlockedGroup(t, client, streamName)
+
+	// Simulate the destroy + sibling-recreate race: the group is gone (so
+	// XReadGroup returns NOGROUP), then a concurrent peer recreates it before
+	// our XGroupCreateMkStream lands. We model this by having the destroy
+	// channel close but the group entry remain present in m.groups, so the
+	// mock returns BUSYGROUP from XGroupCreateMkStream.
+	client.mu.Lock()
+	// Close the destroy channel manually to wake the blocked XReadGroup with
+	// NOGROUP semantics, but leave the group registered so XReadGroup will
+	// also re-find it on retry (group "still there" from our POV).
+	if ch, ok := client.destroyCh[destroyKey(streamName, groupName)]; ok {
+		close(ch)
+		delete(client.destroyCh, destroyKey(streamName, groupName))
+	}
+	client.mu.Unlock()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for recreateCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("recreate handler never fired (BUSYGROUP not treated as success); logs:\n%s", logBuf.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if strings.Contains(logBuf.String(), "failed to recreate consumer group") {
+		t.Errorf("BUSYGROUP was incorrectly treated as failure; logs:\n%s", logBuf.String())
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #118 (v3.17.2), which fixed the shutdown teardown race that produced `NOGROUP` errors but explicitly deferred steady-state recovery. This PR adds the deferred behavior, opt-in, with independent control per delivery mode.

When a Redis consumer group (or its stream) disappears outside the consumer process — restart without persistence, `FLUSHDB`, manual `DEL`, failover to an empty replica, eviction under `maxmemory` — `XREADGROUP` returns `NOGROUP` forever. The existing exponential-backoff loop logs the error indefinitely but cannot recover without a process restart.

## What ships

- `WithAutoRecreateGroup(mode RecreateMode)` — bitmask option (`RecreateBroadcast`, `RecreateWorkerPool`, `RecreateAll`). On `NOGROUP`, the consumer group is recreated via `XGroupCreateMkStream` at the subscription's original start position (`$` for broadcast/latest, `0` for worker-pool/beginning, or the resolved Redis message ID for `StartFromTimestamp`).
- `WithRecreateHandler(fn)` — optional callback fired on each successful recreate. Lets callers plumb a metric counter without the transport pulling in OTel meter infrastructure for a single signal.
- Repeated recreate→`NOGROUP` cycles escalate the existing exponential backoff so a flapping group does not hot-loop.
- `BUSYGROUP` on the recreate is treated as success (concurrent peer already recreated the group).
- Disabled by default (`RecreateMode(0)`).

## Why bitmask, not two booleans

The two modes have asymmetric blast radius and the operator should be able to opt into them independently:

- **Broadcast** — per-`Subscribe` throwaway group. Group has no continuity across pod restarts anyway, so PEL loss is moot. Safe to enable.
- **Worker-pool** — shared cluster-wide group. Recreating drops every worker's in-flight PEL. Opt in deliberately.

A bitmask is self-documenting at the call site (`RecreateBroadcast` vs `true, false`) and extensible if a third mode ever appears.

## Tradeoffs documented

- Destroyed group's Pending Entries List is unrecoverable.
- Messages published in the gap between destruction and recreate are not delivered to a broadcast subscription started at `\$`.
- For `StartFromBeginning` (`0`), the recreated group will replay whatever remains in the stream's retained window.

Both are spelled out in the godoc and the new README subsection.

## Test plan

- [x] `TestAutoRecreateGroup_BroadcastRecoversFromNoGroup` — broadcast + `RecreateBroadcast` → recreate fires, group reappears, no error log.
- [x] `TestAutoRecreateGroup_WorkerPoolRecoversFromNoGroup` — same for worker pool with named worker group.
- [x] `TestAutoRecreateGroup_DisabledLeavesErrorLog` — default (zero mode) preserves existing error+backoff behavior.
- [x] `TestAutoRecreateGroup_WrongModeLeavesErrorLog` — worker subscription + only `RecreateBroadcast` enabled → no recreate.
- [x] `TestAutoRecreateGroup_RecreateFailsFallsBack` — non-`BUSYGROUP` error from `XGroupCreateMkStream` → Warn log + fall through to existing backoff path. Recreate handler not invoked.
- [x] `TestAutoRecreateGroup_BusyGroupTreatedAsSuccess` — concurrent peer wins the recreate race → we treat `BUSYGROUP` as success.
- [x] `TestRecreateMode_String` — bitmask stringer, including unknown-bits hex fallback.
- [x] `go test -race -count=1 ./...` passes across all 40+ packages.
- [x] Mock `XReadGroup` upgraded to match real Redis: returns `NOGROUP` immediately when the group is absent regardless of `Block`, respects `Block <= 0` returning `redis.Nil` immediately for an empty stream.

## Downstream

Zero default-behaviour change. Downstream repos (`event-dlq`, `event-extras`, `event-scheduler`, `event-mongodb`, `mailbox`) need only an explicit dep bump if they want to enable the new option.