### PR TITLE
test(monitor/http): replace all 9 time.Sleep calls with Eventually polling

### DIFF
--- a/monitor/http/system_test.go
+++ b/monitor/http/system_test.go
@@ -9,8 +9,21 @@ import (
 	"time"
 
 	"github.com/rbaliyan/event/v3/health"
+	"github.com/rbaliyan/event/v3/internal/testutil"
 	"github.com/rbaliyan/event/v3/monitor"
 )
+
+// waitForCache polls until the handler's background refresh goroutine has
+// populated the systemView cache, then returns. This replaces the previous
+// fixed time.Sleep waits that were sized as "100-150ms should be enough"
+// against a 50ms refresh interval — worst-case bounds that wasted time on
+// the happy path and could still flake on a loaded CI runner.
+func waitForCache(t *testing.T, h *Handler) {
+	t.Helper()
+	testutil.Eventually(t, 2*time.Second, func() bool {
+		return h.systemView.Load() != nil
+	}, "background refresh did not populate systemView cache")
+}
 
 // mockDLQProvider implements DLQProvider for testing.
 type mockDLQProvider struct {
@@ -42,7 +55,7 @@ func TestHandleSystemView(t *testing.T) {
 	t.Run("basic system view without providers", func(t *testing.T) {
 		h := New(store, WithSystemRefreshInterval(50*time.Millisecond))
 		defer h.Close()
-		time.Sleep(100 * time.Millisecond)
+		waitForCache(t, h)
 		req := httptest.NewRequest(http.MethodGet, "/v1/system", nil)
 		w := httptest.NewRecorder()
 
@@ -84,7 +97,7 @@ func TestHandleSystemView(t *testing.T) {
 
 		h := New(store, WithDLQProvider(dlq), WithSystemRefreshInterval(50*time.Millisecond))
 		defer h.Close()
-		time.Sleep(100 * time.Millisecond)
+		waitForCache(t, h)
 		req := httptest.NewRequest(http.MethodGet, "/v1/system", nil)
 		w := httptest.NewRecorder()
 
@@ -133,7 +146,7 @@ func TestHandleSystemHealth(t *testing.T) {
 	t.Run("healthy when no providers", func(t *testing.T) {
 		h := New(store, WithSystemRefreshInterval(50*time.Millisecond))
 		defer h.Close()
-		time.Sleep(100 * time.Millisecond)
+		waitForCache(t, h)
 		req := httptest.NewRequest(http.MethodGet, "/v1/system/health", nil)
 		w := httptest.NewRecorder()
 
@@ -165,7 +178,7 @@ func TestHandleSystemHealth(t *testing.T) {
 
 		h := New(store, WithDLQProvider(dlq), WithSystemRefreshInterval(50*time.Millisecond))
 		defer h.Close()
-		time.Sleep(100 * time.Millisecond)
+		waitForCache(t, h)
 		req := httptest.NewRequest(http.MethodGet, "/v1/system/health", nil)
 		w := httptest.NewRecorder()
 
@@ -201,7 +214,7 @@ func TestBackgroundRefresh(t *testing.T) {
 	defer h.Close()
 
 	// Wait for first refresh
-	time.Sleep(150 * time.Millisecond)
+	waitForCache(t, h)
 
 	// Verify cache is populated
 	cached := h.systemView.Load()
@@ -241,7 +254,7 @@ func TestBackgroundRefresh_Health(t *testing.T) {
 	defer h.Close()
 
 	// Wait for first refresh
-	time.Sleep(150 * time.Millisecond)
+	waitForCache(t, h)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/system/health", nil)
 	w := httptest.NewRecorder()
@@ -267,7 +280,7 @@ func TestClose(t *testing.T) {
 	h := New(store, WithSystemRefreshInterval(50*time.Millisecond))
 
 	// Wait for at least one refresh
-	time.Sleep(100 * time.Millisecond)
+	waitForCache(t, h)
 
 	// Close should be idempotent
 	h.Close()
@@ -322,7 +335,7 @@ func TestCachedTopology(t *testing.T) {
 	defer h.Close()
 
 	// Wait for refresh
-	time.Sleep(150 * time.Millisecond)
+	waitForCache(t, h)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/topology", nil)
 	w := httptest.NewRecorder()
@@ -361,7 +374,7 @@ func TestHandleSystemView_StuckPending(t *testing.T) {
 		WithStuckPendingProvider(provider),
 	)
 	defer h.Close()
-	time.Sleep(100 * time.Millisecond)
+	waitForCache(t, h)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/system", nil))


### PR DESCRIPTION
## Summary

**Fourth Phase 2.C workstream** after #135 (circuit_breaker Clock), #136 (ack_policy sleeps), and #137 (stack sleeps). The monitor HTTP handler runs a background refresh goroutine that populates `h.systemView` at a configured interval; tests previously slept 100-150ms after construction to ensure the first refresh ran before issuing the test request.

All 9 sleeps replaced with a single **`waitForCache`** helper that polls `h.systemView.Load() != nil`. The helper:

- **Exits the instant** the contract is met (refresh ran), so happy-path tests no longer wait the full sleep duration.
- Has a **generous 2-second deadline** that only fires when something is actually wrong (would catch a refresh-goroutine-crashed bug).
- Replaces a worst-case bound that could simultaneously waste time on fast machines AND flake on loaded CI runners.

## Tests refactored

| Test | Sleeps removed | Replacement |
|---|---:|---|
| `TestHandleSystemView` (basic + DLQ provider) | 2 × 100ms | `waitForCache(t, h)` |
| `TestHandleSystemHealth` (healthy + unhealthy) | 2 × 100ms | `waitForCache(t, h)` |
| `TestBackgroundRefresh` | 1 × 150ms | `waitForCache(t, h)` |
| `TestBackgroundRefresh_Health` | 1 × 150ms | `waitForCache(t, h)` |
| `TestClose` | 1 × 100ms | `waitForCache(t, h)` (was waiting for refresh to populate cache before calling `Close`) |
| `TestCachedTopology` | 1 × 150ms | `waitForCache(t, h)` |
| `TestHandleSystemView_StuckPending` | 1 × 100ms | `waitForCache(t, h)` |

## Import note

`monitor/http` is in `package http` (internal test) but it does not import the root `event` package, so `internal/testutil` works fine — no cycle. (Compare to `ack_policy_test.go` in #136 where the root `event` package's tests had to use a local helper.)

## Total Phase 2.C progress

| PR | Sleeps eliminated |
|---|---:|
| #135 | 3 |
| #136 | 6 |
| #137 | 8 |
| **this PR** | **9** |

**Cumulative: 26 of 154 sleeps eliminated, 128 remaining.**

## Test plan

- [x] `go test -race -count=1 ./monitor/http/...` — all tests pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `golangci-lint run ./...` — 0 issues
- [x] No production code changes; pure test-side refactor.