### PR TITLE
fix(transport/redis): defer consumer group creation to Subscribe

### DIFF
--- a/transport/redis/redis.go
+++ b/transport/redis/redis.go
@@ -143,21 +143,14 @@ func (t *Transport) streamName(eventName string) string {
 	return t.streamPrefix + ":" + eventName
 }
 
-// RegisterEvent creates resources for an event
+// RegisterEvent records the event in the local routing table. Redis-side
+// resources (stream, consumer groups) are created lazily: the stream by the
+// first Publish (XADD auto-creates), and consumer groups by Subscribe. This
+// keeps publish-only buses and worker-group-only subscribers from leaving an
+// unused base consumer group whose PEL grows unboundedly.
 func (t *Transport) RegisterEvent(ctx context.Context, name string) error {
 	if !t.isOpen() {
 		return transport.ErrTransportClosed
-	}
-
-	streamName := t.streamName(name)
-
-	// Create consumer group (also creates stream if it doesn't exist)
-	err := t.client.XGroupCreateMkStream(ctx, streamName, t.groupID, "$").Err()
-	if err != nil && !errors.Is(err, redis.Nil) {
-		// Ignore "BUSYGROUP" error (group already exists)
-		if err.Error() != "BUSYGROUP Consumer Group name already exists" {
-			return err
-		}
 	}
 
 	ev := &redisEvent{
@@ -168,10 +161,7 @@ func (t *Transport) RegisterEvent(ctx context.Context, name string) error {
 		return transport.ErrEventAlreadyExists
 	}
 
-	// Track the base consumer group
-	t.groups.Store(t.groupID, struct{}{})
-
-	t.logger.Debug("registered event", "event", name, "stream", streamName)
+	t.logger.Debug("registered event", "event", name, "stream", t.streamName(name))
 	return nil
 }
 
@@ -274,13 +264,11 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 	subID := transport.NewID()
 
 	var groupID string
-	var needsGroupCreate bool
 	if subOpts.DeliveryMode == transport.WorkerPool {
 		if subOpts.WorkerGroup != "" {
 			// WorkerPool with named group: workers in same group compete
 			// Different groups each receive all messages
 			groupID = t.groupID + "-" + name + "-" + subOpts.WorkerGroup
-			needsGroupCreate = true
 		} else {
 			// WorkerPool default: all workers share the base group
 			groupID = t.groupID
@@ -288,7 +276,6 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 	} else {
 		// Broadcast: unique consumer group per subscriber (fan-out)
 		groupID = t.groupID + "-" + subID
-		needsGroupCreate = true
 	}
 
 	// Determine start position for Redis stream.
@@ -313,12 +300,13 @@ func (t *Transport) Subscribe(ctx context.Context, name string, opts ...transpor
 		startID = fmt.Sprintf("%d-0", subOpts.StartTime.UnixMilli())
 	}
 
-	// Create consumer group if needed (named worker groups or broadcast)
-	if needsGroupCreate {
-		err := t.client.XGroupCreateMkStream(ctx, streamName, groupID, startID).Err()
-		if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-			return nil, err
-		}
+	// Lazily create the consumer group. Idempotent — BUSYGROUP means another
+	// subscriber (or a prior process incarnation, for stable worker groups)
+	// already created it, so we reuse the existing offset. This also creates
+	// the stream if Publish hasn't run yet.
+	err := t.client.XGroupCreateMkStream(ctx, streamName, groupID, startID).Err()
+	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
+		return nil, err
 	}
 
 	// Track this consumer group for lag monitoring
@@ -481,9 +469,16 @@ func (t *Transport) ConsumerLag(ctx context.Context) ([]transport.ConsumerLag, e
 				return
 			}
 
-			// Get consumer group info
+			// Get consumer group info. The stream is created lazily by the first
+			// Publish or Subscribe; until then XInfoGroups errors with
+			// "ERR no such key". Report the event as zero-lag in that case
+			// rather than logging an operator-facing error.
 			groups, err := t.client.XInfoGroups(ctx, streamName).Result()
 			if err != nil {
+				if isNoSuchKeyErr(err) {
+					results[idx].lags = append(results[idx].lags, transport.ConsumerLag{Event: name})
+					return
+				}
 				t.logger.Error("failed to get group info", "stream", streamName, "error", err)
 				return
 			}
@@ -548,6 +543,14 @@ func (t *Transport) ConsumerLag(ctx context.Context) ([]transport.ConsumerLag, e
 // switch to it.
 func isNoGroupErr(err error) bool {
 	return err != nil && strings.HasPrefix(err.Error(), "NOGROUP ")
+}
+
+// isNoSuchKeyErr reports whether err is the Redis "ERR no such key" reply,
+// returned by stream-introspection commands (e.g., XINFO GROUPS) when the
+// target stream does not exist yet. Detection is by error-text prefix for the
+// same reason as isNoGroupErr.
+func isNoSuchKeyErr(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "ERR no such key")
 }
 
 // tryRecreateGroup attempts to recreate the subscription's consumer group at

--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -356,15 +356,29 @@ func TestTransportRegisterEvent(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("register event creates stream and group", func(t *testing.T) {
+	t.Run("register event does not touch redis", func(t *testing.T) {
 		err := tr.RegisterEvent(ctx, "test-event")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Verify group was created
-		if _, ok := client.groups["evt:test-event"]; !ok {
-			t.Error("expected stream group to be created")
+		// Group/stream creation is deferred to Publish/Subscribe so publish-only
+		// or worker-group-only buses don't accrue an unused base consumer group.
+		client.mu.Lock()
+		_, hasGroups := client.groups["evt:test-event"]
+		_, hasStream := client.streams["evt:test-event"]
+		client.mu.Unlock()
+		if hasGroups {
+			t.Error("did not expect RegisterEvent to create a consumer group")
+		}
+		if hasStream {
+			t.Error("did not expect RegisterEvent to create a stream")
+		}
+
+		// And the transport should not track the base group until something
+		// subscribes via it.
+		if _, ok := tr.groups.Load(tr.groupID); ok {
+			t.Error("did not expect base groupID to be tracked after RegisterEvent")
 		}
 	})
 
@@ -383,6 +397,77 @@ func TestTransportRegisterEvent(t *testing.T) {
 			t.Errorf("expected ErrTransportClosed, got %v", err)
 		}
 	})
+}
+
+// TestPublishOnlyDoesNotCreateConsumerGroup verifies that a bus that only
+// publishes (never subscribes) does not leave an orphan base consumer group
+// behind. The stream itself is created by XADD on first publish; consumer
+// groups are created only when Subscribe runs.
+func TestPublishOnlyDoesNotCreateConsumerGroup(t *testing.T) {
+	client := newMockRedisClient()
+	tr, _ := New(client)
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "pub-only"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+
+	if err := tr.Publish(ctx, "pub-only", testMessage("src", "p")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	client.mu.Lock()
+	hasStream := len(client.streams["evt:pub-only"]) > 0
+	groupCount := len(client.groups["evt:pub-only"])
+	client.mu.Unlock()
+
+	if !hasStream {
+		t.Error("expected stream to be created by Publish")
+	}
+	if groupCount != 0 {
+		t.Errorf("expected no consumer groups on publish-only stream, got %d", groupCount)
+	}
+}
+
+// TestDefaultWorkerPoolCreatesBaseGroupOnSubscribe verifies the lazy-creation
+// invariant for the default worker pool: the base consumer group is created
+// by the first Subscribe call, not by RegisterEvent.
+func TestDefaultWorkerPoolCreatesBaseGroupOnSubscribe(t *testing.T) {
+	client := newMockRedisClient()
+	tr, _ := New(client, WithConsumerGroup("bus-a"))
+	defer tr.Close(context.Background())
+
+	ctx := context.Background()
+	if err := tr.RegisterEvent(ctx, "wp-evt"); err != nil {
+		t.Fatalf("RegisterEvent: %v", err)
+	}
+
+	client.mu.Lock()
+	_, before := client.groups["evt:wp-evt"]
+	client.mu.Unlock()
+	if before {
+		t.Fatal("group present before Subscribe")
+	}
+
+	sub, err := tr.Subscribe(ctx, "wp-evt", transport.WithDeliveryMode(transport.WorkerPool))
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
+
+	client.mu.Lock()
+	startID, has := client.groups["evt:wp-evt"]["bus-a"]
+	client.mu.Unlock()
+	if !has {
+		t.Fatal("expected base group to be created by Subscribe")
+	}
+	if startID != "0" {
+		t.Errorf("expected default WorkerPool to create base group at start \"0\", got %q", startID)
+	}
+	if _, tracked := tr.groups.Load("bus-a"); !tracked {
+		t.Error("expected base group to be tracked in transport.groups after Subscribe")
+	}
 }
 
 func TestTransportUnregisterEvent(t *testing.T) {
@@ -742,8 +827,14 @@ func TestConsumerLag_OldestPending(t *testing.T) {
 	defer tr.Close(context.Background())
 
 	ctx := context.Background()
-	// RegisterEvent creates the stream and default consumer group.
 	tr.RegisterEvent(ctx, "lag-event")
+	// Subscribe creates the default consumer group (group creation is lazy
+	// post-fix; RegisterEvent no longer touches Redis).
+	sub, err := tr.Subscribe(ctx, "lag-event", transport.WithDeliveryMode(transport.WorkerPool))
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close(context.Background())
 
 	// Inject a known XPending result with a stream entry ID whose millisecond
 	// prefix encodes a known past timestamp (2023-11-14T22:13:20Z).


### PR DESCRIPTION
## Summary

- `RegisterEvent` no longer eagerly creates a base consumer group via `XGroupCreateMkStream`. Group creation moves to `Subscribe`, which is the path that actually knows the right `groupID` and `startID`.
- Stream creation is implicit: `XADD` creates it on first `Publish`; `XGroupCreateMkStream` creates it on first `Subscribe`. Registered-but-never-touched events no longer materialize on Redis at all.
- `ConsumerLag` treats `XInfoGroups` "ERR no such key" as zero-lag instead of logging an operator-facing error.

## Why

Previously, every `RegisterEvent` call planted a base consumer group named `t.groupID` at `\$` and tracked it in `t.groups`. That group was orphaned whenever the bus was:

- publish-only (no subscribers ever attach), or
- subscribed only via `WithWorkerGroup` (each named group creates its own consumer group), or
- subscribed only in broadcast mode (each subscriber mints a unique consumer group).

In those cases every published message accumulated in the unused base group's PEL — no consumer existed to `XACK`, so the entries lingered, distorting `ConsumerLag` and growing memory in Redis indefinitely.

Side effect of the move: the default-WorkerPool path now actually creates the base group at the documented `startID="0"`, so a stable worker pool subscribing after some `Publish` calls will replay retained messages (which is the documented behavior for `WorkerPool`, matching `WithWorkerGroup`'s stable-group semantics). Before this fix the group was pre-created at `\$`, silently dropping that replay.

## Test plan

- [x] `go test ./transport/redis/... -race -count=1` — all existing tests pass.
- [x] `go test ./... -count=1` — full repo green.
- [x] `golangci-lint run ./transport/redis/...` — 0 issues.
- [x] New `TestPublishOnlyDoesNotCreateConsumerGroup` confirms a publish-only bus leaves zero consumer groups behind.
- [x] New `TestDefaultWorkerPoolCreatesBaseGroupOnSubscribe` confirms the base group is created lazily, at the documented `startID="0"`, and tracked in `t.groups`.
- [x] Updated `TestTransportRegisterEvent` asserts `RegisterEvent` no longer touches Redis or `t.groups`.
- [x] Updated `TestConsumerLag_OldestPending` to bring the base group into existence via `Subscribe` before exercising lag.