### PR TITLE
test(transport/circuit_breaker): Clock injection eliminates time.Sleep

### DIFF
--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -1,0 +1,100 @@
+// Package clock provides a small time abstraction that production code can
+// take as a dependency to enable deterministic tests.
+//
+// This package is a leaf — it has no other internal dependencies — so it
+// can be imported from anywhere in the module (including transport, outbox,
+// monitor, etc.) without risking an import cycle. Test code typically
+// imports github.com/rbaliyan/event/v3/internal/testutil which re-exports
+// type aliases for convenience.
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock is the minimal time surface that production code depends on.
+// The default Real implementation delegates to the time package; tests
+// inject Fake to drive time manually via Advance.
+//
+// Production code should only call methods defined here. Adding new methods
+// (e.g. NewTimer, NewTicker) is fine but requires updating both
+// implementations.
+type Clock interface {
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	Sleep(d time.Duration)
+}
+
+// Real is the production Clock, backed by the standard time package.
+type Real struct{}
+
+// Now returns the current wall-clock time.
+func (Real) Now() time.Time { return time.Now() }
+
+// Since returns the duration elapsed since t.
+func (Real) Since(t time.Time) time.Duration { return time.Since(t) }
+
+// Sleep blocks for at least d.
+func (Real) Sleep(d time.Duration) { time.Sleep(d) }
+
+// Fake is a deterministic Clock for tests. Time only advances when Advance
+// is called explicitly, so race-prone tests built around real time.Sleep
+// timing can be rewritten to drive time directly.
+//
+// Fake is safe for concurrent use.
+type Fake struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewFake constructs a Fake pinned to start. If start is the zero time,
+// Fake starts at the Unix epoch — concrete enough that elapsed durations
+// format readably in test failures.
+func NewFake(start time.Time) *Fake {
+	if start.IsZero() {
+		start = time.Unix(0, 0).UTC()
+	}
+	return &Fake{now: start}
+}
+
+// Now returns the clock's current time.
+func (c *Fake) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// Since returns the duration between the clock's current time and t.
+func (c *Fake) Since(t time.Time) time.Duration {
+	return c.Now().Sub(t)
+}
+
+// Sleep on a Fake advances the clock by d rather than blocking. Production
+// code that calls Sleep for backoff or rate limiting becomes instantly
+// testable.
+func (c *Fake) Sleep(d time.Duration) {
+	c.Advance(d)
+}
+
+// Advance moves the fake clock forward by d. Tests call Advance to simulate
+// the passage of time without blocking.
+func (c *Fake) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// Set forces the fake clock to t. Useful for jumping to a known absolute
+// timestamp (e.g. for testing TTL expiry from a specific epoch).
+func (c *Fake) Set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = t
+}
+
+// Compile-time assertion that both clocks satisfy the interface.
+var (
+	_ Clock = Real{}
+	_ Clock = (*Fake)(nil)
+)

--- a/internal/testutil/clock.go
+++ b/internal/testutil/clock.go
@@ -1,93 +1,26 @@
 package testutil
 
 import (
-	"sync"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
-// Clock is the minimal time surface that production code can take as a
-// dependency to enable deterministic tests. The default RealClock
-// implementation delegates to the time package; tests inject FakeClock to
-// drive time manually via Advance.
-//
-// Production code should only call methods defined here. Adding new methods
-// (e.g. NewTimer, NewTicker) is fine but requires updating both
-// implementations.
-type Clock interface {
-	Now() time.Time
-	Since(t time.Time) time.Duration
-	Sleep(d time.Duration)
-}
+// Clock is re-exported from internal/clock so tests already importing
+// testutil don't need a second import. Production code should import
+// internal/clock directly to avoid pulling in the rest of testutil
+// (which depends on the root event package and would cause cycles when
+// imported from event's own sub-packages).
+type Clock = clock.Clock
 
-// RealClock is the production Clock, backed by the standard time package.
-type RealClock struct{}
+// RealClock is an alias for clock.Real, the production Clock.
+type RealClock = clock.Real
 
-// Now returns the current wall-clock time.
-func (RealClock) Now() time.Time { return time.Now() }
+// FakeClock is an alias for clock.Fake, the test-only deterministic Clock.
+type FakeClock = clock.Fake
 
-// Since returns the duration elapsed since t.
-func (RealClock) Since(t time.Time) time.Duration { return time.Since(t) }
-
-// Sleep blocks for at least d.
-func (RealClock) Sleep(d time.Duration) { time.Sleep(d) }
-
-// FakeClock is a deterministic Clock for tests. Time only advances when
-// Advance is called explicitly, so race-prone tests built around real
-// time.Sleep timing can be rewritten to drive time directly.
-//
-// FakeClock is safe for concurrent use.
-type FakeClock struct {
-	mu  sync.Mutex
-	now time.Time
-}
-
-// NewFakeClock constructs a FakeClock pinned to start. If start is the zero
-// time, FakeClock starts at the Unix epoch — concrete enough that elapsed
-// durations format readably in test failures.
+// NewFakeClock constructs a new test clock pinned to start. If start is the
+// zero time, it defaults to the Unix epoch.
 func NewFakeClock(start time.Time) *FakeClock {
-	if start.IsZero() {
-		start = time.Unix(0, 0).UTC()
-	}
-	return &FakeClock{now: start}
+	return clock.NewFake(start)
 }
-
-// Now returns the clock's current time.
-func (c *FakeClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-// Since returns the duration between the clock's current time and t.
-func (c *FakeClock) Since(t time.Time) time.Duration {
-	return c.Now().Sub(t)
-}
-
-// Sleep on a FakeClock advances the clock by d rather than blocking. Production
-// code that calls Sleep for backoff or rate limiting becomes instantly
-// testable.
-func (c *FakeClock) Sleep(d time.Duration) {
-	c.Advance(d)
-}
-
-// Advance moves the fake clock forward by d. Tests call Advance to simulate
-// the passage of time without blocking.
-func (c *FakeClock) Advance(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.now = c.now.Add(d)
-}
-
-// Set forces the fake clock to t. Useful for jumping to a known absolute
-// timestamp (e.g. for testing TTL expiry from a specific epoch).
-func (c *FakeClock) Set(t time.Time) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.now = t
-}
-
-// Compile-time assertion that both clocks satisfy the interface.
-var (
-	_ Clock = RealClock{}
-	_ Clock = (*FakeClock)(nil)
-)

--- a/transport/circuit_breaker.go
+++ b/transport/circuit_breaker.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"sync/atomic"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
 // ErrCircuitOpen is returned when the circuit breaker is open and rejecting calls.
@@ -25,9 +27,14 @@ type CircuitBreaker struct {
 	threshold int32
 	cooldown  time.Duration
 
+	// clk supplies the current time. Defaults to clock.Real{} in production;
+	// tests inject clock.Fake via withClock to drive cooldown deterministically
+	// without time.Sleep.
+	clk clock.Clock
+
 	state    atomic.Int32
 	failures atomic.Int32
-	openedAt atomic.Int64 // UnixNano when breaker opened
+	openedAt atomic.Int64 // clock.Now().UnixNano() when breaker opened
 	probing  atomic.Int32 // CAS gate: 1 if a half-open probe is in-flight
 }
 
@@ -42,7 +49,20 @@ func NewCircuitBreaker(threshold int, cooldown time.Duration) *CircuitBreaker {
 		enabled:   true,
 		threshold: int32(threshold), // #nosec G115 -- value is bounded
 		cooldown:  cooldown,
+		clk:       clock.Real{},
 	}
+}
+
+// withClock swaps the clock for tests. Unexported on purpose — callers in
+// other packages should not be able to install a clock and rely on its
+// implementation detail. Used only from circuit_breaker_test.go, which
+// golangci-lint excludes by default (--tests=false in CI); hence the
+// explicit allow-list below.
+//
+//nolint:unused // used from circuit_breaker_test.go
+func (cb *CircuitBreaker) withClock(c clock.Clock) *CircuitBreaker {
+	cb.clk = c
+	return cb
 }
 
 // Allow checks whether a call is permitted. Returns nil if allowed,
@@ -59,7 +79,7 @@ func (cb *CircuitBreaker) Allow() error {
 	case cbOpen:
 		// Check if cooldown has elapsed
 		opened := cb.openedAt.Load()
-		if time.Since(time.Unix(0, opened)) < cb.cooldown {
+		if cb.clk.Now().Sub(time.Unix(0, opened)) < cb.cooldown {
 			return ErrCircuitOpen
 		}
 		// Cooldown elapsed — try to become the probe caller
@@ -98,7 +118,7 @@ func (cb *CircuitBreaker) RecordFailure() {
 
 	// Half-open probe failed — re-open immediately
 	if cb.state.CompareAndSwap(cbHalfOpen, cbOpen) {
-		cb.openedAt.Store(time.Now().UnixNano())
+		cb.openedAt.Store(cb.clk.Now().UnixNano())
 		cb.failures.Store(0)
 		cb.probing.Store(0)
 		return
@@ -107,7 +127,7 @@ func (cb *CircuitBreaker) RecordFailure() {
 	n := cb.failures.Add(1)
 	if n >= cb.threshold {
 		if cb.state.CompareAndSwap(cbClosed, cbOpen) {
-			cb.openedAt.Store(time.Now().UnixNano())
+			cb.openedAt.Store(cb.clk.Now().UnixNano())
 			cb.failures.Store(0)
 		}
 	}

--- a/transport/circuit_breaker_test.go
+++ b/transport/circuit_breaker_test.go
@@ -5,7 +5,18 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
+
+// newCBWithFakeClock constructs a breaker wired to a FakeClock pinned at the
+// Unix epoch. Test bodies call clk.Advance to deterministically cross the
+// cooldown boundary instead of time.Sleep.
+func newCBWithFakeClock(threshold int, cooldown time.Duration) (*CircuitBreaker, *clock.Fake) {
+	clk := clock.NewFake(time.Time{})
+	cb := NewCircuitBreaker(threshold, cooldown).withClock(clk)
+	return cb, clk
+}
 
 func TestCircuitBreaker_DisabledByDefault(t *testing.T) {
 	// nil circuit breaker should be a no-op
@@ -88,7 +99,7 @@ func TestCircuitBreaker_SuccessResetsFailureCount(t *testing.T) {
 }
 
 func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
-	cb := NewCircuitBreaker(1, 20*time.Millisecond)
+	cb, clk := newCBWithFakeClock(1, 20*time.Millisecond)
 
 	// Trip the breaker
 	cb.Allow()
@@ -97,14 +108,16 @@ func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
 		t.Fatalf("State() = %q, want %q", s, "open")
 	}
 
-	// Before cooldown — rejected
+	// Before cooldown — rejected. Advance just shy of the cooldown to
+	// pin that the boundary is checked, not the wall clock.
+	clk.Advance(19 * time.Millisecond)
 	err := cb.Allow()
 	if !errors.Is(err, ErrCircuitOpen) {
 		t.Fatalf("Allow() before cooldown = %v, want ErrCircuitOpen", err)
 	}
 
-	// Wait for cooldown
-	time.Sleep(30 * time.Millisecond)
+	// Cross the cooldown boundary.
+	clk.Advance(2 * time.Millisecond)
 
 	// First call should be allowed (probe)
 	if err := cb.Allow(); err != nil {
@@ -122,12 +135,12 @@ func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
 }
 
 func TestCircuitBreaker_ProbeSuccessCloses(t *testing.T) {
-	cb := NewCircuitBreaker(1, 10*time.Millisecond)
+	cb, clk := newCBWithFakeClock(1, 10*time.Millisecond)
 
-	// Trip and wait for cooldown
+	// Trip and cross the cooldown boundary via the fake clock.
 	cb.Allow()
 	cb.RecordFailure()
-	time.Sleep(15 * time.Millisecond)
+	clk.Advance(15 * time.Millisecond)
 
 	// Probe
 	if err := cb.Allow(); err != nil {
@@ -146,12 +159,12 @@ func TestCircuitBreaker_ProbeSuccessCloses(t *testing.T) {
 }
 
 func TestCircuitBreaker_ProbeFailureReopens(t *testing.T) {
-	cb := NewCircuitBreaker(1, 10*time.Millisecond)
+	cb, clk := newCBWithFakeClock(1, 10*time.Millisecond)
 
-	// Trip and wait for cooldown
+	// Trip and cross the cooldown boundary via the fake clock.
 	cb.Allow()
 	cb.RecordFailure()
-	time.Sleep(15 * time.Millisecond)
+	clk.Advance(15 * time.Millisecond)
 
 	// Probe
 	if err := cb.Allow(); err != nil {
@@ -163,10 +176,18 @@ func TestCircuitBreaker_ProbeFailureReopens(t *testing.T) {
 		t.Fatalf("State() after probe failure = %q, want %q", s, "open")
 	}
 
-	// Should be rejected again (cooldown restarted)
+	// Should be rejected again (cooldown restarted). The probe failure
+	// re-records openedAt at the current fake-clock time, so a fresh
+	// cooldown window starts here — verify by NOT advancing.
 	err := cb.Allow()
 	if !errors.Is(err, ErrCircuitOpen) {
 		t.Fatalf("Allow() after reopen = %v, want ErrCircuitOpen", err)
+	}
+
+	// And after advancing past the new cooldown, the probe path opens again.
+	clk.Advance(15 * time.Millisecond)
+	if err := cb.Allow(); err != nil {
+		t.Errorf("Allow() after second cooldown = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

**First Phase 2.C workstream.** Replaces three `time.Sleep` cooldown waits in `circuit_breaker_test.go` with deterministic `clock.Fake.Advance` calls. Establishes the pattern for the remaining Clock-injection surfaces called out in the test-quality plan (coalesce, outbox/relay, monitor/stream/broadcaster, store/base/cleanup, distributed/recovery).

## What changed in production

- **New `internal/clock` package** — leaf package (no other internal deps) with `Clock` interface, `Real`, and `Fake`. Lives separately from `internal/testutil` so that production code (transport, outbox, etc.) can import it without pulling `testutil`'s `bus.go` through the root `event` package, which would create an import cycle (`transport → testutil → event → transport`).

- **`internal/testutil/clock.go`** now re-exports `Clock` / `RealClock` / `FakeClock` / `NewFakeClock` as aliases of `clock.Clock` / `clock.Real` / `clock.Fake` / `clock.NewFake` for back-compat with existing test consumers.

- **`CircuitBreaker`** gains an unexported `clk clock.Clock` field (default `clock.Real{}`) and an unexported `withClock` test hook. The two `time.Now().UnixNano()` call sites (`RecordFailure` → `openedAt`) and the `time.Since()` call site (`Allow` cooldown check) all route through the clock.

## What changed in tests

- `newCBWithFakeClock` helper constructs a breaker wired to a `clock.Fake` pinned at the Unix epoch.
- `TestCircuitBreaker_HalfOpenAfterCooldown` drops its 30ms `time.Sleep` and instead `Advance(19ms)` then `Advance(2ms)` — **pinning that the cooldown boundary is checked at exactly the configured duration**, not "approximately".
- `TestCircuitBreaker_ProbeSuccessCloses` and `_ProbeFailureReopens` drop their 15ms sleeps for `Advance(15ms)`.
- `_ProbeFailureReopens` additionally pins that the probe-failure reopen path **resets the cooldown window** (no advance ⇒ still rejected; advance again ⇒ permitted) — a behavior previously implicit and untested.

## Why a new `internal/clock` package instead of `internal/testutil`

The initial naive approach (production imports `internal/testutil`) triggered an import cycle: `internal/testutil/bus.go` imports the root `event` package for `event.NewBus`, and the root `event` package transitively imports `transport`. So `transport → testutil → event → transport` is forbidden.

Splitting Clock into its own leaf package avoids the cycle. `internal/testutil/clock.go` continues to expose the same identifiers via type aliases, so all existing test imports keep working — no test-side churn.

## Coverage and runtime

- Test runtime collapsed from ~60ms of real sleeps to ~0ms — verified by `go test -race` timing.
- 3 `time.Sleep` call sites eliminated; **151 remaining** in the rest of the test suite per the Phase 2.C plan.
- Per-function coverage on `circuit_breaker.go` unchanged (~100%); the `withClock` hook is marked `//nolint:unused` because golangci-lint runs with `--tests=false` and would otherwise flag it.

## Test plan

- [x] `go test -race -count=1 ./transport/...` — 8 circuit-breaker tests pass in <10ms (previously ~70ms)
- [x] `go test -race -count=1 ./...` — full repo green (no spillover from the Clock split)
- [x] `golangci-lint run ./...` — 0 issues
- [x] No external API changes; downstream consumers see no churn.

## Next surfaces (deferred to follow-up PRs)

Per the plan: `coalesce.go`, `outbox/relay.go`, `monitor/stream/broadcaster.go`, `store/base/cleanup.go`, `distributed/recovery.go`. Each is a separate small PR following the same pattern (default `clock.Real{}` in constructor, unexported `withClock` test hook, swap call sites).