### PR TITLE
test(transport/bridge): SetClockForTesting hook eliminates 70ms TTL sleep

### DIFF
--- a/transport/bridge/bridge_test.go
+++ b/transport/bridge/bridge_test.go
@@ -526,10 +526,25 @@ func TestDistributedDedup_crossReplicaDedup_stillWorks(t *testing.T) {
 	src1.inject("x", msg)
 	src2.inject("x", msg)
 
-	// Exactly one replica wins — total across both sinks must be 1.
-	time.Sleep(100 * time.Millisecond)
-	total := len(sink1.publishedEvents()) + len(sink2.publishedEvents())
-	if total != 1 {
+	// Wait until at least one replica publishes — the bridge processes
+	// each source on its own goroutine, so the absolute timing varies.
+	// After the first publish lands, give the loser a deterministic
+	// window to also attempt (and fail) the Claim. The waitFor helper
+	// polls every 5ms; "first publish + ~50ms window" is plenty for the
+	// second goroutine to schedule its Claim attempt on any platform.
+	totalPublished := func() int {
+		return len(sink1.publishedEvents()) + len(sink2.publishedEvents())
+	}
+	waitFor(t, func() bool { return totalPublished() >= 1 }, time.Second)
+	// One more bounded wait to give the loser a chance to (incorrectly)
+	// publish — if total ever exceeds 1, the test below catches it.
+	// This 50ms is an intentional workload-simulation sleep, not a setup
+	// margin: we are checking "exactly 1 publish, not 2" and need to
+	// observe the system for long enough that a second publish would
+	// have surfaced. Polling on `total > 1` would never fire on the
+	// happy path so doesn't help here.
+	time.Sleep(50 * time.Millisecond)
+	if total := totalPublished(); total != 1 {
 		t.Errorf("total sink publishes = %d, want 1 (exactly one replica wins)", total)
 	}
 }
@@ -736,6 +751,13 @@ func TestMemoryCoordinator_claimsAndExpires(t *testing.T) {
 	ctx := context.Background()
 	c := bridge.NewMemoryCoordinator()
 
+	// Drive the coordinator's clock from a manually-advanced variable so the
+	// 70ms TTL-expiry wait below becomes a deterministic clock jump rather
+	// than a real time.Sleep. SetClockForTesting is only available in the
+	// _test build; production callers cannot reach it.
+	var now = time.Unix(0, 0).UTC()
+	c.SetClockForTesting(func() time.Time { return now })
+
 	ok, err := c.Claim(ctx, "k", 50*time.Millisecond)
 	if err != nil || !ok {
 		t.Fatalf("first claim: ok=%v err=%v", ok, err)
@@ -745,7 +767,8 @@ func TestMemoryCoordinator_claimsAndExpires(t *testing.T) {
 		t.Errorf("second claim: ok=%v err=%v, want false", ok, err)
 	}
 
-	time.Sleep(70 * time.Millisecond)
+	// Jump 70ms past the 50ms TTL — claim must now succeed.
+	now = now.Add(70 * time.Millisecond)
 
 	ok, err = c.Claim(ctx, "k", 50*time.Millisecond)
 	if err != nil || !ok {

--- a/transport/bridge/export_test.go
+++ b/transport/bridge/export_test.go
@@ -1,0 +1,16 @@
+package bridge
+
+import "time"
+
+// SetClockForTesting swaps the clock function used by MemoryCoordinator to
+// determine TTL expiry. Lives in an _test.go file so it compiles only in
+// the test build and is invisible to production consumers.
+//
+// Tests use this to drive expiry deterministically via a fake clock instead
+// of time.Sleep. The replacement function should return monotonically non-
+// decreasing values within a single test to match real-clock semantics.
+func (c *MemoryCoordinator) SetClockForTesting(fn func() time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.clock = fn
+}


### PR DESCRIPTION
## Summary

**Tenth Phase 2.C workstream** after #135-#145. `transport/bridge` had 3 sleeps:

| # | Test | Sleep | Disposition |
|---|---|---|---|
| 1 | `TestMemoryCoordinator_claimsAndExpires` | 70ms wall-clock wait for 50ms TTL to expire | **Eliminated** via new `SetClockForTesting` hook |
| 2 | `TestDistributedDedup_crossReplicaDedup_stillWorks` | 100ms "let both replicas race" wait | **Reduced** from 100ms to ~55ms via `waitFor`-then-bounded-window |
| 3 | The 5ms polling tick inside the `waitFor` helper | (unchanged) | Helper internal |

## Production change

`transport/bridge/coordinator.go` is **unchanged**. The test-only hook is in a new `export_test.go`:

```go
// export_test.go — compiled only in the test build
package bridge

func (c *MemoryCoordinator) SetClockForTesting(fn func() time.Time) {
    c.mu.Lock()
    defer c.mu.Unlock()
    c.clock = fn
}
```

This is the canonical Go pattern for granting external `_test` packages access to unexported state without changing the public API. The symbol exists only when `go test` is building the package — production binaries never see it.

## Test changes

**`TestMemoryCoordinator_claimsAndExpires`** — replace `time.Sleep(70ms)` with a manually-advanced `now` variable:

```go
var now = time.Unix(0, 0).UTC()
c.SetClockForTesting(func() time.Time { return now })

c.Claim(ctx, "k", 50*time.Millisecond) // ok
c.Claim(ctx, "k", 50*time.Millisecond) // !ok (already claimed)

now = now.Add(70 * time.Millisecond)   // jump past 50ms TTL

c.Claim(ctx, "k", 50*time.Millisecond) // ok again
```

**`TestDistributedDedup_crossReplicaDedup_stillWorks`** — replace `time.Sleep(100ms)`:

```go
totalPublished := func() int {
    return len(sink1.publishedEvents()) + len(sink2.publishedEvents())
}
// Exit the instant the first publish lands.
waitFor(t, func() bool { return totalPublished() >= 1 }, time.Second)
// Then a bounded 50ms window for the loser to attempt (and fail) Claim.
// Can't be fully eliminated without instrumenting the coordinator —
// documented in-code as intentional workload simulation.
time.Sleep(50 * time.Millisecond)
if totalPublished() != 1 { ... }
```

## Verification

```
$ go test -race -count=10 ./transport/bridge/
ok  github.com/rbaliyan/event/v3/transport/bridge  3.348s
```

10/10 stress runs pass.

## Total Phase 2.C progress

| PR | Sleeps eliminated |
|---|---:|
| #135-#145 | 51 |
| **this PR** | **1 (+ 1 reduced)** |

**Cumulative: 52 of 154 sleeps eliminated, 102 remaining.**

## Test plan

- [x] `go test -race -count=10 ./transport/bridge/` — 10/10 pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `coordinator.go` (production) unchanged
- [x] `SetClockForTesting` is in `export_test.go` so it never reaches production binaries