### PR TITLE
test(bus_metrics): replace all 5 time.Sleep with eventuallyMetrics polling

### DIFF
--- a/bus_metrics_test.go
+++ b/bus_metrics_test.go
@@ -38,6 +38,35 @@ func setupMetricsProvider(t *testing.T) *sdkmetric.ManualReader {
 	return reader
 }
 
+// eventuallyMetrics polls collectMetrics until the predicate returns true or
+// the deadline fires. Replaces the time.Sleep + collect + assert pattern:
+// OTel metric recording is asynchronous, so the handler's recordHandlerDuration
+// call may not have updated the reader's view by the time the test reads it.
+// Polling exits the instant the metric arrives, not after a fixed wait.
+//
+// The predicate receives the four metric maps the test would otherwise read
+// inline; tests express their actual contract directly inside the predicate.
+func eventuallyMetrics(
+	t *testing.T,
+	reader *sdkmetric.ManualReader,
+	timeout time.Duration,
+	predicate func(counters map[string]int64, histograms map[string]uint64, int64Gauges map[string]int64, float64Gauges map[string]float64) bool,
+	msg string,
+) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		counters, histograms, int64Gauges, float64Gauges := collectMetrics(t, reader)
+		if predicate(counters, histograms, int64Gauges, float64Gauges) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("eventuallyMetrics: %s (after %s)", msg, timeout)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
 // collectMetrics reads all metrics from the reader and returns maps keyed by metric name.
 func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) (
 	counters map[string]int64,
@@ -114,20 +143,15 @@ func TestHandlerDurationAndErrorMetrics(t *testing.T) {
 		t.Fatal("timeout waiting for failure handler")
 	}
 
-	// Allow metrics propagation.
-	time.Sleep(10 * time.Millisecond)
-
-	counters, histogramCounts, _, _ := collectMetrics(t, reader)
-
-	// handler_duration should have been recorded for both calls.
-	if histogramCounts["event.handler_duration_seconds"] != 2 {
-		t.Errorf("handler_duration_seconds count: got %d, want 2", histogramCounts["event.handler_duration_seconds"])
-	}
-
-	// handler_errors should have been recorded for the failure.
-	if counters["event.handler_errors_total"] != 1 {
-		t.Errorf("handler_errors_total: got %d, want 1", counters["event.handler_errors_total"])
-	}
+	// Poll until both metrics arrive — OTel recording is async after the
+	// handler returns, but at most ~tens of ms in practice.
+	eventuallyMetrics(t, reader, 2*time.Second,
+		func(counters map[string]int64, histograms map[string]uint64, _ map[string]int64, _ map[string]float64) bool {
+			return histograms["event.handler_duration_seconds"] == 2 &&
+				counters["event.handler_errors_total"] == 1
+		},
+		"expected 2 handler_duration_seconds samples and 1 handler_errors_total",
+	)
 }
 
 func TestPublishAndSubscribeCounterMetrics(t *testing.T) {
@@ -152,19 +176,19 @@ func TestPublishAndSubscribeCounterMetrics(t *testing.T) {
 		t.Fatal("timeout")
 	}
 
-	time.Sleep(10 * time.Millisecond)
-
-	counters, histogramCounts, _, _ := collectMetrics(t, reader)
-
-	if counters["event.published"] < 1 {
-		t.Errorf("event.published: got %d, want >= 1", counters["event.published"])
-	}
-	if counters["event.subscribed"] < 1 {
-		t.Errorf("event.subscribed: got %d, want >= 1", counters["event.subscribed"])
-	}
-	if histogramCounts["event.publish_duration_seconds"] < 1 {
-		t.Errorf("event.publish_duration_seconds: got %d, want >= 1", histogramCounts["event.publish_duration_seconds"])
-	}
+	// Three metrics need to settle: published counter, subscribed counter,
+	// publish_duration histogram. They're recorded in different places in
+	// the bus pipeline so they may arrive at the reader at slightly
+	// different times — the AND predicate ensures all three are present
+	// before the assertions run.
+	eventuallyMetrics(t, reader, 2*time.Second,
+		func(counters map[string]int64, histograms map[string]uint64, _ map[string]int64, _ map[string]float64) bool {
+			return counters["event.published"] >= 1 &&
+				counters["event.subscribed"] >= 1 &&
+				histograms["event.publish_duration_seconds"] >= 1
+		},
+		"expected event.published, event.subscribed counters and publish_duration_seconds histogram",
+	)
 }
 
 // mockLagTransport wraps a channel transport and implements LagMonitor.
@@ -254,8 +278,11 @@ func TestMetricsDisabled(t *testing.T) {
 		t.Fatal("timeout")
 	}
 
-	time.Sleep(10 * time.Millisecond)
-
+	// With metrics disabled the bus skips ALL metric emission — there is
+	// nothing to "propagate", so we read the metrics state immediately.
+	// The previous 10ms sleep was a defensive wait; now redundant because
+	// the contract is "metrics are never emitted when disabled", not
+	// "metrics are emitted but eventually we observe zero".
 	counters, histogramCounts, _, _ := collectMetrics(t, reader)
 
 	if counters["event.published"] != 0 {
@@ -379,16 +406,15 @@ func TestRegisteredEventsAndActiveSubscribersGauges(t *testing.T) {
 	ev1.Subscribe(ctx, noop)
 	ev2.Subscribe(ctx, noop)
 
-	// Allow goroutines to start.
-	time.Sleep(10 * time.Millisecond)
-
-	_, _, int64Gauges, _ = collectMetrics(t, reader)
-
-	// active_subscribers is summed across all events in collectMetrics,
-	// so total should be 3 (2 on ev1 + 1 on ev2).
-	if int64Gauges["event.active_subscribers"] != 3 {
-		t.Errorf("active_subscribers total: got %d, want 3", int64Gauges["event.active_subscribers"])
-	}
+	// Poll for the active_subscribers gauge to reach 3 — Subscribe registers
+	// the gauge contribution asynchronously after spawning the subscriber
+	// goroutine, so a single immediate read may catch it mid-update.
+	eventuallyMetrics(t, reader, 2*time.Second,
+		func(_ map[string]int64, _ map[string]uint64, int64Gauges map[string]int64, _ map[string]float64) bool {
+			return int64Gauges["event.active_subscribers"] == 3
+		},
+		"expected active_subscribers total to reach 3 (2 on ev1 + 1 on ev2)",
+	)
 }
 
 // TestFilterDropCounter verifies that event_messages_filter_dropped_total is
@@ -447,14 +473,16 @@ func TestFilterDropCounter(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for message")
 	}
-	// Give filter drops time to be recorded.
-	time.Sleep(20 * time.Millisecond)
 
-	counters, _, _, _ := collectMetrics(t, reader)
-
-	if got := counters["event_messages_filter_dropped_total"]; got != 2 {
-		t.Errorf("filter_dropped_total = %d, want 2", got)
-	}
+	// Poll until both filter drops have been recorded — the filter
+	// middleware increments the counter asynchronously after the message
+	// is rejected, separate from the receive-side ack path.
+	eventuallyMetrics(t, reader, 2*time.Second,
+		func(counters map[string]int64, _ map[string]uint64, _ map[string]int64, _ map[string]float64) bool {
+			return counters["event_messages_filter_dropped_total"] == 2
+		},
+		"expected event_messages_filter_dropped_total == 2 (insert + delete were filtered)",
+	)
 }
 
 func durationPtr(d time.Duration) *time.Duration { return &d }


### PR DESCRIPTION
## Summary

**Eighth Phase 2.C workstream** after #135-#142. `bus_metrics_test.go` used fixed 10-20ms sleeps to "allow metrics propagation" before reading the OTel `ManualReader`. These are worst-case bounds — the test passes the instant metrics arrive on a fast machine and risks flaking on a loaded CI runner.

All 5 sleeps replaced with a new **`eventuallyMetrics`** helper that polls `collectMetrics` until a predicate returns true or the deadline fires. The predicate receives all four metric maps (counters, histograms, int64Gauges, float64Gauges), so tests express their assertions **directly inside the predicate** — capturing the actual contract at the polling site instead of reading-then-asserting separately.

## Refactored

| Test | Before | After |
|---|---|---|
| `TestHandlerDurationAndErrorMetrics` | 10ms sleep | `eventuallyMetrics(histogram == 2 && counter == 1)` |
| `TestPublishAndSubscribeCounterMetrics` | 10ms sleep | `eventuallyMetrics(published >= 1 && subscribed >= 1 && publish_duration >= 1)` — AND predicate ensures all three arrive before assertions |
| `TestMetricsDisabled` | 10ms sleep | **dropped entirely** — the contract is "metrics are never emitted when disabled", not "emitted but eventually observe zero"; immediate read is correct |
| `TestRegisteredEventsAndActiveSubscribersGauges` | 10ms sleep | `eventuallyMetrics(active_subscribers == 3)` |
| `TestFilterDropCounter` | 20ms sleep | `eventuallyMetrics(filter_dropped == 2)` |

## Why a local helper instead of `testutil.Eventually`

The root `event` package cannot import `internal/testutil` — `testutil/bus.go` imports `event`, creating an import cycle. Same constraint solved by `eventuallyEqInt32` in #136. The `eventuallyMetrics` helper sits inline in `bus_metrics_test.go`.

## Verification

```
$ go test -race -count=10 -run 'TestHandlerDuration|TestPublishAndSubscribe|TestMetricsDisabled|TestRegisteredEvents|TestFilterDropCounter' .
ok      github.com/rbaliyan/event/v3    1.673s
```

10/10 runs pass.

## Total Phase 2.C progress

| PR | Sleeps eliminated |
|---|---:|
| #135 | 3 |
| #136 | 6 |
| #137 | 8 |
| #138 | 9 |
| #139 | 0 (race fix) |
| #140 | 9 |
| #141 | 5 |
| #142 | 0 (race fix) |
| **this PR** | **5** |

**Cumulative: 45 of 154 sleeps eliminated, 109 remaining.**

## Test plan

- [x] `go test -race -count=10 -run '...' .` — 10/10 pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `golangci-lint run ./...` — 0 issues
- [x] No production code changes; pure test-side refactor.