### PR TITLE
test: foundation — internal/testutil, build-tag scheme, canonical smoke suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 jobs:
-  test:
+  unit:
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +25,7 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -race -shuffle=on -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -35,6 +35,21 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  smoke:
+    name: Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run smoke tests
+        run: go test -tags=smoke -race -count=1 -timeout=60s ./...
 
   lint:
     name: Lint

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,59 @@
+name: Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+# Integration runs against real Redis and Postgres service containers. The
+# suite is non-blocking (continue-on-error) while the test set stabilizes;
+# remove that flag once a 2-week green streak demonstrates the suite is
+# reliable enough to gate merges.
+jobs:
+  integration:
+    name: Integration (Redis + Postgres)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      REDIS_ADDR: 127.0.0.1:6379
+      POSTGRES_DSN: postgres://test:test@127.0.0.1:5432/test?sslmode=disable
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run integration tests
+        run: go test -tags=integration -race -count=1 -timeout=300s ./...

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+# Codecov is in informational mode during the test-quality lift. Targets are
+# 80% on both the project as a whole and on changed code in a PR, but neither
+# blocks merges yet — the badge surfaces the trend so contributors can see
+# regressions without being rejected by a flaky number.
+#
+# Flip threshold from `auto` to a fixed delta and remove informational: true
+# once the unit suite + the new sqlmock/miniredis stores raise project
+# coverage above 80% steady-state.
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, tree"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/*_test.go"
+  - "internal/testutil/**"
+  - "monitor/proto/**"

--- a/distributed/redis_test.go
+++ b/distributed/redis_test.go
@@ -1,3 +1,10 @@
+//go:build !integration
+
+// This file holds the miniredis-backed unit tests for RedisStateManager. The
+// real-Redis suite lives in redis_integration_test.go and reuses the
+// setupRedisStateManager helper name, so the two files are mutually exclusive
+// via build tags.
+
 package distributed
 
 import (

--- a/internal/testutil/bus.go
+++ b/internal/testutil/bus.go
@@ -1,0 +1,65 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+)
+
+// busCloseTimeout is the deadline applied to bus.Close in MustNewBus's
+// cleanup. Long enough to drain typical in-flight handlers; short enough that
+// a leaked-handler test failure surfaces as a timeout rather than hanging the
+// whole suite.
+const busCloseTimeout = 5 * time.Second
+
+// MustNewBus constructs a Bus with a collision-free name and registers
+// t.Cleanup to close it. Tests should always prefer MustNewBus over calling
+// event.NewBus directly so that:
+//
+//   - A panicking or t.Fatal-ing test cannot leak a name into the global bus
+//     registry (which would poison subsequent tests sharing the same name).
+//   - Parallel subtests cannot collide on names — UniqueName mixes 64 bits of
+//     entropy into t.Name().
+//   - Bus.Close runs even when the test fails mid-flight.
+//
+// The returned bus is ready to use; callers can Register events on it
+// immediately.
+func MustNewBus(t testing.TB, opts ...event.BusOption) *event.Bus {
+	t.Helper()
+	return MustNewBusNamed(t, UniqueName(t), opts...)
+}
+
+// MustNewBusNamed is like MustNewBus but lets the caller pick the name. Use
+// this only when the test specifically asserts on bus name semantics — most
+// tests should call MustNewBus.
+func MustNewBusNamed(t testing.TB, name string, opts ...event.BusOption) *event.Bus {
+	t.Helper()
+	bus, err := event.NewBus(name, opts...)
+	if err != nil {
+		t.Fatalf("event.NewBus(%q): %v", name, err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), busCloseTimeout)
+		defer cancel()
+		// Close errors during automatic cleanup are intentionally swallowed:
+		// the test has already finished, and the bus.Close shutdown sequence
+		// can race transport-closed errors that are benign in this context.
+		// Tests that need to assert on bus.Close behavior should call it
+		// explicitly inside the test body.
+		_ = bus.Close(ctx)
+	})
+	return bus
+}
+
+// MustRegister calls event.Register and t.Fatals on error. It's a one-liner
+// that keeps test setup readable: `e := testutil.MustRegister(t, ctx, bus,
+// event.New[int]("foo"))`.
+func MustRegister[T any](t testing.TB, ctx context.Context, bus *event.Bus, ev event.Event[T]) event.Event[T] {
+	t.Helper()
+	if err := event.Register(ctx, bus, ev); err != nil {
+		t.Fatalf("event.Register(%q): %v", ev.Name(), err)
+	}
+	return ev
+}

--- a/internal/testutil/clock.go
+++ b/internal/testutil/clock.go
@@ -1,0 +1,93 @@
+package testutil
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock is the minimal time surface that production code can take as a
+// dependency to enable deterministic tests. The default RealClock
+// implementation delegates to the time package; tests inject FakeClock to
+// drive time manually via Advance.
+//
+// Production code should only call methods defined here. Adding new methods
+// (e.g. NewTimer, NewTicker) is fine but requires updating both
+// implementations.
+type Clock interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	Sleep(d time.Duration)
+}
+
+// RealClock is the production Clock, backed by the standard time package.
+type RealClock struct{}
+
+// Now returns the current wall-clock time.
+func (RealClock) Now() time.Time { return time.Now() }
+
+// Since returns the duration elapsed since t.
+func (RealClock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+// Sleep blocks for at least d.
+func (RealClock) Sleep(d time.Duration) { time.Sleep(d) }
+
+// FakeClock is a deterministic Clock for tests. Time only advances when
+// Advance is called explicitly, so race-prone tests built around real
+// time.Sleep timing can be rewritten to drive time directly.
+//
+// FakeClock is safe for concurrent use.
+type FakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewFakeClock constructs a FakeClock pinned to start. If start is the zero
+// time, FakeClock starts at the Unix epoch — concrete enough that elapsed
+// durations format readably in test failures.
+func NewFakeClock(start time.Time) *FakeClock {
+	if start.IsZero() {
+		start = time.Unix(0, 0).UTC()
+	}
+	return &FakeClock{now: start}
+}
+
+// Now returns the clock's current time.
+func (c *FakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// Since returns the duration between the clock's current time and t.
+func (c *FakeClock) Since(t time.Time) time.Duration {
+	return c.Now().Sub(t)
+}
+
+// Sleep on a FakeClock advances the clock by d rather than blocking. Production
+// code that calls Sleep for backoff or rate limiting becomes instantly
+// testable.
+func (c *FakeClock) Sleep(d time.Duration) {
+	c.Advance(d)
+}
+
+// Advance moves the fake clock forward by d. Tests call Advance to simulate
+// the passage of time without blocking.
+func (c *FakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// Set forces the fake clock to t. Useful for jumping to a known absolute
+// timestamp (e.g. for testing TTL expiry from a specific epoch).
+func (c *FakeClock) Set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = t
+}
+
+// Compile-time assertion that both clocks satisfy the interface.
+var (
+	_ Clock = RealClock{}
+	_ Clock = (*FakeClock)(nil)
+)

--- a/internal/testutil/eventually.go
+++ b/internal/testutil/eventually.go
@@ -1,0 +1,86 @@
+// Package testutil provides shared helpers for unit, smoke, and integration
+// tests across the event repository. It is intentionally internal so external
+// consumers cannot depend on its evolving API.
+//
+// The package is split by concern: eventually.go (polling), clock.go (fake
+// time), bus.go (Bus lifecycle), uniquename.go (collision-free per-run names),
+// and backend harnesses (redis.go, postgres.go) that are gated behind the
+// integration build tag.
+package testutil
+
+import (
+	"testing"
+	"time"
+)
+
+// defaultPollInterval is the interval Eventually uses when polling a condition.
+// Short enough for sub-second total runs to feel responsive; long enough to
+// avoid CPU-bound spin on a hot predicate.
+const defaultPollInterval = 5 * time.Millisecond
+
+// Eventually polls cond until it returns true or timeout elapses. On timeout
+// the test fails (via t.Fatalf) with msg and args. It is the preferred
+// replacement for time.Sleep-followed-by-assertion patterns: it succeeds as
+// soon as the condition holds and only burns the timeout when something is
+// actually wrong.
+//
+// Use a generous timeout (e.g. 2 * expected) — Eventually only blocks until
+// the predicate flips, so over-budgeting the timeout costs nothing on the
+// happy path but eliminates flakes on loaded CI runners.
+func Eventually(t testing.TB, timeout time.Duration, cond func() bool, msg string, args ...any) {
+	t.Helper()
+	if EventuallyOK(timeout, cond) {
+		return
+	}
+	if msg == "" {
+		t.Fatalf("Eventually: condition did not hold within %s", timeout)
+		return
+	}
+	t.Fatalf("Eventually: condition did not hold within %s: "+msg, append([]any{timeout}, args...)...)
+}
+
+// EventuallyOK is the non-fatal form of Eventually. It returns true if cond
+// became true within timeout, false otherwise. Useful when the caller wants
+// to attach a custom failure message that includes diagnostic state captured
+// after the poll loop exits.
+func EventuallyOK(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(defaultPollInterval)
+	defer ticker.Stop()
+
+	if cond() {
+		return true
+	}
+	for {
+		select {
+		case <-ticker.C:
+			if cond() {
+				return true
+			}
+			if time.Now().After(deadline) {
+				return false
+			}
+		case <-time.After(time.Until(deadline)):
+			return cond()
+		}
+	}
+}
+
+// WaitFor blocks until ch receives a value or timeout elapses. On timeout the
+// test fails with msg. The channel-based alternative to Eventually for cases
+// where the production code already signals completion via a channel.
+func WaitFor[T any](t testing.TB, ch <-chan T, timeout time.Duration, msg string, args ...any) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(timeout):
+		if msg == "" {
+			t.Fatalf("WaitFor: no value on channel within %s", timeout)
+		} else {
+			t.Fatalf("WaitFor: no value on channel within %s: "+msg, append([]any{timeout}, args...)...)
+		}
+		var zero T
+		return zero
+	}
+}

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // pq driver registered as side effect for sql.Open
+)
+
+// PostgresDSNEnv is the environment variable consulted for the Postgres DSN.
+const PostgresDSNEnv = "POSTGRES_DSN"
+
+// defaultPostgresDSN is used when PostgresDSNEnv is unset. The CI
+// service-container pattern and the standard local docker compose both expose
+// Postgres at 5432; the user/db `test` defaults match the existing
+// idempotency integration test's DSN.
+const defaultPostgresDSN = "postgres://localhost:5432/test?sslmode=disable"
+
+// SetupPostgres returns a *sql.DB whose search_path is pinned to a
+// per-run schema. If Postgres is unreachable the test is skipped. The
+// per-run schema is DROPed on teardown, so even tests that CREATE TABLE
+// without per-run namespacing produce no cross-test contamination.
+//
+// Tests that need to operate against the public schema (e.g. those exercising
+// CreateTable idempotency on a fixed name) should drop the schema_search via
+// `db.ExecContext(ctx, "SET search_path TO public")` inside the subtest —
+// the cleanup still drops the per-run schema, so nothing leaks.
+func SetupPostgres(t testing.TB) (*sql.DB, string) {
+	t.Helper()
+
+	dsn := os.Getenv(PostgresDSNEnv)
+	if dsn == "" {
+		dsn = defaultPostgresDSN
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open(postgres): %v", err) // misconfigured DSN, not "unreachable"
+	}
+
+	pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := db.PingContext(pingCtx); err != nil {
+		_ = db.Close()
+		t.Skipf("Postgres unreachable at %s (%s=%s): %v",
+			dsn, PostgresDSNEnv, os.Getenv(PostgresDSNEnv), err)
+	}
+
+	schema := "test_" + strings.ToLower(UniqueName(t))
+
+	createCtx, createCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer createCancel()
+	if _, err := db.ExecContext(createCtx, fmt.Sprintf(`CREATE SCHEMA %q`, schema)); err != nil {
+		_ = db.Close()
+		t.Fatalf("CREATE SCHEMA %q: %v", schema, err)
+	}
+
+	// Pin search_path at the connection-pool level so every subsequent query
+	// resolves identifiers within the per-run schema by default. Tests that
+	// need to override can SET search_path themselves.
+	if _, err := db.ExecContext(createCtx, fmt.Sprintf(`SET search_path TO %q`, schema)); err != nil {
+		_, _ = db.ExecContext(context.Background(), fmt.Sprintf(`DROP SCHEMA %q CASCADE`, schema))
+		_ = db.Close()
+		t.Fatalf("SET search_path: %v", err)
+	}
+
+	t.Cleanup(func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer dropCancel()
+		if _, err := db.ExecContext(dropCtx, fmt.Sprintf(`DROP SCHEMA %q CASCADE`, schema)); err != nil {
+			t.Logf("postgres cleanup DROP SCHEMA %q: %v", schema, err)
+		}
+		_ = db.Close()
+	})
+
+	return db, schema
+}

--- a/internal/testutil/redis.go
+++ b/internal/testutil/redis.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisAddrEnv is the environment variable consulted for the Redis address.
+// Tests should not hardcode 127.0.0.1:6379; let SetupRedis resolve it so CI
+// and local-dev can override without code changes.
+const RedisAddrEnv = "REDIS_ADDR"
+
+// defaultRedisAddr is used when RedisAddrEnv is unset. The CI service-container
+// pattern and local docker compose both bind 6379 by default.
+const defaultRedisAddr = "127.0.0.1:6379"
+
+// SetupRedis returns a connected Redis client and a per-run key prefix. If
+// Redis is unreachable the test is skipped — this lets `go test
+// -tags=integration ./...` succeed on developer machines without a running
+// Redis. CI brings Redis up via a services: block and never hits the skip.
+//
+// The returned prefix is collision-free across parallel test runs (see
+// UniqueName). A t.Cleanup hook SCANs and DELs every key under the prefix on
+// teardown, leaving the database in the state it was found.
+//
+// SetupRedis intentionally uses *redis.Client rather than the redis.Client
+// interface from transport/redis, because integration tests assert against
+// real Redis semantics that the abstraction interface hides.
+func SetupRedis(t testing.TB) (*redis.Client, string) {
+	t.Helper()
+
+	addr := os.Getenv(RedisAddrEnv)
+	if addr == "" {
+		addr = defaultRedisAddr
+	}
+
+	client := redis.NewClient(&redis.Options{Addr: addr})
+
+	pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Ping(pingCtx).Err(); err != nil {
+		_ = client.Close()
+		t.Skipf("Redis unreachable at %s (%s=%s): %v",
+			addr, RedisAddrEnv, os.Getenv(RedisAddrEnv), err)
+	}
+
+	prefix := "test:" + UniqueName(t) + ":"
+
+	t.Cleanup(func() {
+		// Scan-and-delete the prefix on teardown. SCAN is bounded by
+		// COUNT=1000 hints; we drain all batches so leaked keys don't survive.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		iter := client.Scan(cleanupCtx, 0, prefix+"*", 1000).Iterator()
+		var keys []string
+		for iter.Next(cleanupCtx) {
+			keys = append(keys, iter.Val())
+			if len(keys) >= 500 {
+				if err := client.Del(cleanupCtx, keys...).Err(); err != nil {
+					t.Logf("redis cleanup DEL: %v", err)
+				}
+				keys = keys[:0]
+			}
+		}
+		if len(keys) > 0 {
+			if err := client.Del(cleanupCtx, keys...).Err(); err != nil {
+				t.Logf("redis cleanup DEL: %v", err)
+			}
+		}
+		_ = client.Close()
+	})
+
+	return client, prefix
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,144 @@
+package testutil_test
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/internal/testutil"
+	"github.com/rbaliyan/event/v3/transport/channel"
+)
+
+func TestEventually_Succeeds(t *testing.T) {
+	t.Parallel()
+	start := time.Now()
+	var flipped atomic.Bool
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		flipped.Store(true)
+	}()
+	testutil.Eventually(t, time.Second, flipped.Load, "should have flipped")
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("Eventually returned too late: %v", elapsed)
+	}
+}
+
+func TestEventuallyOK_Timeout(t *testing.T) {
+	t.Parallel()
+	ok := testutil.EventuallyOK(20*time.Millisecond, func() bool { return false })
+	if ok {
+		t.Error("expected EventuallyOK to return false on timeout")
+	}
+}
+
+func TestEventuallyOK_TrueImmediately(t *testing.T) {
+	t.Parallel()
+	// A condition that is already true should return without polling.
+	calls := 0
+	ok := testutil.EventuallyOK(time.Second, func() bool {
+		calls++
+		return true
+	})
+	if !ok || calls != 1 {
+		t.Errorf("expected single check; ok=%v calls=%d", ok, calls)
+	}
+}
+
+func TestWaitFor(t *testing.T) {
+	t.Parallel()
+	ch := make(chan int, 1)
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		ch <- 42
+	}()
+	got := testutil.WaitFor(t, ch, time.Second, "value should arrive")
+	if got != 42 {
+		t.Errorf("got %d, want 42", got)
+	}
+}
+
+func TestUniqueName_IsCollisionFree(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, 1000)
+	for i := range 1000 {
+		n := testutil.UniqueName(t)
+		if _, dup := seen[n]; dup {
+			t.Fatalf("UniqueName collision after %d iterations: %s", i, n)
+		}
+		seen[n] = struct{}{}
+	}
+}
+
+func TestUniqueName_IsSanitized(t *testing.T) {
+	t.Parallel()
+	n := testutil.UniqueName(t)
+	for _, r := range n {
+		ok := (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '_' || r == '-'
+		if !ok {
+			t.Errorf("UniqueName contains unsafe rune %q in %q", r, n)
+		}
+	}
+	if !strings.Contains(n, "TestUniqueName_IsSanitized") {
+		t.Errorf("UniqueName should embed test name; got %q", n)
+	}
+}
+
+func TestFakeClock_AdvancesOnSleep(t *testing.T) {
+	t.Parallel()
+	clk := testutil.NewFakeClock(time.Time{})
+	start := clk.Now()
+	clk.Sleep(time.Hour)
+	if got := clk.Since(start); got != time.Hour {
+		t.Errorf("FakeClock.Since after Sleep(1h) = %v, want 1h", got)
+	}
+}
+
+func TestFakeClock_Advance(t *testing.T) {
+	t.Parallel()
+	clk := testutil.NewFakeClock(time.Unix(1_700_000_000, 0).UTC())
+	clk.Advance(30 * time.Second)
+	want := time.Unix(1_700_000_030, 0).UTC()
+	if !clk.Now().Equal(want) {
+		t.Errorf("FakeClock.Now after Advance = %v, want %v", clk.Now(), want)
+	}
+}
+
+func TestRealClock_DelegatesToTime(t *testing.T) {
+	t.Parallel()
+	var c testutil.Clock = testutil.RealClock{}
+	before := c.Now()
+	time.Sleep(time.Millisecond)
+	if c.Since(before) <= 0 {
+		t.Errorf("RealClock.Since should be positive after sleep")
+	}
+}
+
+func TestMustNewBus_RegistersCloseCleanup(t *testing.T) {
+	t.Parallel()
+	bus := testutil.MustNewBus(t, event.WithTransport(channel.New()))
+	if bus == nil {
+		t.Fatal("MustNewBus returned nil")
+	}
+	// Cleanup should fire bus.Close at end-of-test — we verify indirectly by
+	// running a publish/subscribe round-trip and trusting t.Cleanup ordering.
+	ev := testutil.MustRegister(t, context.Background(), bus, event.New[int]("ping"))
+	got := make(chan int, 1)
+	if err := ev.Subscribe(context.Background(), func(_ context.Context, _ event.Event[int], v int) error {
+		got <- v
+		return nil
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := ev.Publish(context.Background(), 7); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if v := testutil.WaitFor(t, got, time.Second, "value should arrive"); v != 7 {
+		t.Errorf("got %d, want 7", v)
+	}
+}

--- a/internal/testutil/uniquename.go
+++ b/internal/testutil/uniquename.go
@@ -1,0 +1,57 @@
+package testutil
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// UniqueName returns a short, filesystem- and Redis-key-safe identifier
+// derived from t.Name() plus 64 bits of entropy. It is collision-free under
+// `go test -count=N`, `-shuffle=on`, parallel CI shards, and parallel
+// subtests — the failure mode the second-resolution timestamp prefix in the
+// existing integration tests is vulnerable to.
+//
+// The returned form is `<sanitized-test-name>-<8-hex-bytes>`, e.g.
+// `TestFoo_Subtest-3f9a2b81c4d0ee17`.
+func UniqueName(t testing.TB) string {
+	t.Helper()
+	return sanitize(t.Name()) + "-" + randHex(8)
+}
+
+// sanitize lowercases and replaces characters that are problematic in Redis
+// stream names, Postgres identifiers, and shell paths. The transformation is
+// stable but not invertible; callers should not parse the result.
+func sanitize(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// randHex returns n bytes of crypto-random hex. Hex over base32/64 because the
+// downstream consumers (Redis keys, Postgres schemas) are case-sensitive in
+// some contexts and uppercase-folding in others — hex is always safe.
+func randHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand.Read only fails on a broken OS-level entropy source;
+		// returning a deterministic fallback keeps tests running rather than
+		// taking down the whole suite. The probability is negligible in
+		// practice.
+		return strings.Repeat("0", n*2)
+	}
+	return hex.EncodeToString(b)
+}

--- a/justfile
+++ b/justfile
@@ -22,6 +22,26 @@ test-race:
 test-cover:
     go test -cover ./...
 
+# Run smoke suite (sub-100ms bus-level round-trips, build-tag gated)
+test-smoke:
+    go test -tags=smoke -race -count=1 -timeout=60s ./...
+
+# Run integration suite (real backends; requires REDIS_ADDR / POSTGRES_DSN env or local services)
+test-integration:
+    go test -tags=integration -race -count=1 -timeout=300s ./...
+
+# Run integration tests that talk to Redis
+test-redis:
+    go test -tags=integration -race -count=1 -run='.*[Rr]edis.*' ./...
+
+# Run integration tests that talk to Postgres
+test-pg:
+    go test -tags=integration -race -count=1 -run='.*[Pp]ostgres.*' ./...
+
+# Run the full unit suite with shuffled order to surface ordering-dependent tests
+test-shuffle:
+    go test -race -shuffle=on -count=1 ./...
+
 # Format code
 fmt:
     go fmt ./...

--- a/smoke_channel_test.go
+++ b/smoke_channel_test.go
@@ -1,0 +1,98 @@
+//go:build smoke
+
+// Canonical bus-level smoke test against the channel transport. Establishes
+// the patterns subsequent transport smoke tests (Redis, NATS, Kafka) will
+// follow: MustNewBus + Register + Subscribe + Publish + Eventually-style
+// assertion, no time.Sleep, no global state.
+//
+// Run with: just test-smoke   (or: go test -tags=smoke -race ./...)
+
+package event_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	event "github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/internal/testutil"
+	"github.com/rbaliyan/event/v3/transport/channel"
+)
+
+func TestSmokeBusChannel_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	bus := testutil.MustNewBus(t, event.WithTransport(channel.New()))
+	ev := testutil.MustRegister(t, ctx, bus, event.New[string]("smoke.rt"))
+
+	received := make(chan string, 1)
+	if err := ev.Subscribe(ctx, func(_ context.Context, _ event.Event[string], v string) error {
+		received <- v
+		return nil
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if err := ev.Publish(ctx, "hello"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	got := testutil.WaitFor(t, received, time.Second, "payload should be delivered")
+	if got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+}
+
+func TestSmokeBus_PublishUnboundReturnsSentinel(t *testing.T) {
+	t.Parallel()
+	// An event constructed but never Register'd should refuse to publish with
+	// the documented sentinel. Pins the error-path smoke contract that the
+	// reliability stack relies on.
+	ev := event.New[int]("smoke.unbound")
+	err := ev.Publish(context.Background(), 1)
+	if !errors.Is(err, event.ErrEventNotBound) {
+		t.Errorf("Publish on unbound event: got %v, want ErrEventNotBound", err)
+	}
+}
+
+func TestSmokeBus_WorkerPool_FanOut(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	bus := testutil.MustNewBus(t, event.WithTransport(channel.New()))
+	ev := testutil.MustRegister(t, ctx, bus, event.New[int]("smoke.workers"))
+
+	var a, b atomic.Int64
+	handler := func(counter *atomic.Int64) event.Handler[int] {
+		return func(_ context.Context, _ event.Event[int], _ int) error {
+			counter.Add(1)
+			return nil
+		}
+	}
+	if err := ev.Subscribe(ctx, handler(&a), event.AsWorker[int](), event.WithWorkerGroup[int]("g")); err != nil {
+		t.Fatalf("Subscribe a: %v", err)
+	}
+	if err := ev.Subscribe(ctx, handler(&b), event.AsWorker[int](), event.WithWorkerGroup[int]("g")); err != nil {
+		t.Fatalf("Subscribe b: %v", err)
+	}
+
+	const total = 20
+	for i := range total {
+		if err := ev.Publish(ctx, i); err != nil {
+			t.Fatalf("Publish %d: %v", i, err)
+		}
+	}
+
+	testutil.Eventually(t, 2*time.Second, func() bool {
+		return a.Load()+b.Load() == total
+	}, "expected a+b=%d, got a=%d b=%d", total, a.Load(), b.Load())
+
+	// Worker semantics: each message must land on exactly one handler. Both
+	// counters should be non-zero given the round-robin in the channel
+	// transport, but the canonical smoke assertion is on the sum so we don't
+	// pin the implementation's distribution policy.
+	if a.Load() == 0 || b.Load() == 0 {
+		t.Errorf("worker fan-out skewed: a=%d b=%d", a.Load(), b.Load())
+	}
+}


### PR DESCRIPTION
## Summary

This is Phase 0 of the test-quality lift identified by three evaluation reports (unit 5.77 / 10, integration 41 / 100, smoke 5.0 / 10). Phase 0 is intentionally **additive only** — no production code is touched, no existing test changes behavior. It lays the rails that Phase 1 (NATS/Kafka tests, real-Redis integration tests, partition tests) will build on.

### What ships

- **`internal/testutil` package**
  - `Eventually(t, timeout, cond, msg)` + `WaitFor[T](t, ch, timeout, msg)` — the replacement for `time.Sleep`-followed-by-assertion. 145 sleep call sites will switch to this in Phase 2.
  - `Clock` interface + `RealClock` + `FakeClock` — deterministic time for coalesce / outbox relay / circuit breaker / recovery code in Phase 2.
  - `UniqueName(t)` — `t.Name()` + 64 bits of entropy. Collision-free under `-count=N`, `-shuffle=on`, parallel CI shards.
  - `MustNewBus(t, opts...)` + `MustRegister(t, ctx, bus, ev)` — auto-registers `bus.Close` via `t.Cleanup`. Replaces ad-hoc `mustNewBus` helpers.
  - `SetupRedis(t)` / `SetupPostgres(t)` — gated `//go:build integration`. Skip-on-unreachable, per-run key prefix / schema namespace, automatic cleanup.
  - Unit tests for every always-on helper.

- **`//go:build smoke` tag** + `smoke_channel_test.go`
  - `TestSmokeBusChannel_RoundTrip` — canonical sub-100ms bus-level pub/sub/receive.
  - `TestSmokeBus_PublishUnboundReturnsSentinel` — pins `ErrEventNotBound` contract.
  - `TestSmokeBus_WorkerPool_FanOut` — exercises `AsWorker` + `WithWorkerGroup` at the bus layer.

- **`justfile`** new recipes
  - `just test-smoke` — `go test -tags=smoke -race -count=1 -timeout=60s ./...`
  - `just test-integration` — `go test -tags=integration -race -count=1 -timeout=300s ./...`
  - `just test-redis`, `just test-pg` — focused integration runs
  - `just test-shuffle` — `go test -race -shuffle=on -count=1 ./...`

- **CI changes**
  - `ci.yml` test job split: `unit` (now runs with `-shuffle=on`) + new `smoke` job.
  - New `integration.yml` workflow brings up Redis + Postgres service containers and runs `go test -tags=integration ./...`. `continue-on-error: true` while the suite is being populated by Phase 1.

- **`codecov.yml`**: 80% project + patch targets in informational mode. Flip to blocking once steady-state coverage clears the bar.

### Drive-by fix

`distributed/redis_test.go` (the miniredis-backed test) had no build tag, so it shared `setupRedisStateManager` with `redis_integration_test.go` and compile-failed under `-tags=integration`. Latent bug — nobody hit it because nobody ran `-tags=integration ./...` before. Now tagged `//go:build !integration` so the two files are mutually exclusive.

## How this maps to the evaluation reports

| Report finding | This PR addresses by |
|---|---|
| Unit: pervasive `time.Sleep` (145 sites) | Lands `Eventually`/`WaitFor`/`Clock` so Phase 2 can mechanically retrofit |
| Unit: no `t.Parallel()` anywhere | `internal/testutil` tests are all `t.Parallel()` — proves the helpers are parallel-safe |
| Unit: no CI coverage threshold | `codecov.yml` informational at 80% |
| Integration: CI never runs `-tags=integration` | New `integration.yml` with Redis + Postgres services |
| Integration: no `just test-integration` recipe | Added, plus per-backend variants |
| Integration: second-resolution name collision | `UniqueName` uses 64 bits of crypto entropy |
| Smoke: no `//go:build smoke` tag | Tag established; one canonical suite shipped |
| Smoke: no `just smoke` recipe | `just test-smoke` added |
| Smoke: no fast pre-merge gate | New CI `smoke` job runs in ~60s with `-timeout=60s` |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (default), `go vet -tags=integration ./...`, `go vet -tags=smoke ./...`
- [x] `go test ./... -race -count=1` — all 41 packages pass (existing suite unaffected)
- [x] `go test -tags=smoke -race -count=1 ./...` — all 3 smoke tests pass in <2s
- [x] `golangci-lint run ./...` — 0 issues
- [x] Helpers themselves covered by `internal/testutil/testutil_test.go`

## What's next (not in this PR)

Phase 1 (parallel PRs unblocked by this one): `transport/nats` + `transport/kafka` test suites, real-Redis integration tests for `transport/redis` pinning PRs #116/#118/#119/#120, `partition` package unit tests. Phase 2: `sqlmock` / `miniredis` adoption for SQL + Redis stores, retrofit existing tests onto `Eventually`. Phase 3: split mega test files, `t.Parallel()` rollout, flip Codecov to blocking.