### PR TITLE
ci: make integration tests blocking + mark required checks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,15 +8,14 @@ on:
 
 permissions: read-all
 
-# Integration runs against real Redis and Postgres service containers. The
-# suite is non-blocking (continue-on-error) while the test set stabilizes;
-# remove that flag once a 2-week green streak demonstrates the suite is
-# reliable enough to gate merges.
+# Integration runs against real Redis and Postgres service containers and
+# is a required check on the main branch. The original stabilization flag
+# (continue-on-error: true) was removed once the suite proved reliable
+# through Phase 1 and Phase 2 of the test-quality lift.
 jobs:
   integration:
     name: Integration (Redis + Postgres)
     runs-on: ubuntu-latest
-    continue-on-error: true
     services:
       redis:
         image: redis:7-alpine


### PR DESCRIPTION
## Summary

Closes the gap where Smoke failures (caught in #136 → fixed in #139) and Integration failures (caught in #140 → fixed in #142) were **not blocking PR merges** — they would only surface as red checks that reviewers had to manually notice.

### Change 1: Remove `continue-on-error: true` from `integration.yml`

That flag was a temporary "ignore failures while the suite stabilizes" added in Phase 0 (#121). Through Phase 1 (#122-#125 added the actual integration tests for transport/redis, NATS, Kafka, partition) and Phase 2 (#126-#140 broadened SQL + Redis store coverage and Clock injection), the suite has proven reliable. Recent failures have been real regressions, caught and fixed in forward-fix PRs.

### Change 2: Update branch protection on main

Applied via `gh api repos/rbaliyan/event/branches/main/protection` (separate from this code PR — branch protection is repo configuration, not in-tree):

| Status | Before | After |
|---|---|---|
| `Test` (unit) | required | required |
| `Lint` | required | required |
| `CodeQL Analysis` | required | required |
| `Smoke` | NOT required | **required** |
| `Integration (Redis + Postgres)` | NOT required | **required** |
| `Vulnerability Check` | NOT required | **required** |
| `GoSec SAST` | NOT required | **required** |

**Total: 3 → 7 required checks.**

### Workflows intentionally NOT made required

| Workflow | Why not required |
|---|---|
| `ClusterFuzzLite Batch` | Runs on schedule + push-only; no PR signal |
| `Scorecard Analysis` | Runs on schedule + security telemetry; no PR signal |
| `Dependabot Tidy` | Only fires on Dependabot PRs; requiring it would block human PRs |

### Verification

```
$ gh api repos/rbaliyan/event/branches/main/protection --jq '.required_status_checks.contexts'
["Lint","CodeQL Analysis","Test","Smoke","Integration (Redis + Postgres)","Vulnerability Check","GoSec SAST"]
```

## Test plan

- [x] Branch protection updated via `gh api` — verified with read-back query above
- [x] integration.yml change is minimal (removed `continue-on-error: true` + updated comment)
- [x] No code changes; no test changes; this is pure infrastructure plumbing