### PR TITLE
fix(test): retry initial Publish in coalesce test to avoid CI race

### DIFF
--- a/ack_policy_test.go
+++ b/ack_policy_test.go
@@ -239,16 +239,42 @@ func TestWithCoalesceByKey_SupersedesPendingMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Subscribe is synchronous — publish initial message immediately.
-	if err := ev.Publish(ctx, Order{ID: "A", Value: 1}); err != nil {
+	// Publish the initial message and wait for the handler to start. Unlike
+	// the other ack_policy tests, WithCoalesceByKey wraps the subscription
+	// in a coalescer that runs on a separate goroutine started during
+	// Subscribe; that goroutine's `select { case <-incoming: ... }` is set
+	// up asynchronously, so a Publish that races it can land in the
+	// coalescer's buffered incoming channel before the run loop is reading
+	// from it. The buffer absorbs the message but the handler has nothing
+	// to react to until the run loop catches up.
+	//
+	// Retry the initial publish until handlerReady fires. All retries land
+	// under the same key and coalesce harmlessly into a single delivery —
+	// the coalescer's supersede logic preserves the latest value. This
+	// pattern is deterministic on both fast machines and loaded CI runners,
+	// replacing a fixed 50ms pre-Publish sleep that CI proved was not
+	// always sufficient.
+	const initial = 1
+	if err := ev.Publish(ctx, Order{ID: "A", Value: initial}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Wait for handler to start processing the first message.
-	select {
-	case <-handlerReady:
-	case <-time.After(time.Second):
-		t.Fatal("handler didn't start")
+	handlerStarted := false
+	deadline := time.Now().Add(2 * time.Second)
+	for !handlerStarted && time.Now().Before(deadline) {
+		select {
+		case <-handlerReady:
+			handlerStarted = true
+		case <-time.After(50 * time.Millisecond):
+			// Republish — coalescer may have missed the first send if its
+			// run loop was not yet ready when we published.
+			if err := ev.Publish(ctx, Order{ID: "A", Value: initial}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if !handlerStarted {
+		t.Fatal("handler didn't start after retries")
 	}
 
 	// While handler is busy, send more messages for same key.


### PR DESCRIPTION
## Summary

**Forward-fix for #136.** CI smoke and integration jobs on PR #138 surfaced a race that #136 introduced.

`TestWithCoalesceByKey_SupersedesPendingMessages` removed the pre-Publish 50ms sleep on the assumption that `Subscribe` is synchronous on the channel transport. That's true for the simple ack_policy tests (BestEffort, AckPolicy, BestEffortMiddleware) — and remains true in their current form — but **not** for `WithCoalesceByKey`.

### Root cause

`WithCoalesceByKey` wraps the subscription in a coalescer that runs on a **separate goroutine** started by `Subscribe`. The goroutine's `select { case <-c.incoming: ... }` is set up asynchronously, so a `Publish` that races it can land in the coalescer's buffered `incoming` channel before the run loop is reading from it. The buffer absorbs the message but the handler has nothing to react to until the run loop catches up — which on a loaded CI runner may take longer than 50ms.

Failure surfaced on both:
- [Smoke](https://github.com/rbaliyan/event/actions/runs/26143862946/job/76894820076)
- [Integration (Redis + Postgres)](https://github.com/rbaliyan/event/actions/runs/26143862968/job/76894820177)

Both fail with `ack_policy_test.go:251: handler didn't start`.

### Fix

Retry the initial `Publish` until `handlerReady` fires. All retries land under the same key and coalesce harmlessly into a single delivery (the coalescer's supersede logic preserves the latest value). The retry loop has a 2-second deadline with 50ms between retries.

This is **deterministic** on both fast machines and loaded CI runners — verified with:

```
go test -race -count=10 -run TestWithCoalesceByKey .
```

10/10 runs pass.

### Why not just restore the fixed sleep

A fixed sleep is a worst-case bound that can simultaneously waste time on fast machines AND flake on loaded CI runners — exactly the pattern Phase 2.C is moving the suite away from. The retry-publish loop pins the actual contract (`handler started`) directly and exits the instant the contract is met.

### Test plan

- [x] `go test -race -count=10 -run TestWithCoalesceByKey .` — 10/10 pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `go test -race -tags=smoke ./...` — smoke green
- [x] `golangci-lint run ./...` — 0 issues
- [x] No production code changes.