### PR TITLE
fix(test): atomic.Bool for handlerStarted signal in coalesce test

### DIFF
--- a/ack_policy_test.go
+++ b/ack_policy_test.go
@@ -212,15 +212,17 @@ func TestWithCoalesceByKey_SupersedesPendingMessages(t *testing.T) {
 	var mu sync.Mutex
 	delivered := make(map[string]int) // id -> latest value delivered
 	coalescedCounts := make(map[string]int)
-	handlerReady := make(chan struct{})
+	// handlerStarted is an idempotent signal that the handler has begun
+	// processing. atomic.Bool — NOT a channel — because the retry loop
+	// below may not yet be in a select when the handler signals, and a
+	// dropped channel signal would cause the loop to keep republishing
+	// Value=1 indefinitely. With atomic.Bool the polling loop sees the
+	// signal regardless of when it was set.
+	var handlerStarted atomic.Bool
 	handlerDone := make(chan struct{}, 10)
 
 	err := ev.Subscribe(ctx, func(ctx context.Context, e Event[Order], data Order) error {
-		// Signal that handler is processing.
-		select {
-		case handlerReady <- struct{}{}:
-		default:
-		}
+		handlerStarted.Store(true)
 		// Slow handler to allow coalescing
 		time.Sleep(100 * time.Millisecond)
 
@@ -245,27 +247,22 @@ func TestWithCoalesceByKey_SupersedesPendingMessages(t *testing.T) {
 	// Subscribe; that goroutine's `select { case <-incoming: ... }` is set
 	// up asynchronously, so a Publish that races it can land in the
 	// coalescer's buffered incoming channel before the run loop is reading
-	// from it. The buffer absorbs the message but the handler has nothing
-	// to react to until the run loop catches up.
+	// from it.
 	//
-	// Retry the initial publish until handlerReady fires. All retries land
-	// under the same key and coalesce harmlessly into a single delivery —
-	// the coalescer's supersede logic preserves the latest value. This
-	// pattern is deterministic on both fast machines and loaded CI runners,
-	// replacing a fixed 50ms pre-Publish sleep that CI proved was not
-	// always sufficient.
+	// Retry the initial publish until handlerStarted flips. All retries
+	// land under the same key and coalesce harmlessly into a single pending
+	// delivery — the coalescer's supersede logic preserves the latest
+	// value, and since all retries publish the same Value=1, the pending
+	// entry stays at Value=1 until the subsequent for-loop bumps it up.
 	const initial = 1
 	if err := ev.Publish(ctx, Order{ID: "A", Value: initial}); err != nil {
 		t.Fatal(err)
 	}
 
-	handlerStarted := false
 	deadline := time.Now().Add(2 * time.Second)
-	for !handlerStarted && time.Now().Before(deadline) {
-		select {
-		case <-handlerReady:
-			handlerStarted = true
-		case <-time.After(50 * time.Millisecond):
+	for !handlerStarted.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+		if !handlerStarted.Load() {
 			// Republish — coalescer may have missed the first send if its
 			// run loop was not yet ready when we published.
 			if err := ev.Publish(ctx, Order{ID: "A", Value: initial}); err != nil {
@@ -273,7 +270,7 @@ func TestWithCoalesceByKey_SupersedesPendingMessages(t *testing.T) {
 			}
 		}
 	}
-	if !handlerStarted {
+	if !handlerStarted.Load() {
 		t.Fatal("handler didn't start after retries")
 	}
 


### PR DESCRIPTION
## Summary

**Forward-fix #2 for the coalesce test race.** PR #140's Integration CI surfaced a different failure mode than #139 caught:

```
--- FAIL: TestWithCoalesceByKey_SupersedesPendingMessages (0.20s)
    ack_policy_test.go:310: expected latest value 5 for key A, got 1
```

### Root cause

#139's retry loop used an unbuffered `handlerReady` channel to signal the handler had started. The handler's `select { case handlerReady <- struct{}{}; default: }` **drops the signal** if the retry loop isn't in its select yet — which happens on slow CI when the channel transport schedules the handler before the test goroutine reaches the wait.

Symptoms when the signal is dropped:
1. Retry loop keeps publishing `Value=1` for the full 2s deadline
2. Handler runs many times, each time picking up a `Value=1` pending entry — coalesced from the spam of retries
3. Test's subsequent for-loop publishes `Value=2..5` but by then the handler is on its Nth invocation
4. `delivered["A"]` ends up as `1` (from one of the retry invocations), not `5` (the test's expected post-coalesce value)

### Fix

Replace `handlerReady` channel with `atomic.Bool`. The handler does `handlerStarted.Store(true)` unconditionally; the retry loop polls `handlerStarted.Load()` at 5ms intervals.

`atomic.Bool` is **idempotent and order-independent** — the signal can fire before, during, or after the polling loop is entered, and the loop will see it on the next poll regardless.

### Verification

Stress-tested with:

```
go test -race -count=20 -run TestWithCoalesceByKey .
```

**20/20 runs pass.** Previous version's failure surfaced ~1 in 20 on a loaded CI runner.

### Why not a buffered channel

`make(chan struct{}, 1)` with `select+default` would also work, but then we'd have a buffered channel that captures the FIRST signal only — subsequent invocations still hit `default` and drop. Semantically identical to `atomic.Bool` for this use case, but the bool is more obviously idempotent at the read site.

## Test plan

- [x] `go test -race -count=20 -run TestWithCoalesceByKey .` — 20/20 pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `go test -race -tags=smoke ./...` — smoke green
- [x] No production code changes; test-only forward-fix for #140's integration CI.