### PR TITLE
test(transport/redis): centralize 8 polling sleeps on testutil.Eventually

### DIFF
--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rbaliyan/event/v3/internal/testutil"
 	"github.com/rbaliyan/event/v3/transport"
 	"github.com/rbaliyan/event/v3/transport/codec"
 	"github.com/rbaliyan/event/v3/transport/message"
@@ -906,13 +907,9 @@ func TestBroadcastCloseDoesNotRaceWithConsumeLoop(t *testing.T) {
 	}
 
 	// Wait until the consume goroutine is parked inside the blocking XREADGROUP.
-	deadline := time.Now().Add(2 * time.Second)
-	for atomic.LoadInt32(&client.xreadgroupActive) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("consume goroutine never entered blocking XReadGroup")
-		}
-		time.Sleep(time.Millisecond)
-	}
+	testutil.Eventually(t, 2*time.Second,
+		func() bool { return atomic.LoadInt32(&client.xreadgroupActive) != 0 },
+		"consume goroutine never entered blocking XReadGroup")
 
 	if err := sub.Close(context.Background()); err != nil {
 		t.Fatalf("sub.Close: %v", err)
@@ -953,13 +950,9 @@ func (b *safeBuffer) String() string {
 // XReadGroup, or fails the test on timeout.
 func waitForActiveReader(t *testing.T, m *mockRedisClient) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for atomic.LoadInt32(&m.xreadgroupActive) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("consume goroutine never entered blocking XReadGroup")
-		}
-		time.Sleep(time.Millisecond)
-	}
+	testutil.Eventually(t, 2*time.Second,
+		func() bool { return atomic.LoadInt32(&m.xreadgroupActive) != 0 },
+		"consume goroutine never entered blocking XReadGroup")
 }
 
 // pickBlockedGroup returns the group name that currently has a blocked
@@ -1021,12 +1014,8 @@ func TestAutoRecreateGroup_BroadcastRecoversFromNoGroup(t *testing.T) {
 	client.XGroupDestroy(context.Background(), streamName, groupName)
 
 	// Wait for the recreate callback to fire.
-	deadline := time.Now().Add(2 * time.Second)
-	for recreateCount.Load() == 0 {
-		if time.Now().After(deadline) {
-			t.Fatalf("recreate handler never fired; logs:\n%s", logBuf.String())
-		}
-		time.Sleep(time.Millisecond)
+	if !testutil.EventuallyOK(2*time.Second, func() bool { return recreateCount.Load() != 0 }) {
+		t.Fatalf("recreate handler never fired; logs:\n%s", logBuf.String())
 	}
 
 	if got := RecreateMode(recreateMode.Load()); got != RecreateBroadcast {
@@ -1091,12 +1080,8 @@ func TestAutoRecreateGroup_WorkerPoolRecoversFromNoGroup(t *testing.T) {
 
 	client.XGroupDestroy(context.Background(), streamName, groupName)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for recreateCount.Load() == 0 {
-		if time.Now().After(deadline) {
-			t.Fatalf("recreate handler never fired; logs:\n%s", logBuf.String())
-		}
-		time.Sleep(time.Millisecond)
+	if !testutil.EventuallyOK(2*time.Second, func() bool { return recreateCount.Load() != 0 }) {
+		t.Fatalf("recreate handler never fired; logs:\n%s", logBuf.String())
 	}
 
 	if got := RecreateMode(recreateMode.Load()); got != RecreateWorkerPool {
@@ -1149,12 +1134,10 @@ func TestAutoRecreateGroup_DisabledLeavesErrorLog(t *testing.T) {
 	client.XGroupDestroy(context.Background(), streamName, groupName)
 
 	// Wait for the existing error-log + backoff path to log.
-	deadline := time.Now().Add(2 * time.Second)
-	for !strings.Contains(logBuf.String(), "read error, retrying with backoff") {
-		if time.Now().After(deadline) {
-			t.Fatalf("expected error log never appeared; logs:\n%s", logBuf.String())
-		}
-		time.Sleep(time.Millisecond)
+	if !testutil.EventuallyOK(2*time.Second, func() bool {
+		return strings.Contains(logBuf.String(), "read error, retrying with backoff")
+	}) {
+		t.Fatalf("expected error log never appeared; logs:\n%s", logBuf.String())
 	}
 
 	if recreateCount.Load() != 0 {
@@ -1211,12 +1194,10 @@ func TestAutoRecreateGroup_WrongModeLeavesErrorLog(t *testing.T) {
 
 	client.XGroupDestroy(context.Background(), streamName, groupName)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for !strings.Contains(logBuf.String(), "read error, retrying with backoff") {
-		if time.Now().After(deadline) {
-			t.Fatalf("expected error log never appeared; logs:\n%s", logBuf.String())
-		}
-		time.Sleep(time.Millisecond)
+	if !testutil.EventuallyOK(2*time.Second, func() bool {
+		return strings.Contains(logBuf.String(), "read error, retrying with backoff")
+	}) {
+		t.Fatalf("expected error log never appeared; logs:\n%s", logBuf.String())
 	}
 
 	if recreateCount.Load() != 0 {
@@ -1289,17 +1270,12 @@ func TestAutoRecreateGroup_RecreateFailsFallsBack(t *testing.T) {
 	client.XGroupDestroy(context.Background(), streamName, groupName)
 
 	// Wait for both the recreate-failure Warn and the fall-through ERROR log.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
+	if !testutil.EventuallyOK(2*time.Second, func() bool {
 		s := logBuf.String()
-		if strings.Contains(s, "failed to recreate consumer group after NOGROUP") &&
-			strings.Contains(s, "read error, retrying with backoff") {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("expected failure + fall-through logs never both appeared; logs:\n%s", s)
-		}
-		time.Sleep(time.Millisecond)
+		return strings.Contains(s, "failed to recreate consumer group after NOGROUP") &&
+			strings.Contains(s, "read error, retrying with backoff")
+	}) {
+		t.Fatalf("expected failure + fall-through logs never both appeared; logs:\n%s", logBuf.String())
 	}
 
 	if recreateCount.Load() != 0 {
@@ -1360,12 +1336,8 @@ func TestAutoRecreateGroup_BusyGroupTreatedAsSuccess(t *testing.T) {
 	}
 	client.mu.Unlock()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for recreateCount.Load() == 0 {
-		if time.Now().After(deadline) {
-			t.Fatalf("recreate handler never fired (BUSYGROUP not treated as success); logs:\n%s", logBuf.String())
-		}
-		time.Sleep(time.Millisecond)
+	if !testutil.EventuallyOK(2*time.Second, func() bool { return recreateCount.Load() != 0 }) {
+		t.Fatalf("recreate handler never fired (BUSYGROUP not treated as success); logs:\n%s", logBuf.String())
 	}
 
 	if strings.Contains(logBuf.String(), "failed to recreate consumer group") {


### PR DESCRIPTION
## Summary
All 8 surviving \`time.Sleep(time.Millisecond)\` calls in \`transport/redis/redis_test.go\` lived inside hand-rolled \`deadline + for { sleep }\` polling loops — already eventually-style, just inlined. Replace each with \`testutil.Eventually\` / \`testutil.EventuallyOK\` so the package shares the centralized polling-tick and deadline behavior used elsewhere in the repo.

## Capture-on-timeout pattern
Several sites format their timeout message with \`logBuf.String()\` so an engineer reading the failure sees the full log trail accumulated during polling. With \`Eventually\`, the args would be evaluated at call site — capturing only the empty pre-poll buffer. For those sites we use \`EventuallyOK\` plus a manual \`t.Fatalf\` so the log state reflects what was actually observed when the deadline fired.

## Test plan
- [x] \`go test -race -count=20 ./transport/redis/...\` — green
- [x] \`golangci-lint run ./transport/redis/...\` clean