### PR TITLE
test(distributed/redis): Clock injection eliminates 7 stale-timeout sleeps

### DIFF
--- a/distributed/redis.go
+++ b/distributed/redis.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rbaliyan/event/v3/internal/clock"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -81,6 +82,19 @@ type RedisStateManager struct {
 	client        redis.Cmdable
 	prefix        string
 	completionTTL time.Duration
+	// clk supplies the current time for setting UpdatedAt timestamps and for
+	// the stale-cutoff comparisons in ListStale/LoadStalePayloads. Defaults
+	// to clock.Real{}; tests inject clock.Fake via the unexported withClock
+	// option (defined in claimer.go from PR #140) to drive expiry checks
+	// deterministically without time.Sleep.
+	//
+	// Note: the Redis SETNX TTL passed to Acquire is interpreted by Redis
+	// itself (or miniredis), not by clk. This is fine for stale-detection
+	// tests because they pass very large TTLs (time.Hour) so the Redis key
+	// outlives the test's logical time advance, leaving stale-detection
+	// driven purely by the JSON-encoded UpdatedAt timestamp this clock
+	// emits.
+	clk clock.Clock
 }
 
 // NewRedisStateManager creates a new Redis-based state manager.
@@ -125,6 +139,7 @@ func NewRedisStateManager(client redis.Cmdable, opts ...Option) (*RedisStateMana
 		client:        client,
 		prefix:        o.prefix,
 		completionTTL: o.completionTTL,
+		clk:           o.clock,
 	}, nil
 }
 
@@ -147,7 +162,7 @@ func NewRedisStateManager(client redis.Cmdable, opts ...Option) (*RedisStateMana
 //   - (false, error): Redis error occurred
 func (s *RedisStateManager) Acquire(ctx context.Context, messageID string, ttl time.Duration) (bool, error) {
 	key := s.prefix + messageID
-	now := time.Now()
+	now := s.clk.Now()
 
 	// Create state value with timestamps for stale detection
 	value := redisStateValue{
@@ -216,7 +231,7 @@ return 1
 // Returns nil on success (including no-op when key was deleted).
 func (s *RedisStateManager) MarkProcessed(ctx context.Context, messageID string) error {
 	key := s.prefix + messageID
-	now := time.Now().Format(time.RFC3339Nano)
+	now := s.clk.Now().Format(time.RFC3339Nano)
 	ttlMs := s.completionTTL.Milliseconds()
 
 	err := markProcessedScript.Run(ctx, s.client, []string{key}, redisStatusCompleted, now, ttlMs).Err()
@@ -317,7 +332,7 @@ type staleEntry struct {
 //
 // Returns list of message IDs that are stale.
 func (s *RedisStateManager) ListStale(ctx context.Context, staleTimeout time.Duration, limit int) ([]string, error) {
-	cutoff := time.Now().Add(-staleTimeout)
+	cutoff := s.clk.Now().Add(-staleTimeout)
 	entries, err := s.scanStaleStates(ctx, cutoff, limit)
 	if err != nil {
 		return nil, err
@@ -426,7 +441,7 @@ func (s *RedisStateManager) StorePayload(ctx context.Context, messageID string, 
 // entries processed per cycle, or use a MongoDB-backed state manager from the
 // event-mongodb module (https://github.com/rbaliyan/event-mongodb).
 func (s *RedisStateManager) LoadStalePayloads(ctx context.Context, staleTimeout time.Duration, limit int) ([]*StaleMessage, error) {
-	cutoff := time.Now().Add(-staleTimeout)
+	cutoff := s.clk.Now().Add(-staleTimeout)
 	// Scan without limit since we need to filter by payload existence after
 	entries, err := s.scanStaleStates(ctx, cutoff, 0)
 	if err != nil {

--- a/distributed/redis_test.go
+++ b/distributed/redis_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/rbaliyan/event/v3/internal/clock"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -26,6 +27,24 @@ func setupRedisStateManager(t *testing.T, opts ...Option) (*RedisStateManager, *
 		t.Fatalf("failed to create state manager: %v", err)
 	}
 	return sm, mr
+}
+
+// setupRedisStateManagerWithClock is the Clock-injected variant for tests
+// that need to drive stale-timeout boundaries deterministically. The
+// returned clock.Fake is pinned at the Unix epoch and feeds into the
+// RedisStateManager's clk via #140's withClock option (defined in
+// claimer.go).
+//
+// Note: the Acquire TTL is still interpreted by miniredis itself (a real
+// timer on the Redis side). Tests pass time.Hour so Redis-side expiry
+// doesn't trip — stale-detection is driven purely by the JSON UpdatedAt
+// timestamp which IS controlled by clk.
+func setupRedisStateManagerWithClock(t *testing.T, opts ...Option) (*RedisStateManager, *miniredis.Miniredis, *clock.Fake) {
+	t.Helper()
+	clk := clock.NewFake(time.Time{})
+	allOpts := append([]Option{withClock(clk)}, opts...)
+	sm, mr := setupRedisStateManager(t, allOpts...)
+	return sm, mr, clk
 }
 
 func TestRedisStateManager_Acquire(t *testing.T) {
@@ -147,7 +166,7 @@ func TestRedisStateManager_Reset(t *testing.T) {
 }
 
 func TestRedisStateManager_ListStale(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	// Acquire some messages
@@ -158,8 +177,8 @@ func TestRedisStateManager_ListStale(t *testing.T) {
 	// Mark one as processed
 	sm.MarkProcessed(ctx, "msg-2")
 
-	// Wait for stale timeout (stale = UpdatedAt older than staleTimeout)
-	time.Sleep(60 * time.Millisecond)
+	// Cross the 50ms stale-timeout boundary via the fake clock.
+	clk.Advance(60 * time.Millisecond)
 
 	// List stale with 50ms timeout
 	stale, err := sm.ListStale(ctx, 50*time.Millisecond, 0)
@@ -183,13 +202,13 @@ func TestRedisStateManager_ListStale(t *testing.T) {
 }
 
 func TestRedisStateManager_ResetStale(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.Acquire(ctx, "msg-2", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	reset, err := sm.ResetStale(ctx, 50*time.Millisecond, 0)
 	if err != nil {
@@ -207,14 +226,14 @@ func TestRedisStateManager_ResetStale(t *testing.T) {
 }
 
 func TestRedisStateManager_ResetStale_Limit(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
 	sm.Acquire(ctx, "msg-2", time.Hour)
 	sm.Acquire(ctx, "msg-3", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	// Reset with limit=1
 	reset, err := sm.ResetStale(ctx, 50*time.Millisecond, 1)
@@ -281,7 +300,7 @@ func TestRedisStateManager_StorePayload_NilOrEmpty(t *testing.T) {
 }
 
 func TestRedisStateManager_LoadStalePayloads(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	// Acquire and store payload for msg-1
@@ -294,7 +313,7 @@ func TestRedisStateManager_LoadStalePayloads(t *testing.T) {
 	// Acquire msg-2 without payload
 	sm.Acquire(ctx, "msg-2", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	// LoadStalePayloads should only return msg-1 (has payload)
 	stale, err := sm.LoadStalePayloads(ctx, 50*time.Millisecond, 0)
@@ -316,7 +335,7 @@ func TestRedisStateManager_LoadStalePayloads(t *testing.T) {
 }
 
 func TestRedisStateManager_ClearPayload(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	sm.Acquire(ctx, "msg-1", time.Hour)
@@ -330,7 +349,7 @@ func TestRedisStateManager_ClearPayload(t *testing.T) {
 		t.Fatalf("ClearPayload failed: %v", err)
 	}
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	// LoadStalePayloads should find no entries with payload
 	stale, err := sm.LoadStalePayloads(ctx, 50*time.Millisecond, 0)
@@ -360,7 +379,7 @@ func TestRedisStateManager_Prefix(t *testing.T) {
 }
 
 func TestRedisStateManager_RecoveryRunner(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	runner, err := NewRecoveryRunner(sm,
@@ -382,8 +401,8 @@ func TestRedisStateManager_RecoveryRunner(t *testing.T) {
 		t.Fatalf("expected 0 reset, got %d", reset)
 	}
 
-	// Wait for stale timeout
-	time.Sleep(60 * time.Millisecond)
+	// Cross the 50ms stale-timeout boundary.
+	clk.Advance(60 * time.Millisecond)
 
 	reset, err = runner.RecoverOnce(ctx)
 	if err != nil {
@@ -455,7 +474,7 @@ func TestRedisStateManager_StorePayload_AtomicTTL(t *testing.T) {
 }
 
 func TestRedisStateManager_PayloadRecovery(t *testing.T) {
-	sm, _ := setupRedisStateManager(t)
+	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
 	pub := &mockPublisher{}
@@ -479,7 +498,7 @@ func TestRedisStateManager_PayloadRecovery(t *testing.T) {
 	// Acquire without payload (should be reset via Phase 2)
 	sm.Acquire(ctx, "msg-recovery-2", time.Hour)
 
-	time.Sleep(60 * time.Millisecond)
+	clk.Advance(60 * time.Millisecond)
 
 	// Phase 1: re-publish payload entry, Phase 2: reset no-payload entry
 	recovered, err := runner.RecoverOnce(ctx)


### PR DESCRIPTION
## Summary

**Eleventh Phase 2.C workstream** after #135-#146. Extends #140's Clock injection from `MemoryStateManager` to `RedisStateManager`. Tests that waited 60ms for the 50ms stale-timeout to elapse now advance the fake clock instantly via `withClock + clk.Advance`.

## Production changes (`distributed/redis.go`)

- `RedisStateManager` gains an unexported `clk clock.Clock` field set from `stateOptions.clock` (the option already exists from #140 — no new option needed).
- **Four `time.Now()` call sites** routed through `s.clk.Now()`:
  - `Acquire` (CreatedAt/UpdatedAt timestamps in the JSON state value)
  - `MarkProcessed` (updated_at param to the Lua script)
  - `ListStale` (cutoff for the Go-side staleness filter)
  - `LoadStalePayloads` (same cutoff)

### Why this works against miniredis

The struct comment documents the subtle point: the Redis `SETNX` TTL is interpreted by Redis (or miniredis), **not** by `clk`. Stale-detection tests pass `time.Hour` TTLs that outlive the test's logical time advance, so the Redis-side key never expires during the test. Stale-detection is driven purely by the JSON-encoded `UpdatedAt` timestamp emitted from `clk` — which IS test-controllable.

## Test changes (`distributed/redis_test.go`)

- New `setupRedisStateManagerWithClock` helper threads `withClock` into the existing `setupRedisStateManager`. Returns the fake clock alongside the state manager and miniredis instance.
- **7 stale-timeout sleeps replaced with `clk.Advance(60ms)`:**

| Test | Before | After |
|---|---|---|
| `TestRedisStateManager_ListStale` | 60ms | `clk.Advance(60ms)` |
| `TestRedisStateManager_ResetStale` | 60ms | same |
| `TestRedisStateManager_ResetStale_Limit` | 60ms | same |
| `TestRedisStateManager_LoadStalePayloads` | 60ms | same |
| `TestRedisStateManager_ClearPayload` | 60ms | same |
| `TestRedisStateManager_RecoveryRunner` | 60ms | same |
| `TestRedisStateManager_PayloadRecovery` | 60ms | same |

## Verification

```
$ go test -race -count=10 -run TestRedisStateManager ./distributed/
ok  github.com/rbaliyan/event/v3/distributed   2.067s
```

10/10 stress runs pass.

## Total Phase 2.C progress

| PR | Sleeps eliminated |
|---|---:|
| #135-#146 | 52 |
| **this PR** | **7** |

**Cumulative: 59 of 154 sleeps eliminated, 95 remaining.**

`distributed/redis_test.go` test runtime collapsed from **~420ms aggregate** sleep time to **~0ms**.

## Test plan

- [x] `go test -race -count=10 -run TestRedisStateManager ./distributed/` — 10/10 pass
- [x] `go test -race -count=1 ./...` — full repo green
- [x] `golangci-lint run ./...` — 0 issues
- [x] No external API changes (`withClock` is unexported)
- [x] Integration-tagged real-Redis suite (`redis_integration_test.go`) is unaffected — it uses the default `clock.Real{}` and never invokes `withClock`