### PR TITLE
test(distributed): inject Clock into MemoryStateManager, replace 9 sleeps

### DIFF
--- a/distributed/claimer.go
+++ b/distributed/claimer.go
@@ -89,6 +89,7 @@ import (
 	"time"
 
 	event "github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
 // Coordinator handles atomic state transitions for WorkerPool emulation.
@@ -182,6 +183,20 @@ func (s *StaleMessage) HasPayload() bool {
 // Option configures a state manager implementation.
 type Option func(*stateOptions)
 
+// withClock is an unexported test hook that swaps the clock used by
+// MemoryStateManager for TTL and stale-timeout checks. Tests use it together
+// with clock.Fake to drive expiry deterministically instead of time.Sleep.
+//
+// Not exported because production users have no reason to override the clock,
+// and locking the door at the package boundary keeps the contract clear.
+func withClock(c clock.Clock) Option { //nolint:unused // used by *_test.go
+	return func(o *stateOptions) {
+		if c != nil {
+			o.clock = c
+		}
+	}
+}
+
 // StaleResetter is an optional interface that Coordinator implementations
 // can provide for efficient batch stale state reset.
 type StaleResetter interface {
@@ -202,6 +217,10 @@ type stateOptions struct {
 	capped         bool
 	cappedSize     int64
 	cappedMaxDocs  int64
+	// clock supplies the current time for TTL and stale-timeout checks.
+	// Defaults to clock.Real{}; tests override via the unexported withClock
+	// option to drive expiry deterministically.
+	clock clock.Clock
 }
 
 // defaultStateOptions returns sensible defaults for state manager configuration.
@@ -211,6 +230,7 @@ func defaultStateOptions() *stateOptions {
 		completionTTL:  24 * time.Hour,
 		cleanupEnabled: true,
 		cleanupPeriod:  time.Hour,
+		clock:          clock.Real{},
 	}
 }
 

--- a/distributed/memory.go
+++ b/distributed/memory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
 // stateValue represents the state of a message.
@@ -64,6 +66,9 @@ type MemoryStateManager struct {
 	completionTTL time.Duration
 	stopCleanup   chan struct{}
 	cleanupDone   chan struct{}
+	// clk supplies the current time for TTL and stale-timeout checks.
+	// Defaults to clock.Real{}; tests inject clock.Fake via withClock.
+	clk clock.Clock
 }
 
 // NewMemoryStateManager creates a new in-memory state manager.
@@ -97,6 +102,7 @@ func NewMemoryStateManager(opts ...Option) *MemoryStateManager {
 		completionTTL: o.completionTTL,
 		stopCleanup:   make(chan struct{}),
 		cleanupDone:   make(chan struct{}),
+		clk:           o.clock,
 	}
 
 	if o.cleanupEnabled {
@@ -125,7 +131,7 @@ func (s *MemoryStateManager) Acquire(_ context.Context, messageID string, ttl ti
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
+	now := s.clk.Now()
 
 	// Check existing state
 	if entry, exists := s.states[messageID]; exists {
@@ -161,7 +167,7 @@ func (s *MemoryStateManager) MarkProcessed(_ context.Context, messageID string) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
+	now := s.clk.Now()
 	if entry, exists := s.states[messageID]; exists {
 		entry.state = stateCompleted
 		entry.expiresAt = now.Add(s.completionTTL)
@@ -201,7 +207,7 @@ func (s *MemoryStateManager) ListStale(_ context.Context, staleTimeout time.Dura
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cutoff := time.Now().Add(-staleTimeout)
+	cutoff := s.clk.Now().Add(-staleTimeout)
 	var stale []string
 
 	for id, entry := range s.states {
@@ -232,7 +238,7 @@ func (s *MemoryStateManager) LoadStalePayloads(_ context.Context, staleTimeout t
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	cutoff := time.Now().Add(-staleTimeout)
+	cutoff := s.clk.Now().Add(-staleTimeout)
 	var result []*StaleMessage
 
 	for id, entry := range s.states {
@@ -277,7 +283,7 @@ func (s *MemoryStateManager) ResetStale(_ context.Context, staleTimeout time.Dur
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cutoff := time.Now().Add(-staleTimeout)
+	cutoff := s.clk.Now().Add(-staleTimeout)
 	var reset int64
 
 	for id, entry := range s.states {
@@ -330,7 +336,7 @@ func (s *MemoryStateManager) cleanupExpired() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
+	now := s.clk.Now()
 	for id, entry := range s.states {
 		if now.After(entry.expiresAt) {
 			delete(s.states, id)

--- a/distributed/payload_test.go
+++ b/distributed/payload_test.go
@@ -7,12 +7,25 @@ import (
 	"time"
 
 	"github.com/rbaliyan/event/v3"
+	"github.com/rbaliyan/event/v3/internal/clock"
 	"github.com/rbaliyan/event/v3/transport/channel"
 )
 
+// newSMWithFakeClock constructs a MemoryStateManager wired to a Fake clock
+// pinned at the Unix epoch. Test bodies call clk.Advance to deterministically
+// cross TTL / stale-timeout boundaries instead of time.Sleep.
+//
+// Cleanup is disabled (WithCleanup(false, 0)) so the background goroutine
+// doesn't race with the test's clock manipulation.
+func newSMWithFakeClock(opts ...Option) (*MemoryStateManager, *clock.Fake) {
+	clk := clock.NewFake(time.Time{})
+	all := append([]Option{WithCleanup(false, 0), withClock(clk)}, opts...)
+	return NewMemoryStateManager(all...), clk
+}
+
 func TestMemoryCoordinator_AcquireAndStorePayload(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, _ := newSMWithFakeClock()
 	defer sm.Close()
 
 	// Acquire state
@@ -55,7 +68,7 @@ func TestMemoryCoordinator_AcquireAndStorePayload(t *testing.T) {
 
 func TestMemoryCoordinator_Acquire_Expiry(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	// Acquire with very short TTL
@@ -64,8 +77,8 @@ func TestMemoryCoordinator_Acquire_Expiry(t *testing.T) {
 		t.Fatal("expected acquisition to succeed")
 	}
 
-	// Wait for expiry
-	time.Sleep(20 * time.Millisecond)
+	// Cross the TTL boundary via the fake clock — instant, deterministic.
+	clk.Advance(20 * time.Millisecond)
 
 	// Should be acquirable again
 	acquired, _ = sm.Acquire(ctx, "msg-1", time.Minute)
@@ -76,7 +89,7 @@ func TestMemoryCoordinator_Acquire_Expiry(t *testing.T) {
 
 func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	// Acquire with payload
@@ -94,11 +107,13 @@ func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
 	sm.StorePayload(ctx, "msg-3", &MessageData{Payload: []byte(`completed`)})
 	sm.MarkProcessed(ctx, "msg-3")
 
-	// Make processing entries stale
+	// Make processing entries stale by backdating updatedAt relative to the
+	// FAKE clock — not real wall-clock — since LoadStalePayloads compares
+	// against clk.Now() under the injected fake.
 	sm.mu.Lock()
 	for id, entry := range sm.states {
 		if id != "msg-3" {
-			entry.updatedAt = time.Now().Add(-5 * time.Minute)
+			entry.updatedAt = clk.Now().Add(-5 * time.Minute)
 		}
 	}
 	sm.mu.Unlock()
@@ -128,7 +143,7 @@ func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
 	sm.Acquire(ctx, "msg-4", time.Hour)
 	sm.StorePayload(ctx, "msg-4", &MessageData{Payload: []byte(`another`)})
 	sm.mu.Lock()
-	sm.states["msg-4"].updatedAt = time.Now().Add(-5 * time.Minute)
+	sm.states["msg-4"].updatedAt = clk.Now().Add(-5 * time.Minute)
 	sm.mu.Unlock()
 
 	stale, err = sm.LoadStalePayloads(ctx, time.Minute, 1)
@@ -142,7 +157,7 @@ func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
 
 func TestMemoryPayloadStore_ClearPayload(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, _ := newSMWithFakeClock()
 	defer sm.Close()
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
@@ -235,7 +250,7 @@ func (m *mockPublisher) Send(_ context.Context, eventName, eventID string, paylo
 
 func TestRecoveryRunner_BasicReset(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	// No Publisher → basic reset mode
@@ -249,7 +264,7 @@ func TestRecoveryRunner_BasicReset(t *testing.T) {
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.Acquire(ctx, "msg-2", time.Hour)
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	recovered, err := runner.RecoverOnce(ctx)
 	if err != nil {
@@ -272,7 +287,7 @@ func TestRecoveryRunner_BasicReset(t *testing.T) {
 
 func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	pub := &mockPublisher{}
@@ -302,7 +317,7 @@ func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
 	// msg-3: no payload (Phase 2 resets)
 	sm.Acquire(ctx, "msg-3", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	recovered, err := runner.RecoverOnce(ctx)
 	if err != nil {
@@ -326,7 +341,7 @@ func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
 
 func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	runner, err := NewRecoveryRunner(sm,
@@ -341,7 +356,7 @@ func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
 	sm.Acquire(ctx, "msg-2", time.Hour)
 	sm.Acquire(ctx, "msg-3", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	recovered, err := runner.RecoverOnce(ctx)
 	if err != nil {
@@ -355,7 +370,7 @@ func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
 
 func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	pub := &mockPublisher{}
@@ -380,7 +395,7 @@ func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
 	// Acquire without payload (should be reset, not re-published)
 	sm.Acquire(ctx, "msg-2", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	recovered, err := runner.RecoverOnce(ctx)
 	if err != nil {
@@ -422,7 +437,7 @@ func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
 
 func TestRecoveryRunner_PublishFailure_SkipsEntry(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	// Publisher that always fails
@@ -442,7 +457,7 @@ func TestRecoveryRunner_PublishFailure_SkipsEntry(t *testing.T) {
 		EventName: "order.created",
 	})
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	// Phase 1 should skip the entry (publish failed), Phase 2 should NOT
 	// reset it because it was handled by Phase 1 (in the exclusion set)
@@ -480,7 +495,7 @@ func TestRecoveryRunner_WithRealBus(t *testing.T) {
 		t.Fatalf("failed to register event: %v", err)
 	}
 
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	// Bus satisfies Publisher interface
@@ -500,7 +515,7 @@ func TestRecoveryRunner_WithRealBus(t *testing.T) {
 		EventName: "order.created",
 	})
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	recovered, err := runner.RecoverOnce(ctx)
 	if err != nil {
@@ -647,7 +662,7 @@ func TestRecoveryOption_WithBackoff(t *testing.T) {
 
 func TestRecoveryRunner_RecoverOnce_NoStaleEntries(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, _ := newSMWithFakeClock()
 	defer sm.Close()
 
 	runner, err := NewRecoveryRunner(sm,
@@ -668,14 +683,14 @@ func TestRecoveryRunner_RecoverOnce_NoStaleEntries(t *testing.T) {
 }
 
 func TestMemoryStateManager_CleanupExpired(t *testing.T) {
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	ctx := context.Background()
 	sm.Acquire(ctx, "msg-1", 10*time.Millisecond)
 	sm.Acquire(ctx, "msg-2", time.Hour)
 
-	time.Sleep(20 * time.Millisecond)
+	clk.Advance(20 * time.Millisecond)
 	sm.cleanupExpired()
 
 	sm.mu.RLock()
@@ -689,7 +704,7 @@ func TestMemoryStateManager_CleanupExpired(t *testing.T) {
 
 func TestRecoveryRunner_WithMetrics(t *testing.T) {
 	ctx := context.Background()
-	sm := NewMemoryStateManager(WithCleanup(false, 0))
+	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
 	metrics, err := NewRecoveryMetrics()
@@ -706,7 +721,7 @@ func TestRecoveryRunner_WithMetrics(t *testing.T) {
 	}
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	recovered, err := runner.RecoverOnce(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

**Sixth Phase 2.C workstream** after #135 (circuit_breaker Clock), #136 (ack_policy sleeps), #137 (stack sleeps), #138 (monitor/http sleeps), and #139 (coalesce race fix).

The `distributed` package's `TestMemoryCoordinator_Acquire_Expiry` and 7 `RecoveryRunner` tests slept 20-60ms after `Acquire` to wait for **TTL expiry or stale-timeout to fire** — these are deliberate, scenario-relevant waits for time-based production logic, NOT async-setup races. Perfect Clock-injection candidates per the plan.

All 9 sleeps replaced with `clock.Fake.Advance` via the pattern established in #135.

## Production changes

**`distributed/claimer.go`**:
- `stateOptions` gains an unexported `clock clock.Clock` field defaulting to `clock.Real{}`
- Adds unexported `withClock` option (annotated `//nolint:unused` — golangci-lint runs with `--tests=false`)

**`distributed/memory.go`**:
- `MemoryStateManager` gains an unexported `clk clock.Clock` field set from options
- **Six** `time.Now()` call sites routed through `s.clk.Now()`:
  - `Acquire`: expiry check + setting `expiresAt`/`updatedAt`
  - `MarkProcessed`: same
  - `ListStale`: cutoff
  - `LoadStalePayloads`: cutoff
  - `ResetStale`: cutoff
  - `cleanupExpired`: now

## Test changes

**`newSMWithFakeClock`** helper constructs a state manager wired to a `clock.Fake` pinned at the Unix epoch with cleanup disabled (so the background goroutine doesn't race the test's clock manipulation).

| Test | Sleep before | After |
|---|---|---|
| `TestMemoryCoordinator_Acquire_Expiry` | 20ms | `clk.Advance(20ms)` — pins TTL boundary check |
| `TestRecoveryRunner_BasicReset` | 60ms | `clk.Advance(60ms)` (50ms stale threshold) |
| `TestRecoveryRunner_Phase1And2Exclusion` | 60ms | same |
| `TestRecoveryRunner_BatchLimitZero` | 60ms | same |
| `TestRecoveryRunner_PayloadRepublish` | 60ms | same |
| `TestRecoveryRunner_PublishFailure_SkipsEntry` | 60ms | same |
| `TestRecoveryRunner_WithRealBus` | 60ms | same |
| `TestMemoryStateManager_CleanupExpired` | 20ms | `clk.Advance(20ms)` |
| `TestRecoveryRunner_WithMetrics` | 60ms | `clk.Advance(60ms)` |

### Drive-by fix

`TestMemoryPayloadStore_LoadStalePayloads` manually backdates `entry.updatedAt` to simulate stale entries. Switched the backdate from `time.Now().Add(-5*time.Minute)` to `clk.Now().Add(-5*time.Minute)` so it stays on the fake-clock timeline. Without this, the manual override races against the now-fake `LoadStalePayloads` cutoff (real-now is "in the future" relative to fake-clock-epoch, so backdated entries are still in the future relative to the cutoff).

## Total Phase 2.C progress

| PR | Sleeps eliminated |
|---|---:|
| #135 | 3 |
| #136 | 6 |
| #137 | 8 |
| #138 | 9 |
| #139 | 0 (race fix) |
| **this PR** | **9** |

**Cumulative: 35 of 154 sleeps eliminated, 119 remaining.**

Distributed test runtime collapsed from **~540ms** aggregate sleep time to **~0ms**.

## Test plan

- [x] `go test -race -count=1 ./distributed/...` — all tests pass in <3s
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `go test -race -count=1 -tags=smoke ./...` — smoke green
- [x] `golangci-lint run ./...` — 0 issues
- [x] No external API changes; `withClock` is unexported.