### PR TITLE
feat(idempotency): Clock injection on MemoryStore eliminates 3 test sleeps

### DIFF
--- a/idempotency/idempotency_test.go
+++ b/idempotency/idempotency_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
 func TestMemoryStore(t *testing.T) {
@@ -112,7 +114,8 @@ func TestMemoryStore(t *testing.T) {
 	})
 
 	t.Run("expired entries return false", func(t *testing.T) {
-		store := NewMemoryStore(10 * time.Millisecond)
+		clk := clock.NewFake(time.Time{})
+		store := NewMemoryStore(10*time.Millisecond, withClock(clk))
 		defer store.Close()
 
 		store.MarkProcessed(ctx, "msg-1")
@@ -123,8 +126,8 @@ func TestMemoryStore(t *testing.T) {
 			t.Error("expected duplicate before expiry")
 		}
 
-		// Wait for expiry
-		time.Sleep(20 * time.Millisecond)
+		// Cross the TTL boundary deterministically.
+		clk.Advance(20 * time.Millisecond)
 
 		// Should not be duplicate after expiry
 		isDuplicate, _ = store.IsDuplicate(ctx, "msg-1")
@@ -192,19 +195,21 @@ func TestMemoryStore(t *testing.T) {
 	})
 
 	t.Run("overwrite existing entry updates expiry", func(t *testing.T) {
-		store := NewMemoryStore(50 * time.Millisecond)
+		clk := clock.NewFake(time.Time{})
+		store := NewMemoryStore(50*time.Millisecond, withClock(clk))
 		defer store.Close()
 
 		store.MarkProcessed(ctx, "msg-1")
 
-		// Wait a bit
-		time.Sleep(30 * time.Millisecond)
+		// Advance partway through original TTL.
+		clk.Advance(30 * time.Millisecond)
 
-		// Mark again with longer TTL
+		// Mark again with a longer TTL. Expiry should now be
+		// 30ms (current fake time) + 100ms = 130ms total.
 		store.MarkProcessedWithTTL(ctx, "msg-1", 100*time.Millisecond)
 
-		// Wait past original expiry
-		time.Sleep(30 * time.Millisecond)
+		// Cross what would have been the original 50ms expiry.
+		clk.Advance(30 * time.Millisecond)
 
 		// Should still be duplicate due to updated TTL
 		isDuplicate, _ := store.IsDuplicate(ctx, "msg-1")

--- a/idempotency/memory.go
+++ b/idempotency/memory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/rbaliyan/event/v3/internal/clock"
 )
 
 // MemoryStore implements Store using in-memory storage with TTL support.
@@ -46,6 +48,26 @@ type MemoryStore struct {
 	entries map[string]time.Time // messageID -> expiry time
 	ttl     time.Duration
 	stopCh  chan struct{}
+
+	// clk supplies the current time for expiry computations. Defaults to
+	// clock.Real{}; tests inject clock.Fake via the unexported withClock
+	// option to drive expiry deterministically instead of time.Sleep.
+	clk clock.Clock
+}
+
+// MemoryStoreOption configures a MemoryStore at construction time. The only
+// currently exposed configuration is internal to the test build (withClock);
+// the public surface is the existing ttl positional argument.
+type MemoryStoreOption func(*MemoryStore)
+
+// withClock swaps the clock used by MemoryStore for expiry checks. Unexported
+// on purpose — it is only meant to be reachable from tests within this
+// package via clock.Fake. Annotated unused because production code never
+// instantiates it.
+//
+//nolint:unused
+func withClock(c clock.Clock) MemoryStoreOption {
+	return func(s *MemoryStore) { s.clk = c }
 }
 
 // NewMemoryStore creates a new in-memory idempotency store.
@@ -68,11 +90,15 @@ type MemoryStore struct {
 //
 //	// For testing, use shorter TTL
 //	testStore := idempotency.NewMemoryStore(time.Second)
-func NewMemoryStore(ttl time.Duration) *MemoryStore {
+func NewMemoryStore(ttl time.Duration, opts ...MemoryStoreOption) *MemoryStore {
 	s := &MemoryStore{
 		entries: make(map[string]time.Time),
 		ttl:     ttl,
 		stopCh:  make(chan struct{}),
+		clk:     clock.Real{},
+	}
+	for _, opt := range opts {
+		opt(s)
 	}
 
 	// Start cleanup goroutine
@@ -109,7 +135,7 @@ func (s *MemoryStore) IsDuplicate(ctx context.Context, messageID string) (bool, 
 	}
 
 	// Check if expired
-	if time.Now().After(expiry) {
+	if s.clk.Now().After(expiry) {
 		return false, nil
 	}
 
@@ -154,7 +180,7 @@ func (s *MemoryStore) MarkProcessedWithTTL(ctx context.Context, messageID string
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.entries[messageID] = time.Now().Add(ttl)
+	s.entries[messageID] = s.clk.Now().Add(ttl)
 	return nil
 }
 
@@ -234,7 +260,7 @@ func (s *MemoryStore) cleanup() {
 			return
 		case <-ticker.C:
 			s.mu.Lock()
-			now := time.Now()
+			now := s.clk.Now()
 			for id, expiry := range s.entries {
 				if now.After(expiry) {
 					delete(s.entries, id)


### PR DESCRIPTION
## Summary
Add unexported \`withClock\` test hook to \`idempotency.MemoryStore\` so unit tests can cross TTL boundaries via \`clock.Fake.Advance\` instead of \`time.Sleep\`. Clock field defaults to \`clock.Real{}\` — production behavior unchanged.

The cleanup goroutine's outer \`time.NewTicker(time.Minute)\` stays on real time because it is a memory-saver, not a correctness gate. The correctness gate (\`IsDuplicate\`'s expiry check) routes through \`s.clk.Now()\`, so tests get determinism without disturbing the periodic GC.

\`idempotency_test.go\` removed 3 sleeps:
- \`expired entries return false\`: \`time.Sleep(20ms)\` → \`clk.Advance(20ms)\`
- \`overwrite existing entry updates expiry\` (×2 sleeps): both → \`clk.Advance\`

Example and redis-integration tests keep their sleeps — they exercise real-time TTL expiration on the underlying backend (Redis \`EXPIRE\` / illustrative example) where the fake clock has no effect.

## Test plan
- [x] \`go test -race -count=20 ./idempotency\` — green
- [x] \`golangci-lint run ./idempotency/...\` clean