### PR TITLE
test(distributed): route ListWorkers stale check through Clock, replace 6 sleeps

### DIFF
--- a/distributed/memory_worker_store.go
+++ b/distributed/memory_worker_store.go
@@ -11,11 +11,16 @@ func (s *MemoryStateManager) ListWorkers(_ context.Context, filter WorkerFilter)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	// Take a single now-reading from the clock so all stale-filter comparisons
+	// in this listing use a consistent cutoff. Routing through s.clk also
+	// keeps the stale filter testable via clock.Fake.
+	now := s.clk.Now()
+
 	// Collect matching entries
 	var all []*WorkerEntry
 	for id, entry := range s.states {
 		we := memoryEntryToWorkerEntry(id, entry)
-		if !matchesWorkerFilter(we, filter) {
+		if !matchesWorkerFilter(we, filter, now) {
 			continue
 		}
 		all = append(all, we)
@@ -99,10 +104,11 @@ func (s *MemoryStateManager) CountWorkers(_ context.Context, filter WorkerFilter
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	now := s.clk.Now()
 	var count int64
 	for id, entry := range s.states {
 		we := memoryEntryToWorkerEntry(id, entry)
-		if matchesWorkerFilter(we, filter) {
+		if matchesWorkerFilter(we, filter, now) {
 			count++
 		}
 	}
@@ -145,7 +151,13 @@ func memoryEntryToWorkerEntry(id string, entry *stateEntry) *WorkerEntry {
 	}
 }
 
-func matchesWorkerFilter(entry *WorkerEntry, filter WorkerFilter) bool {
+// matchesWorkerFilter returns true if entry passes all conditions in filter.
+// The `now` parameter is the reference time used for the StaleTimeout check —
+// callers pass s.clk.Now() so tests using clock.Fake can drive the stale
+// boundary deterministically. Taking `now` once at the caller (instead of
+// reading time.Now() inside the loop) also gives a consistent cutoff across
+// all entries in a single ListWorkers call.
+func matchesWorkerFilter(entry *WorkerEntry, filter WorkerFilter, now time.Time) bool {
 	if len(filter.Status) > 0 {
 		matched := false
 		for _, s := range filter.Status {
@@ -165,7 +177,7 @@ func matchesWorkerFilter(entry *WorkerEntry, filter WorkerFilter) bool {
 		return false
 	}
 	if filter.StaleTimeout > 0 {
-		cutoff := time.Now().Add(-filter.StaleTimeout)
+		cutoff := now.Add(-filter.StaleTimeout)
 		if entry.Status != WorkerStateProcessing || !entry.UpdatedAt.Before(cutoff) {
 			return false
 		}

--- a/distributed/memory_worker_store_test.go
+++ b/distributed/memory_worker_store_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
 func newTestMemoryWorkerStore(t *testing.T) *MemoryStateManager {
@@ -11,6 +13,19 @@ func newTestMemoryWorkerStore(t *testing.T) *MemoryStateManager {
 	sm := NewMemoryStateManager(WithCleanup(false, 0))
 	t.Cleanup(sm.Close)
 	return sm
+}
+
+// newTestMemoryWorkerStoreWithClock returns a state manager wired to a
+// clock.Fake pinned at the Unix epoch. Tests that need to establish a
+// time-ordering between Acquire calls (e.g., to assert "msg-stale was
+// created before msg-fresh") use clk.Advance to bump the fake clock
+// deterministically instead of time.Sleep.
+func newTestMemoryWorkerStoreWithClock(t *testing.T) (*MemoryStateManager, *clock.Fake) {
+	t.Helper()
+	clk := clock.NewFake(time.Time{})
+	sm := NewMemoryStateManager(WithCleanup(false, 0), withClock(clk))
+	t.Cleanup(sm.Close)
+	return sm, clk
 }
 
 func TestMemoryListWorkers(t *testing.T) {
@@ -71,10 +86,10 @@ func TestMemoryListWorkersFilterStatus(t *testing.T) {
 
 func TestMemoryListWorkersStaleTimeout(t *testing.T) {
 	ctx := context.Background()
-	sm := newTestMemoryWorkerStore(t)
+	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
 	sm.Acquire(ctx, "msg-stale", 5*time.Minute)
-	time.Sleep(15 * time.Millisecond)
+	clk.Advance(15 * time.Millisecond) // msg-stale ages past the 10ms threshold
 	sm.Acquire(ctx, "msg-fresh", 5*time.Minute)
 
 	page, err := sm.ListWorkers(ctx, WorkerFilter{
@@ -93,12 +108,12 @@ func TestMemoryListWorkersStaleTimeout(t *testing.T) {
 
 func TestMemoryListWorkersCreatedRange(t *testing.T) {
 	ctx := context.Background()
-	sm := newTestMemoryWorkerStore(t)
+	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
 	sm.Acquire(ctx, "msg-1", 5*time.Minute)
-	time.Sleep(5 * time.Millisecond)
-	midpoint := time.Now()
-	time.Sleep(5 * time.Millisecond)
+	clk.Advance(5 * time.Millisecond)
+	midpoint := clk.Now() // capture from the fake clock so filter comparisons use the same timeline
+	clk.Advance(5 * time.Millisecond)
 	sm.Acquire(ctx, "msg-2", 5*time.Minute)
 
 	t.Run("created after midpoint", func(t *testing.T) {
@@ -128,12 +143,12 @@ func TestMemoryListWorkersCreatedRange(t *testing.T) {
 
 func TestMemoryListWorkersOrderDesc(t *testing.T) {
 	ctx := context.Background()
-	sm := newTestMemoryWorkerStore(t)
+	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
 	sm.Acquire(ctx, "msg-a", 5*time.Minute)
-	time.Sleep(2 * time.Millisecond)
+	clk.Advance(2 * time.Millisecond)
 	sm.Acquire(ctx, "msg-b", 5*time.Minute)
-	time.Sleep(2 * time.Millisecond)
+	clk.Advance(2 * time.Millisecond)
 	sm.Acquire(ctx, "msg-c", 5*time.Minute)
 
 	page, err := sm.ListWorkers(ctx, WorkerFilter{OrderDesc: true})
@@ -154,11 +169,11 @@ func TestMemoryListWorkersOrderDesc(t *testing.T) {
 
 func TestMemoryListWorkersPagination(t *testing.T) {
 	ctx := context.Background()
-	sm := newTestMemoryWorkerStore(t)
+	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
 	for i := 0; i < 5; i++ {
 		sm.Acquire(ctx, "msg-"+string(rune('a'+i)), 5*time.Minute)
-		time.Sleep(2 * time.Millisecond)
+		clk.Advance(2 * time.Millisecond)
 	}
 
 	// First page


### PR DESCRIPTION
## Summary

**Ninth Phase 2.C workstream** after #135-#144. `memory_worker_store_test.go` used 2-15ms sleeps to advance time between `Acquire` calls — the same "establish a created-at ordering" pattern that #140 solved for the `RecoveryRunner` tests via `clock.Clock` injection.

## Production changes

`distributed/memory_worker_store.go`:

- **`ListWorkers` and `CountWorkers`** take a single `now := s.clk.Now()` reading at entry and pass it to `matchesWorkerFilter`. Routing through `s.clk` makes the stale filter testable via `clock.Fake`; using a single snapshot also gives a **consistent cutoff** across all entries in one call (previously each loop iteration could observe a slightly different `time.Now()`).

- **`matchesWorkerFilter`** signature extended with `now time.Time`. Inside, `cutoff = now.Add(-filter.StaleTimeout)` replaces the inline `time.Now().Add(...)`.

## Test changes

`distributed/memory_worker_store_test.go`:

- New `newTestMemoryWorkerStoreWithClock` helper wires the state manager to a `clock.Fake` pinned at the Unix epoch via #140's `withClock` option.

- 4 tests refactored:

| Test | Before | After |
|---|---|---|
| `TestMemoryListWorkersStaleTimeout` | 15ms sleep | `clk.Advance(15ms)` — msg-stale crosses the 10ms staleness boundary deterministically |
| `TestMemoryListWorkersCreatedRange` | 2 × 5ms sleeps | `clk.Advance(5ms)` ×2; **midpoint captured from `clk.Now()`** so filter comparisons stay on the same timeline |
| `TestMemoryListWorkersOrderDesc` | 2 × 2ms sleeps | `clk.Advance(2ms)` ×2, pinning msg-a < msg-b < msg-c created-at ordering |
| `TestMemoryListWorkersPagination` | per-iteration 2ms | `clk.Advance(2ms)` |

## Verification

```
$ go test -race -count=10 -run TestMemoryListWorkers ./distributed/
ok      github.com/rbaliyan/event/v3/distributed    1.998s
```

10/10 runs pass. The previously-needed 15-30ms aggregate sleep collapsed to ~0ms.

## Total Phase 2.C progress

| PR | Sleeps eliminated |
|---|---:|
| #135 | 3 |
| #136 | 6 |
| #137 | 8 |
| #138 | 9 |
| #139 | 0 (race fix) |
| #140 | 9 |
| #141 | 5 |
| #142 | 0 (race fix) |
| #144 | 5 |
| **this PR** | **6** |

**Cumulative: 51 of 154 sleeps eliminated, 103 remaining.**

## Test plan

- [x] `go test -race -count=10 -run TestMemoryListWorkers ./distributed/` — 10/10 pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `ListWorkers`/`CountWorkers` signature unchanged for external callers (only the unexported `matchesWorkerFilter` helper got a new parameter)