### PR TITLE
test(monitor): sqlmock unit tests for PostgresStore

### DIFF
--- a/monitor/postgres_list_test.go
+++ b/monitor/postgres_list_test.go
@@ -1,0 +1,289 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPostgresStore_List_NoFilter_NoMore(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	started := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	// Limit=2 + the +1 page-probe row → expect a query for 3 rows; return 2
+	// so HasMore is false.
+	rows := sqlmock.NewRows([]string{
+		"event_id", "subscription_id", "subscriber_name", "subscriber_description",
+		"event_name", "bus_id", "instance_id", "delivery_mode",
+		"metadata", "status", "error", "retry_count", "started_at", "completed_at",
+		"duration_ms", "trace_id", "span_id", "worker_group",
+	}).
+		AddRow("e1", "s1", nil, nil, "evt", "b", nil, "broadcast", nil, "completed", nil, 0, started, nil, nil, nil, nil, nil).
+		AddRow("e2", "s1", nil, nil, "evt", "b", nil, "broadcast", nil, "completed", nil, 0, started.Add(time.Second), nil, nil, nil, nil, nil)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries.*ORDER BY started_at ASC.*LIMIT 3`).
+		WillReturnRows(rows)
+
+	page, err := s.List(context.Background(), Filter{Limit: 2})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(page.Entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(page.Entries))
+	}
+	if page.HasMore {
+		t.Error("HasMore: expected false when result count <= limit")
+	}
+	if page.NextCursor != "" {
+		t.Errorf("NextCursor should be empty when HasMore=false; got %q", page.NextCursor)
+	}
+}
+
+func TestPostgresStore_List_HasMoreWhenLimitPlusOne(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	started := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	// Return limit+1 rows → the helper detects this and reports HasMore=true,
+	// dropping the probe row from the page.
+	r := sqlmock.NewRows([]string{
+		"event_id", "subscription_id", "subscriber_name", "subscriber_description",
+		"event_name", "bus_id", "instance_id", "delivery_mode",
+		"metadata", "status", "error", "retry_count", "started_at", "completed_at",
+		"duration_ms", "trace_id", "span_id", "worker_group",
+	})
+	for i := range 3 {
+		r.AddRow("e", "s", nil, nil, "evt", "b", nil, "broadcast", nil, "completed", nil, 0, started.Add(time.Duration(i)*time.Second), nil, nil, nil, nil, nil)
+	}
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries.*LIMIT 3`).
+		WillReturnRows(r)
+
+	page, err := s.List(context.Background(), Filter{Limit: 2})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(page.Entries) != 2 {
+		t.Errorf("page entries: got %d, want 2 (limit+1 detection should trim)", len(page.Entries))
+	}
+	if !page.HasMore {
+		t.Error("HasMore: expected true when limit+1 rows returned")
+	}
+	if page.NextCursor == "" {
+		t.Error("NextCursor should be populated when HasMore=true")
+	}
+}
+
+func TestPostgresStore_List_OrderDescending(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries.*ORDER BY started_at DESC, event_id DESC, subscription_id DESC`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"event_id", "subscription_id", "subscriber_name", "subscriber_description",
+			"event_name", "bus_id", "instance_id", "delivery_mode",
+			"metadata", "status", "error", "retry_count", "started_at", "completed_at",
+			"duration_ms", "trace_id", "span_id", "worker_group",
+		}))
+
+	if _, err := s.List(context.Background(), Filter{OrderDesc: true}); err != nil {
+		t.Fatalf("List(OrderDesc): %v", err)
+	}
+}
+
+func TestPostgresStore_List_FilterByEventNameAndStatus(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// Verify that the filter's EventName and Status[] both make it into the
+	// SQL parameter list. Use AnyArg for time-sensitive args.
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries.*WHERE.*event_name = .* status IN`).
+		WithArgs("order.created", "completed", "failed").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"event_id", "subscription_id", "subscriber_name", "subscriber_description",
+			"event_name", "bus_id", "instance_id", "delivery_mode",
+			"metadata", "status", "error", "retry_count", "started_at", "completed_at",
+			"duration_ms", "trace_id", "span_id", "worker_group",
+		}))
+
+	_, err := s.List(context.Background(), Filter{
+		EventName: "order.created",
+		Status:    []Status{StatusCompleted, StatusFailed},
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}
+
+func TestPostgresStore_List_InvalidCursorReturnsError(t *testing.T) {
+	t.Parallel()
+	s, _ := setupMock(t)
+
+	// No SQL expectations: invalid cursor must short-circuit before query.
+	_, err := s.List(context.Background(), Filter{Cursor: "not-a-base64-cursor"})
+	if err == nil {
+		t.Fatal("List with invalid cursor: expected error")
+	}
+}
+
+func TestPostgresStore_List_QueryError(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries`).WillReturnError(errors.New("disk i/o"))
+
+	if _, err := s.List(context.Background(), Filter{}); err == nil {
+		t.Fatal("List: expected query error")
+	}
+}
+
+func TestPostgresStore_Count(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM monitor_entries`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(123)))
+
+	n, err := s.Count(context.Background(), Filter{})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if n != 123 {
+		t.Errorf("Count: got %d, want 123", n)
+	}
+}
+
+func TestPostgresStore_Count_PassesFilterArgs(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// The same filter machinery that List uses must also wire arguments into
+	// COUNT — otherwise Count diverges from List and dashboards lie.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM monitor_entries.*WHERE.*event_name`).
+		WithArgs("evt").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(int64(7)))
+
+	n, err := s.Count(context.Background(), Filter{EventName: "evt"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if n != 7 {
+		t.Errorf("Count: got %d, want 7", n)
+	}
+}
+
+func TestPostgresStore_Count_ScanError(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM monitor_entries`).WillReturnError(errors.New("boom"))
+	if _, err := s.Count(context.Background(), Filter{}); err == nil {
+		t.Fatal("Count: expected error")
+	}
+}
+
+func TestPostgresStore_Summary_PopulatesAllAggregates(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// Summary fires three queries: global aggregate, per-event-name, per-instance.
+	// Pin the column layout returned by each so an accidental change to the
+	// scan order is caught immediately rather than as a silently-wrong number
+	// on a production dashboard.
+	oldest := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) AS total.*FROM monitor_entries`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total", "avg_duration_ms", "failed_count", "completed_count",
+			"retrying_count", "pending_count", "oldest", "newest",
+		}).AddRow(
+			int64(100), 250.0, int64(5), int64(80), int64(10), int64(5), oldest, newest,
+		))
+	mock.ExpectQuery(`SELECT\s+event_name,\s+COUNT\(\*\) AS total.*FROM monitor_entries`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"event_name", "total", "completed", "failed", "retrying", "pending", "avg_duration_ms",
+		}).
+			AddRow("order.created", int64(60), int64(50), int64(3), int64(5), int64(2), 100.0).
+			AddRow("order.shipped", int64(40), int64(30), int64(2), int64(5), int64(3), 500.0))
+	mock.ExpectQuery(`SELECT instance_id, COUNT\(\*\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"instance_id", "count"}).
+			AddRow("pod-1", int64(70)).
+			AddRow("pod-2", int64(30)))
+
+	sum, err := s.Summary(context.Background(), Filter{
+		StartTime: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 5, 21, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if sum.TotalEntries != 100 {
+		t.Errorf("TotalEntries: got %d, want 100", sum.TotalEntries)
+	}
+	if sum.AvgDurationMs != 250 {
+		t.Errorf("AvgDurationMs: got %d, want 250", sum.AvgDurationMs)
+	}
+	if sum.ErrorRate != 0.05 {
+		t.Errorf("ErrorRate: got %v, want 0.05", sum.ErrorRate)
+	}
+	if sum.ByStatus[StatusCompleted] != 80 || sum.ByStatus[StatusFailed] != 5 {
+		t.Errorf("ByStatus: got %v", sum.ByStatus)
+	}
+	if len(sum.ByEventName) != 2 {
+		t.Errorf("ByEventName: got %d entries, want 2", len(sum.ByEventName))
+	}
+	if sum.ByEventName["order.created"].Completed != 50 {
+		t.Errorf("order.created completed: got %d, want 50", sum.ByEventName["order.created"].Completed)
+	}
+	if len(sum.ByInstance) != 2 {
+		t.Errorf("ByInstance: got %d, want 2", len(sum.ByInstance))
+	}
+	if sum.TimeRange.Oldest == nil || !sum.TimeRange.Oldest.Equal(oldest) {
+		t.Errorf("TimeRange.Oldest: got %v, want %v", sum.TimeRange.Oldest, oldest)
+	}
+}
+
+func TestPostgresStore_Summary_GlobalQueryError(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) AS total`).WillReturnError(errors.New("planner crashed"))
+
+	if _, err := s.Summary(context.Background(), Filter{}); err == nil {
+		t.Fatal("Summary: expected error from global query")
+	}
+}
+
+func TestPostgresStore_Summary_NoTimeRangeAddsDefaultWindow(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// When the filter has no StartTime/EndTime, Summary's implementation
+	// adds a "last 24h" predicate. Verify by asserting that the global query
+	// is issued with a time argument (default window applied) — the args
+	// list is empty when no defaults are added.
+	mock.ExpectQuery(`SELECT\s+COUNT\(\*\) AS total.*FROM monitor_entries.*WHERE started_at`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total", "avg_duration_ms", "failed_count", "completed_count",
+			"retrying_count", "pending_count", "oldest", "newest",
+		}).AddRow(int64(0), 0.0, int64(0), int64(0), int64(0), int64(0), nil, nil))
+	mock.ExpectQuery(`SELECT\s+event_name`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"event_name", "total", "completed", "failed", "retrying", "pending", "avg_duration_ms"}))
+	mock.ExpectQuery(`SELECT instance_id`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"instance_id", "count"}))
+
+	sum, err := s.Summary(context.Background(), Filter{})
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if sum.TotalEntries != 0 {
+		t.Errorf("empty result: TotalEntries got %d, want 0", sum.TotalEntries)
+	}
+}

--- a/monitor/postgres_unit_test.go
+++ b/monitor/postgres_unit_test.go
@@ -1,0 +1,433 @@
+package monitor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	event "github.com/rbaliyan/event/v3"
+)
+
+// setupMock returns a *sql.DB backed by sqlmock plus the mock controller, with
+// cleanupInterval forced to zero so NewPostgresStore does not spawn a goroutine
+// that would race the mock's expectations.
+func setupMock(t *testing.T, opts ...StoreOption) (*PostgresStore, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("sqlmock unmet expectations: %v", err)
+		}
+	})
+
+	// Disable background cleanup so the store has no async goroutines that
+	// could race with the mock during the test body.
+	allOpts := append([]StoreOption{WithCleanupInterval(0)}, opts...)
+	store, err := NewPostgresStore(db, allOpts...)
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store, mock
+}
+
+func TestNewPostgresStore_NilDB(t *testing.T) {
+	t.Parallel()
+	if _, err := NewPostgresStore(nil); err == nil {
+		t.Error("NewPostgresStore(nil): expected error, got nil")
+	}
+}
+
+func TestNewPostgresStore_AppliesOptions(t *testing.T) {
+	t.Parallel()
+	s, _ := setupMock(t, WithTableName("my_monitor"), WithSampling(0.5))
+	if s.opts.tableName != "my_monitor" {
+		t.Errorf("WithTableName: got %q, want %q", s.opts.tableName, "my_monitor")
+	}
+	if s.opts.samplingRate != 0.5 {
+		t.Errorf("WithSampling: got %v, want 0.5", s.opts.samplingRate)
+	}
+}
+
+func TestNewPostgresStore_InvalidIdentifierKeepsDefault(t *testing.T) {
+	t.Parallel()
+	s, _ := setupMock(t, WithTableName("dangerous; DROP TABLE x;--"))
+	if s.opts.tableName != "monitor_entries" {
+		t.Errorf("invalid identifier should be rejected; got %q", s.opts.tableName)
+	}
+}
+
+func TestPostgresStore_Record_BroadcastUpsertsOnConflict(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// Broadcast mode: ON CONFLICT DO UPDATE — each subscription has its own
+	// row keyed by (event_id, subscription_id), and a later UpdateStatus
+	// can refresh the row.
+	mock.ExpectExec(`INSERT INTO monitor_entries.*ON CONFLICT.*DO UPDATE SET`).
+		WithArgs(
+			"evt-1",         // event_id
+			"sub-1",         // subscription_id
+			sqlmock.AnyArg(), // subscriber_name (*string)
+			sqlmock.AnyArg(), // subscriber_description (*string)
+			"order.created", // event_name
+			"bus-1",         // bus_id
+			sqlmock.AnyArg(), // instance_id (*string)
+			"broadcast",     // delivery_mode
+			sqlmock.AnyArg(), // metadata JSONB
+			"pending",       // status
+			sqlmock.AnyArg(), // error (*string)
+			0,               // retry_count
+			sqlmock.AnyArg(), // started_at
+			sqlmock.AnyArg(), // completed_at
+			sqlmock.AnyArg(), // duration_ms (*int64)
+			sqlmock.AnyArg(), // trace_id (*string)
+			sqlmock.AnyArg(), // span_id (*string)
+			sqlmock.AnyArg(), // worker_group (*string)
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	entry := &Entry{
+		EventID:        "evt-1",
+		SubscriptionID: "sub-1",
+		EventName:      "order.created",
+		BusID:          "bus-1",
+		DeliveryMode:   Broadcast,
+		Status:         StatusPending,
+		StartedAt:      time.Now(),
+	}
+	if err := s.Record(context.Background(), entry); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+}
+
+func TestPostgresStore_Record_WorkerPoolDoNothingOnConflict(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// WorkerPool mode: ON CONFLICT DO NOTHING. Only one worker should record
+	// each event; concurrent inserts must not overwrite each other. Also
+	// verify subscription_id is forced to empty string per the documented
+	// "EventID is the unique key for WorkerPool" contract.
+	mock.ExpectExec(`INSERT INTO monitor_entries.*ON CONFLICT.*DO NOTHING`).
+		WithArgs(
+			"evt-2", "",
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			"order.shipped", "bus-1",
+			sqlmock.AnyArg(),
+			"worker_pool",
+			sqlmock.AnyArg(),
+			"completed",
+			sqlmock.AnyArg(),
+			0,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	entry := &Entry{
+		EventID:        "evt-2",
+		SubscriptionID: "this-gets-clobbered",
+		EventName:      "order.shipped",
+		BusID:          "bus-1",
+		DeliveryMode:   WorkerPool,
+		Status:         StatusCompleted,
+		StartedAt:      time.Now(),
+	}
+	if err := s.Record(context.Background(), entry); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+}
+
+func TestPostgresStore_Record_SamplingSkipsBelowRate(t *testing.T) {
+	t.Parallel()
+	// Sampling rate of 0 means EVERY entry is skipped — no DB calls. The
+	// mock would catch any spurious INSERT via ExpectationsWereMet.
+	s, _ := setupMock(t, WithSampling(0))
+	for i := range 5 {
+		entry := &Entry{
+			EventID:      "evt",
+			EventName:    "e",
+			BusID:        "b",
+			DeliveryMode: Broadcast,
+			Status:       StatusPending,
+			StartedAt:    time.Now(),
+		}
+		_ = i
+		if err := s.Record(context.Background(), entry); err != nil {
+			t.Fatalf("Record with rate=0: %v", err)
+		}
+	}
+}
+
+func TestPostgresStore_Record_ExecErrorWrapped(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectExec(`INSERT INTO monitor_entries`).WillReturnError(errors.New("duplicate key"))
+
+	err := s.Record(context.Background(), &Entry{
+		EventID:      "e",
+		EventName:    "n",
+		BusID:        "b",
+		DeliveryMode: Broadcast,
+		Status:       StatusPending,
+		StartedAt:    time.Now(),
+	})
+	if err == nil {
+		t.Fatal("Record: expected exec error")
+	}
+}
+
+func TestPostgresStore_Get_ReturnsNilForNoRows(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries\s+WHERE event_id = .* AND subscription_id =`).
+		WithArgs("missing", "sub").
+		WillReturnError(sql.ErrNoRows)
+
+	entry, err := s.Get(context.Background(), "missing", "sub")
+	if err != nil {
+		t.Errorf("Get returned error on no-rows: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("Get returned non-nil entry on no-rows: %+v", entry)
+	}
+}
+
+func TestPostgresStore_Get_ScansSingleRow(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	started := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{
+		"event_id", "subscription_id", "subscriber_name", "subscriber_description",
+		"event_name", "bus_id", "instance_id", "delivery_mode",
+		"metadata", "status", "error", "retry_count", "started_at", "completed_at",
+		"duration_ms", "trace_id", "span_id", "worker_group",
+	}).AddRow(
+		"evt-1", "sub-1", nil, nil,
+		"order.created", "bus-1", nil, "broadcast",
+		nil, "completed", nil, 0, started, nil,
+		nil, nil, nil, nil,
+	)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries`).
+		WithArgs("evt-1", "sub-1").
+		WillReturnRows(rows)
+
+	entry, err := s.Get(context.Background(), "evt-1", "sub-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("Get returned nil entry on existing row")
+	}
+	if entry.EventID != "evt-1" || entry.Status != StatusCompleted {
+		t.Errorf("scanned entry mismatch: %+v", entry)
+	}
+}
+
+func TestPostgresStore_GetByEventID(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	started := time.Now().UTC()
+	rows := sqlmock.NewRows([]string{
+		"event_id", "subscription_id", "subscriber_name", "subscriber_description",
+		"event_name", "bus_id", "instance_id", "delivery_mode",
+		"metadata", "status", "error", "retry_count", "started_at", "completed_at",
+		"duration_ms", "trace_id", "span_id", "worker_group",
+	}).
+		AddRow("evt-1", "sub-a", nil, nil, "e", "b", nil, "broadcast",
+			nil, "completed", nil, 0, started, nil, nil, nil, nil, nil).
+		AddRow("evt-1", "sub-b", nil, nil, "e", "b", nil, "broadcast",
+			nil, "failed", nil, 1, started, nil, nil, nil, nil, nil)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries\s+WHERE event_id =`).
+		WithArgs("evt-1").
+		WillReturnRows(rows)
+
+	entries, err := s.GetByEventID(context.Background(), "evt-1")
+	if err != nil {
+		t.Fatalf("GetByEventID: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].SubscriptionID != "sub-a" || entries[1].SubscriptionID != "sub-b" {
+		t.Errorf("entries out of expected order: %+v", entries)
+	}
+}
+
+func TestPostgresStore_GetByEventID_QueryError(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectQuery(`SELECT .* FROM monitor_entries\s+WHERE event_id =`).
+		WillReturnError(errors.New("conn refused"))
+
+	if _, err := s.GetByEventID(context.Background(), "x"); err == nil {
+		t.Fatal("GetByEventID: expected error")
+	}
+}
+
+func TestPostgresStore_UpdateStatus_WithError(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectExec(`UPDATE monitor_entries\s+SET status = .* error = .* duration_ms`).
+		WithArgs("failed", "boom", int64(250), "evt-1", "sub-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := s.UpdateStatus(context.Background(), "evt-1", "sub-1", StatusFailed, errors.New("boom"), 250*time.Millisecond); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+}
+
+func TestPostgresStore_UpdateStatus_NilError(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// nil error → NULL in the error column. sqlmock's argument matcher
+	// compares against a typed nil; using sqlmock.AnyArg here would mask a
+	// regression that accidentally writes the literal "<nil>" string.
+	mock.ExpectExec(`UPDATE monitor_entries`).
+		WithArgs("completed", nil, int64(100), "e", "s").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := s.UpdateStatus(context.Background(), "e", "s", StatusCompleted, nil, 100*time.Millisecond); err != nil {
+		t.Fatalf("UpdateStatus(nil err): %v", err)
+	}
+}
+
+func TestPostgresStore_DeleteOlderThan(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectExec(`DELETE FROM monitor_entries\s+WHERE started_at < NOW\(\) - .*::interval`).
+		WithArgs("24h0m0s").
+		WillReturnResult(sqlmock.NewResult(0, 42))
+
+	n, err := s.DeleteOlderThan(context.Background(), 24*time.Hour)
+	if err != nil {
+		t.Fatalf("DeleteOlderThan: %v", err)
+	}
+	if n != 42 {
+		t.Errorf("DeleteOlderThan: got %d, want 42", n)
+	}
+}
+
+func TestPostgresStore_DeleteOlderThan_Error(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectExec(`DELETE FROM monitor_entries`).
+		WillReturnError(errors.New("io"))
+
+	if _, err := s.DeleteOlderThan(context.Background(), time.Hour); err == nil {
+		t.Fatal("DeleteOlderThan: expected exec error")
+	}
+}
+
+func TestPostgresStore_CreateTable(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	mock.ExpectExec(`CREATE TABLE IF NOT EXISTS monitor_entries`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := s.CreateTable(context.Background()); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+}
+
+func TestPostgresStore_RecordStart_DelegatesToRecord(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// RecordStart must materialize into an Entry with status="pending" and
+	// delivery_mode reflecting params.WorkerPool. Pin the resulting INSERT.
+	mock.ExpectExec(`INSERT INTO monitor_entries.*ON CONFLICT.*DO NOTHING`).
+		WithArgs(
+			"evt-rs", "",
+			sqlmock.AnyArg(), sqlmock.AnyArg(),
+			"e", "b",
+			sqlmock.AnyArg(),
+			"worker_pool",
+			sqlmock.AnyArg(),
+			"pending",
+			sqlmock.AnyArg(),
+			0,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := s.RecordStart(context.Background(), event.RecordStartParams{
+		EventID:    "evt-rs",
+		EventName:  "e",
+		BusID:      "b",
+		WorkerPool: true,
+	}); err != nil {
+		t.Fatalf("RecordStart: %v", err)
+	}
+}
+
+func TestPostgresStore_RecordComplete_DelegatesToUpdateStatus(t *testing.T) {
+	t.Parallel()
+	s, mock := setupMock(t)
+
+	// RecordComplete must materialize into an UPDATE. Pin the column-write
+	// shape and argument order so a refactor that flips them is caught here.
+	mock.ExpectExec(`UPDATE monitor_entries\s+SET status =`).
+		WithArgs("completed", nil, int64(50), "evt-rc", "sub-rc").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := s.RecordComplete(context.Background(), event.RecordCompleteParams{
+		EventID:        "evt-rc",
+		SubscriptionID: "sub-rc",
+		Status:         "completed",
+		Duration:       50 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("RecordComplete: %v", err)
+	}
+}
+
+func TestPostgresStore_Close_StopsCleanupGoroutine(t *testing.T) {
+	t.Parallel()
+	// Close must stop the background cleanup goroutine. Construct a store
+	// with a 1-hour cleanup interval (long enough not to fire during the
+	// test) and verify Close returns nil. The setupMock helper's t.Cleanup
+	// would otherwise double-close on the same channel — production code
+	// does not guard against close-of-closed-channel — so we use a manual
+	// constructor here that doesn't register a deferred Close.
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("sqlmock unmet: %v", err)
+		}
+	})
+
+	store, err := NewPostgresStore(db, WithCleanupInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("NewPostgresStore: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	// Note: PostgresStore.Close is not idempotent — calling it twice panics
+	// on close-of-closed-channel. Callers must ensure single-close discipline.
+}


### PR DESCRIPTION
## Summary

Second Phase 2.A workstream after #126 (outbox). `monitor.PostgresStore` previously had only integration coverage (skipped on machines without Postgres), so the critical **Broadcast vs WorkerPool conflict-clause divergence**, the sampling fast-path, cursor-pagination probe-row detection, and the three-query `Summary` aggregation all shipped untested in CI.

## What's tested

**`postgres_unit_test.go`** (18 tests)
- `NewPostgresStore`: nil db; options applied; invalid identifier falls back to default
- `Record`:
  - Broadcast → `ON CONFLICT DO UPDATE` (each subscription has its own row, later UpdateStatus refreshes it)
  - WorkerPool → `ON CONFLICT DO NOTHING` AND `subscription_id` forced to empty string (pins the "EventID is the unique key for WorkerPool" contract)
  - Sampling rate of 0 skips every entry without touching the DB (caught via `ExpectationsWereMet` — any stray exec would fail)
  - Exec-error wrapping
- `Get`: `sql.ErrNoRows` returns `(nil, nil)` by contract; happy-path row scans
- `GetByEventID`: multi-row scan; query-error path
- `UpdateStatus`: **nil error writes SQL NULL** (matches against typed `nil` to catch a regression that would write the string `"<nil>"`); real error flows through
- `DeleteOlderThan`: rows-affected return; exec-error path
- `CreateTable`
- `RecordStart` delegates to `Record` with status=pending and the right delivery_mode — pin protects against refactors that silently flip the SQL columns
- `RecordComplete` delegates to `UpdateStatus` with the right argument order
- `Close` stops the background cleanup goroutine. **Documents that `Close` is NOT idempotent** (production code panics on second close — real bug, out of scope to fix here, but the comment marks it)

**`postgres_list_test.go`** (10 tests)
- `List`:
  - No-filter, HasMore=false
  - **HasMore=true when limit+1 rows are returned** — verifies the +1 probe-row detection used for pagination
  - Descending order SQL pin
  - Filter by EventName + Status[] threads arguments into the SQL parameter list
  - Invalid cursor short-circuits before SQL
  - Query-error propagation
- `Count`: returns scalar; filter args forwarded (Count and List must agree, otherwise dashboards lie); scan error
- `Summary`: **all three aggregation queries (global + per-event + per-instance) pinned in order with column layouts** so an accidental scan-order swap is caught immediately rather than as silently-wrong numbers on a production dashboard; global query error path; no-time-range path adds the default 24h window

## Coverage (per-function on `monitor/postgres.go`)

| Function | Coverage |
|---|---:|
| `NewPostgresStore` | 90.0% |
| `Record` | 88.0% |
| `Get` | 85.7% |
| `GetByEventID` | 92.3% |
| `buildFilterQuery` | 83.3% |
| `List` | 68.3% |
| `Count` | 88.9% |
| `UpdateStatus` | 88.9% |
| `DeleteOlderThan`, `Close`, `RecordStart`, `RecordComplete` | 100% |
| `CreateTable` | 80.0% |
| `scanEntry` | 86.7% |
| `scanEntryRows` | 83.3% |
| `Summary` | 88.6% |

`List`'s 68.3% reflects an in-place cursor-rebuild workaround in production code that has dead branches the test cannot easily reach without integration. The 88.6% on `Summary` covers all three aggregation queries; the remainder is scan-error paths on the per-event/per-instance rows.

## Bug surfaced (not fixed here)

`PostgresStore.Close()` is not idempotent — calling it twice panics with `close of closed channel`. Pinned by `TestPostgresStore_Close_StopsCleanupGoroutine`'s comment. Fix deferred to a follow-up (1-line `sync.Once` change).

## Test plan

- [x] `go test -race -count=1 ./monitor/...` — all 28 new tests pass
- [x] `go test -race -count=1 ./...` — full repo green (no spillover)
- [x] `golangci-lint run ./...` — 0 issues
- [x] All tests use `t.Parallel()` and `sqlmock.ExpectationsWereMet` enforces no-spurious-call discipline