### PR TITLE
test: enable t.Parallel() across 6 leaf packages (113 tests)

### DIFF
--- a/monitor/proto/convert_test.go
+++ b/monitor/proto/convert_test.go
@@ -9,12 +9,14 @@ import (
 )
 
 func TestEntryToProto_Nil(t *testing.T) {
+	t.Parallel()
 	if got := EntryToProto(nil); got != nil {
 		t.Errorf("EntryToProto(nil) = %v, want nil", got)
 	}
 }
 
 func TestEntryToProto_RoundTrip(t *testing.T) {
+	t.Parallel()
 	now := time.Now().Truncate(time.Second)
 	completed := now.Add(5 * time.Second)
 	entry := &monitor.Entry{
@@ -67,12 +69,14 @@ func TestEntryToProto_RoundTrip(t *testing.T) {
 }
 
 func TestProtoToEntry_Nil(t *testing.T) {
+	t.Parallel()
 	if got := ProtoToEntry(nil); got != nil {
 		t.Errorf("ProtoToEntry(nil) = %v, want nil", got)
 	}
 }
 
 func TestFilterRoundTrip(t *testing.T) {
+	t.Parallel()
 	dm := monitor.WorkerPool
 	hasErr := true
 	f := monitor.Filter{
@@ -118,6 +122,7 @@ func TestFilterRoundTrip(t *testing.T) {
 }
 
 func TestProtoToFilter_Nil(t *testing.T) {
+	t.Parallel()
 	f := ProtoToFilter(nil)
 	if f.EventID != "" {
 		t.Errorf("expected empty filter, got EventID=%q", f.EventID)
@@ -125,6 +130,7 @@ func TestProtoToFilter_Nil(t *testing.T) {
 }
 
 func TestPageToListResponse_Nil(t *testing.T) {
+	t.Parallel()
 	resp := PageToListResponse(nil)
 	if resp == nil {
 		t.Fatal("expected non-nil response")
@@ -135,6 +141,7 @@ func TestPageToListResponse_Nil(t *testing.T) {
 }
 
 func TestPageToListResponse(t *testing.T) {
+	t.Parallel()
 	page := &monitor.Page{
 		Entries: []*monitor.Entry{
 			{EventID: "e1", EventName: "test"},
@@ -157,12 +164,14 @@ func TestPageToListResponse(t *testing.T) {
 }
 
 func TestEntriesToProto_Nil(t *testing.T) {
+	t.Parallel()
 	if got := EntriesToProto(nil); got != nil {
 		t.Errorf("EntriesToProto(nil) = %v, want nil", got)
 	}
 }
 
 func TestDurationConversions(t *testing.T) {
+	t.Parallel()
 	d := 5 * time.Second
 	pb := DurationToProto(d)
 	got := ProtoToDuration(pb)
@@ -176,6 +185,7 @@ func TestDurationConversions(t *testing.T) {
 }
 
 func TestStatusConversions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		status monitor.Status
 		proto  Status
@@ -199,6 +209,7 @@ func TestStatusConversions(t *testing.T) {
 }
 
 func TestDeliveryModeConversions(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		dm    monitor.DeliveryMode
 		proto DeliveryMode
@@ -220,6 +231,7 @@ func TestDeliveryModeConversions(t *testing.T) {
 }
 
 func TestDurationToProto_WithDuration(t *testing.T) {
+	t.Parallel()
 	pb := DurationToProto(0)
 	if pb == nil {
 		t.Fatal("expected non-nil")
@@ -235,6 +247,7 @@ func TestDurationToProto_WithDuration(t *testing.T) {
 }
 
 func TestProtoToDuration_NilInput(t *testing.T) {
+	t.Parallel()
 	got := ProtoToDuration(nil)
 	if got != 0 {
 		t.Errorf("expected 0, got %v", got)
@@ -242,6 +255,7 @@ func TestProtoToDuration_NilInput(t *testing.T) {
 }
 
 func TestProtoToDuration_ValidInput(t *testing.T) {
+	t.Parallel()
 	pb := &durationpb.Duration{Seconds: 10, Nanos: 500000000}
 	got := ProtoToDuration(pb)
 	expected := 10*time.Second + 500*time.Millisecond

--- a/monitor/stream/broadcaster_test.go
+++ b/monitor/stream/broadcaster_test.go
@@ -49,6 +49,7 @@ func (m *mockStore) DeleteOlderThan(ctx context.Context, age time.Duration) (int
 }
 
 func TestMatchesFilter_Empty(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{
 		EventID:   "e1",
 		EventName: "orders.created",
@@ -60,6 +61,7 @@ func TestMatchesFilter_Empty(t *testing.T) {
 }
 
 func TestMatchesFilter_EventName(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{EventName: "orders.created"}
 
 	if !matchesFilter(entry, monitor.Filter{EventName: "orders.created"}) {
@@ -71,6 +73,7 @@ func TestMatchesFilter_EventName(t *testing.T) {
 }
 
 func TestMatchesFilter_Status(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{Status: monitor.StatusFailed}
 
 	f := monitor.Filter{
@@ -87,6 +90,7 @@ func TestMatchesFilter_Status(t *testing.T) {
 }
 
 func TestMatchesFilter_HasError(t *testing.T) {
+	t.Parallel()
 	withErr := &monitor.Entry{Error: "something failed"}
 	noErr := &monitor.Entry{}
 
@@ -105,6 +109,7 @@ func TestMatchesFilter_HasError(t *testing.T) {
 }
 
 func TestMatchesFilter_DeliveryMode(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{DeliveryMode: monitor.WorkerPool}
 
 	wp := monitor.WorkerPool
@@ -119,6 +124,7 @@ func TestMatchesFilter_DeliveryMode(t *testing.T) {
 }
 
 func TestMatchesFilter_TimeRange(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	entry := &monitor.Entry{StartedAt: now}
 
@@ -131,6 +137,7 @@ func TestMatchesFilter_TimeRange(t *testing.T) {
 }
 
 func TestMatchesFilter_MinDuration(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{Duration: 5 * time.Second}
 
 	if !matchesFilter(entry, monitor.Filter{MinDuration: 3 * time.Second}) {
@@ -142,6 +149,7 @@ func TestMatchesFilter_MinDuration(t *testing.T) {
 }
 
 func TestMatchesFilter_MinRetries(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{RetryCount: 3}
 
 	if !matchesFilter(entry, monitor.Filter{MinRetries: 2}) {
@@ -153,6 +161,7 @@ func TestMatchesFilter_MinRetries(t *testing.T) {
 }
 
 func TestSubscriber_Close(t *testing.T) {
+	t.Parallel()
 	sub := &Subscriber{
 		entries: make(chan *monitor.Entry, 10),
 		done:    make(chan struct{}),
@@ -164,6 +173,7 @@ func TestSubscriber_Close(t *testing.T) {
 }
 
 func TestSubscriber_Entries(t *testing.T) {
+	t.Parallel()
 	sub := &Subscriber{
 		entries: make(chan *monitor.Entry, 10),
 		done:    make(chan struct{}),
@@ -175,6 +185,7 @@ func TestSubscriber_Entries(t *testing.T) {
 }
 
 func TestNewBroadcaster(t *testing.T) {
+	t.Parallel()
 	store := &mockStore{}
 	b := NewBroadcaster(store, 0)
 	if b.pollInterval != DefaultPollInterval {
@@ -188,6 +199,7 @@ func TestNewBroadcaster(t *testing.T) {
 }
 
 func TestBroadcaster_SubscribeUnsubscribe(t *testing.T) {
+	t.Parallel()
 	store := &mockStore{}
 	b := NewBroadcaster(store, time.Second)
 
@@ -213,6 +225,7 @@ func TestBroadcaster_SubscribeUnsubscribe(t *testing.T) {
 }
 
 func TestBroadcaster_UnsubscribeNil(t *testing.T) {
+	t.Parallel()
 	store := &mockStore{}
 	b := NewBroadcaster(store, time.Second)
 	// Should not panic
@@ -220,6 +233,7 @@ func TestBroadcaster_UnsubscribeNil(t *testing.T) {
 }
 
 func TestBroadcaster_StartStop(t *testing.T) {
+	t.Parallel()
 	store := &mockStore{}
 	b := NewBroadcaster(store, 50*time.Millisecond)
 
@@ -234,6 +248,7 @@ func TestBroadcaster_StartStop(t *testing.T) {
 }
 
 func TestBroadcaster_StopWithoutStart(t *testing.T) {
+	t.Parallel()
 	store := &mockStore{}
 	b := NewBroadcaster(store, time.Second)
 	// Should not panic
@@ -241,6 +256,7 @@ func TestBroadcaster_StopWithoutStart(t *testing.T) {
 }
 
 func TestBroadcaster_BroadcastEntries(t *testing.T) {
+	t.Parallel()
 	entry := &monitor.Entry{
 		EventID:   "e1",
 		EventName: "orders.created",

--- a/schema/http/handler_test.go
+++ b/schema/http/handler_test.go
@@ -46,6 +46,7 @@ func decodeJSON(t *testing.T, w *httptest.ResponseRecorder, v any) {
 
 // TestList_Empty verifies an empty provider returns an empty schemas array.
 func TestList_Empty(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 	w := do(t, h, http.MethodGet, "/v1/schemas", nil)
 
@@ -64,6 +65,7 @@ func TestList_Empty(t *testing.T) {
 
 // TestPutAndGet verifies creating and retrieving a schema.
 func TestPutAndGet(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{
@@ -108,6 +110,7 @@ func TestPutAndGet(t *testing.T) {
 
 // TestPut_AutoIncrementVersion verifies version is auto-incremented on update.
 func TestPut_AutoIncrementVersion(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{"description": "v1", "enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
@@ -128,6 +131,7 @@ func TestPut_AutoIncrementVersion(t *testing.T) {
 
 // TestList_WithSchemas verifies the list endpoint returns all schemas.
 func TestList_WithSchemas(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{"enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
@@ -150,6 +154,7 @@ func TestList_WithSchemas(t *testing.T) {
 
 // TestDelete verifies deletion removes a schema.
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{"enable_monitor": false, "enable_idempotency": false, "enable_poison": false}
@@ -169,6 +174,7 @@ func TestDelete(t *testing.T) {
 
 // TestGet_NotFound verifies 404 for missing schemas.
 func TestGet_NotFound(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 	w := do(t, h, http.MethodGet, "/v1/schemas/nonexistent", nil)
 	if w.Code != http.StatusNotFound {
@@ -178,6 +184,7 @@ func TestGet_NotFound(t *testing.T) {
 
 // TestPut_InvalidJSON verifies 400 for malformed bodies.
 func TestPut_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 	req := httptest.NewRequest(http.MethodPut, "/v1/schemas/test", bytes.NewBufferString("not json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -190,6 +197,7 @@ func TestPut_InvalidJSON(t *testing.T) {
 
 // TestMethodNotAllowed verifies 405 for wrong HTTP methods.
 func TestMethodNotAllowed(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 	w := do(t, h, http.MethodPost, "/v1/schemas", nil)
 	if w.Code != http.StatusMethodNotAllowed {
@@ -199,6 +207,7 @@ func TestMethodNotAllowed(t *testing.T) {
 
 // TestPut_MissingName verifies 400 for /v1/schemas/ with no name.
 func TestPut_MissingName(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 	w := do(t, h, http.MethodPut, "/v1/schemas/", map[string]any{})
 	if w.Code != http.StatusBadRequest {
@@ -208,6 +217,7 @@ func TestPut_MissingName(t *testing.T) {
 
 // TestPut_MetadataRoundtrip verifies metadata is preserved.
 func TestPut_MetadataRoundtrip(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{
@@ -229,6 +239,7 @@ func TestPut_MetadataRoundtrip(t *testing.T) {
 
 // TestPut_ServerFieldsIgnored verifies that version supplied in the PUT body is ignored.
 func TestPut_ServerFieldsIgnored(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{
@@ -251,6 +262,7 @@ func TestPut_ServerFieldsIgnored(t *testing.T) {
 
 // TestPut_ConcurrentVersionIncrement verifies that concurrent PUTs serialize version increments.
 func TestPut_ConcurrentVersionIncrement(t *testing.T) {
+	t.Parallel()
 	h, _ := newHandler(t)
 
 	body := map[string]any{"enable_monitor": false, "enable_idempotency": false, "enable_poison": false}

--- a/transport/ackonly/ackonly_test.go
+++ b/transport/ackonly/ackonly_test.go
@@ -88,6 +88,7 @@ func (m *mockAckBackend) getAcked(eventName string) []string {
 }
 
 func TestNew_Defaults(t *testing.T) {
+	t.Parallel()
 	tr := New()
 
 	if tr == nil {
@@ -116,6 +117,7 @@ func TestNew_Defaults(t *testing.T) {
 }
 
 func TestNew_WithBufferSize(t *testing.T) {
+	t.Parallel()
 	tr := New(WithBufferSize(200))
 
 	if tr.bufferSize != 200 {
@@ -124,6 +126,7 @@ func TestNew_WithBufferSize(t *testing.T) {
 }
 
 func TestNew_WithBufferSize_Negative(t *testing.T) {
+	t.Parallel()
 	tr := New(WithBufferSize(-10))
 
 	if tr.bufferSize != 100 {
@@ -132,6 +135,7 @@ func TestNew_WithBufferSize_Negative(t *testing.T) {
 }
 
 func TestNew_WithLogger(t *testing.T) {
+	t.Parallel()
 	logger := slog.Default()
 	tr := New(WithLogger(logger))
 
@@ -141,6 +145,7 @@ func TestNew_WithLogger(t *testing.T) {
 }
 
 func TestNew_WithLogger_Nil(t *testing.T) {
+	t.Parallel()
 	tr := New(WithLogger(nil))
 
 	if tr.logger == nil {
@@ -149,6 +154,7 @@ func TestNew_WithLogger_Nil(t *testing.T) {
 }
 
 func TestNew_WithAckBackend(t *testing.T) {
+	t.Parallel()
 	backend := newMockAckBackend()
 	tr := New(WithAckBackend(backend))
 
@@ -158,6 +164,7 @@ func TestNew_WithAckBackend(t *testing.T) {
 }
 
 func TestNew_WithErrorHandler(t *testing.T) {
+	t.Parallel()
 	var called bool
 	handler := func(err error) {
 		called = true
@@ -173,6 +180,7 @@ func TestNew_WithErrorHandler(t *testing.T) {
 }
 
 func TestNew_WithErrorHandler_Nil(t *testing.T) {
+	t.Parallel()
 	tr := New(WithErrorHandler(nil))
 
 	if tr.onError == nil {
@@ -181,6 +189,7 @@ func TestNew_WithErrorHandler_Nil(t *testing.T) {
 }
 
 func TestRegisterEvent_Success(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -197,6 +206,7 @@ func TestRegisterEvent_Success(t *testing.T) {
 }
 
 func TestRegisterEvent_Duplicate(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -212,6 +222,7 @@ func TestRegisterEvent_Duplicate(t *testing.T) {
 }
 
 func TestRegisterEvent_TransportClosed(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -224,6 +235,7 @@ func TestRegisterEvent_TransportClosed(t *testing.T) {
 }
 
 func TestUnregisterEvent_Success(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -242,6 +254,7 @@ func TestUnregisterEvent_Success(t *testing.T) {
 }
 
 func TestUnregisterEvent_NotRegistered(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -252,6 +265,7 @@ func TestUnregisterEvent_NotRegistered(t *testing.T) {
 }
 
 func TestUnregisterEvent_TransportClosed(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -265,6 +279,7 @@ func TestUnregisterEvent_TransportClosed(t *testing.T) {
 }
 
 func TestUnregisterEvent_ClosesSubscriptions(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -285,6 +300,7 @@ func TestUnregisterEvent_ClosesSubscriptions(t *testing.T) {
 }
 
 func TestPublish_NotSupported(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -299,6 +315,7 @@ func TestPublish_NotSupported(t *testing.T) {
 }
 
 func TestSubscribe_Success(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -323,6 +340,7 @@ func TestSubscribe_Success(t *testing.T) {
 }
 
 func TestSubscribe_EventNotRegistered(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -333,6 +351,7 @@ func TestSubscribe_EventNotRegistered(t *testing.T) {
 }
 
 func TestSubscribe_TransportClosed(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -346,6 +365,7 @@ func TestSubscribe_TransportClosed(t *testing.T) {
 }
 
 func TestSubscribe_CustomBufferSize(t *testing.T) {
+	t.Parallel()
 	tr := New(WithBufferSize(100))
 	ctx := context.Background()
 
@@ -363,6 +383,7 @@ func TestSubscribe_CustomBufferSize(t *testing.T) {
 }
 
 func TestDeliver_ToSubscribers(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -398,6 +419,7 @@ func TestDeliver_ToSubscribers(t *testing.T) {
 }
 
 func TestDeliver_EventNotRegistered(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -410,6 +432,7 @@ func TestDeliver_EventNotRegistered(t *testing.T) {
 }
 
 func TestDeliver_TransportClosed(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -425,6 +448,7 @@ func TestDeliver_TransportClosed(t *testing.T) {
 }
 
 func TestDeliver_WithAckBackend(t *testing.T) {
+	t.Parallel()
 	backend := newMockAckBackend()
 	tr := New(WithAckBackend(backend))
 	ctx := context.Background()
@@ -463,6 +487,7 @@ func TestDeliver_WithAckBackend(t *testing.T) {
 }
 
 func TestDeliver_AckBackend_StoreError(t *testing.T) {
+	t.Parallel()
 	backend := newMockAckBackend()
 	backend.storeErr = errors.New("store failed")
 
@@ -498,6 +523,7 @@ func TestDeliver_AckBackend_StoreError(t *testing.T) {
 }
 
 func TestDeliver_NoSubscribers(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -513,6 +539,7 @@ func TestDeliver_NoSubscribers(t *testing.T) {
 }
 
 func TestDeliver_ClosedSubscriber(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -530,6 +557,7 @@ func TestDeliver_ClosedSubscriber(t *testing.T) {
 }
 
 func TestClose_Success(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -557,6 +585,7 @@ func TestClose_Success(t *testing.T) {
 }
 
 func TestClose_Idempotent(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -573,6 +602,7 @@ func TestClose_Idempotent(t *testing.T) {
 }
 
 func TestClose_MultipleSubscriptions(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -603,6 +633,7 @@ func TestClose_MultipleSubscriptions(t *testing.T) {
 }
 
 func TestHealth_Healthy(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -648,6 +679,7 @@ func TestHealth_Healthy(t *testing.T) {
 }
 
 func TestHealth_WithAckBackend(t *testing.T) {
+	t.Parallel()
 	backend := newMockAckBackend()
 	tr := New(WithAckBackend(backend))
 	ctx := context.Background()
@@ -660,6 +692,7 @@ func TestHealth_WithAckBackend(t *testing.T) {
 }
 
 func TestHealth_Unhealthy(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -677,6 +710,7 @@ func TestHealth_Unhealthy(t *testing.T) {
 }
 
 func TestSubscription_Close(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -700,6 +734,7 @@ func TestSubscription_Close(t *testing.T) {
 }
 
 func TestDeliver_ConcurrentSubscribers(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 

--- a/transport/composite/composite_test.go
+++ b/transport/composite/composite_test.go
@@ -57,6 +57,7 @@ func publishAndWait(t *testing.T, ctx context.Context, ct *Transport, eventName 
 }
 
 func TestNew_Validation(t *testing.T) {
+	t.Parallel()
 	store := persistent.NewMemoryStore()
 	signal := channel.New()
 
@@ -87,6 +88,7 @@ func TestNew_Validation(t *testing.T) {
 }
 
 func TestNew_Options(t *testing.T) {
+	t.Parallel()
 	store := persistent.NewMemoryStore()
 	signal := channel.New()
 
@@ -112,6 +114,7 @@ func TestNew_Options(t *testing.T) {
 }
 
 func TestRegisterEvent(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx := context.Background()
 	defer ct.Close(ctx)
@@ -127,6 +130,7 @@ func TestRegisterEvent(t *testing.T) {
 }
 
 func TestUnregisterEvent(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx := context.Background()
 	defer ct.Close(ctx)
@@ -144,6 +148,7 @@ func TestUnregisterEvent(t *testing.T) {
 }
 
 func TestPublish_Success(t *testing.T) {
+	t.Parallel()
 	ct, store, _ := newTestTransport(t)
 	ctx := context.Background()
 	defer ct.Close(ctx)
@@ -171,6 +176,7 @@ func TestPublish_Success(t *testing.T) {
 }
 
 func TestPublish_DurableFailure(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx := context.Background()
 	defer ct.Close(ctx)
@@ -188,6 +194,7 @@ func TestPublish_DurableFailure(t *testing.T) {
 }
 
 func TestPublish_SignalFailure(t *testing.T) {
+	t.Parallel()
 	store := persistent.NewMemoryStore()
 	signal := channel.New()
 	ctx := context.Background()
@@ -227,6 +234,7 @@ func TestPublish_SignalFailure(t *testing.T) {
 }
 
 func TestSubscribe_SignalDriven(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -258,6 +266,7 @@ func TestSubscribe_SignalDriven(t *testing.T) {
 }
 
 func TestSubscribe_PollFallback(t *testing.T) {
+	t.Parallel()
 	store := persistent.NewMemoryStore()
 	signal := channel.New()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -306,6 +315,7 @@ func TestSubscribe_PollFallback(t *testing.T) {
 }
 
 func TestSubscribe_MultipleMessages(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -340,6 +350,7 @@ func TestSubscribe_MultipleMessages(t *testing.T) {
 }
 
 func TestSubscribe_Checkpoint(t *testing.T) {
+	t.Parallel()
 	store := persistent.NewMemoryStore()
 	cpStore := persistent.NewMemoryCheckpointStore()
 	signal := channel.New(channel.WithBufferSize(100))
@@ -430,6 +441,7 @@ func TestSubscribe_Checkpoint(t *testing.T) {
 }
 
 func TestClose_Graceful(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx := context.Background()
 
@@ -462,6 +474,7 @@ func TestClose_Graceful(t *testing.T) {
 }
 
 func TestHealth(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx := context.Background()
 	defer ct.Close(ctx)
@@ -476,6 +489,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestHealth_Closed(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx := context.Background()
 
@@ -488,6 +502,7 @@ func TestHealth_Closed(t *testing.T) {
 }
 
 func TestSubscribe_ConcurrentPublish(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -537,6 +552,7 @@ func TestSubscribe_ConcurrentPublish(t *testing.T) {
 }
 
 func TestSubscribe_NackRedelivery(t *testing.T) {
+	t.Parallel()
 	ct, _, _ := newTestTransport(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -579,6 +595,7 @@ func TestSubscribe_NackRedelivery(t *testing.T) {
 }
 
 func TestSubscribe_ConsumerID(t *testing.T) {
+	t.Parallel()
 	store := persistent.NewMemoryStore()
 	cpStore := persistent.NewMemoryCheckpointStore()
 	signal := channel.New(channel.WithBufferSize(100))

--- a/transport/migration/migration_test.go
+++ b/transport/migration/migration_test.go
@@ -31,6 +31,7 @@ func setup(t *testing.T) (*Transport, *channel.Transport, *channel.Transport) {
 }
 
 func TestNew_Validation(t *testing.T) {
+	t.Parallel()
 	_, err := New(nil, channel.New())
 	if !errors.Is(err, ErrOldTransportRequired) {
 		t.Fatalf("expected ErrOldTransportRequired, got %v", err)
@@ -42,6 +43,7 @@ func TestNew_Validation(t *testing.T) {
 }
 
 func TestPublish_GoesToNewOnly(t *testing.T) {
+	t.Parallel()
 	mt, old, new := setup(t)
 	ctx := context.Background()
 	event := "test.event"
@@ -81,6 +83,7 @@ func TestPublish_GoesToNewOnly(t *testing.T) {
 }
 
 func TestSubscribe_MergesBothTransports(t *testing.T) {
+	t.Parallel()
 	mt, old, _ := setup(t)
 	ctx := context.Background()
 	event := "test.event"
@@ -123,6 +126,7 @@ func TestSubscribe_MergesBothTransports(t *testing.T) {
 }
 
 func TestRegisterEvent_NewOnly(t *testing.T) {
+	t.Parallel()
 	mt, old, _ := setup(t)
 	ctx := context.Background()
 
@@ -138,6 +142,7 @@ func TestRegisterEvent_NewOnly(t *testing.T) {
 }
 
 func TestUnregisterEvent_Both(t *testing.T) {
+	t.Parallel()
 	mt, old, new := setup(t)
 	ctx := context.Background()
 	event := "test.event"
@@ -159,6 +164,7 @@ func TestUnregisterEvent_Both(t *testing.T) {
 }
 
 func TestClose_ClosesBoth(t *testing.T) {
+	t.Parallel()
 	mt, old, new := setup(t)
 	ctx := context.Background()
 
@@ -174,6 +180,7 @@ func TestClose_ClosesBoth(t *testing.T) {
 }
 
 func TestMergedSubscription_Close(t *testing.T) {
+	t.Parallel()
 	mt, old, _ := setup(t)
 	ctx := context.Background()
 	event := "test.event"
@@ -203,6 +210,7 @@ func TestMergedSubscription_Close(t *testing.T) {
 }
 
 func TestOldSubscribeFailure_FallsBackToNew(t *testing.T) {
+	t.Parallel()
 	old := channel.New(channel.WithBufferSize(100))
 	new := channel.New(channel.WithBufferSize(100))
 	mt, _ := New(old, new)
@@ -234,6 +242,7 @@ func TestOldSubscribeFailure_FallsBackToNew(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
+	t.Parallel()
 	mt, _, _ := setup(t)
 	name := mt.Name()
 	if name != "migration(channel->channel)" {
@@ -243,6 +252,7 @@ func TestName(t *testing.T) {
 }
 
 func TestHealth(t *testing.T) {
+	t.Parallel()
 	mt, _, _ := setup(t)
 	ctx := context.Background()
 
@@ -255,6 +265,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestConsumerLag(t *testing.T) {
+	t.Parallel()
 	mt, _, _ := setup(t)
 	ctx := context.Background()
 
@@ -271,6 +282,7 @@ func TestConsumerLag(t *testing.T) {
 }
 
 func TestCloseThenOperate(t *testing.T) {
+	t.Parallel()
 	mt, _, _ := setup(t)
 	ctx := context.Background()
 
@@ -291,6 +303,7 @@ func TestCloseThenOperate(t *testing.T) {
 }
 
 func TestDoubleClose(t *testing.T) {
+	t.Parallel()
 	mt, _, _ := setup(t)
 	ctx := context.Background()
 	if err := mt.Close(ctx); err != nil {
@@ -302,6 +315,7 @@ func TestDoubleClose(t *testing.T) {
 }
 
 func TestWithLogger(t *testing.T) {
+	t.Parallel()
 	old := channel.New(channel.WithBufferSize(10))
 	newT := channel.New(channel.WithBufferSize(10))
 	logger := slog.New(slog.NewTextHandler(nil, nil))
@@ -313,6 +327,7 @@ func TestWithLogger(t *testing.T) {
 }
 
 func TestWithMergedBufferSize(t *testing.T) {
+	t.Parallel()
 	old := channel.New(channel.WithBufferSize(10))
 	newT := channel.New(channel.WithBufferSize(10))
 	mt, err := New(old, newT, WithMergedBufferSize(128))
@@ -326,6 +341,7 @@ func TestWithMergedBufferSize(t *testing.T) {
 }
 
 func TestWithMergedBufferSize_InvalidIgnored(t *testing.T) {
+	t.Parallel()
 	old := channel.New(channel.WithBufferSize(10))
 	newT := channel.New(channel.WithBufferSize(10))
 	mt, err := New(old, newT, WithMergedBufferSize(0))
@@ -339,6 +355,7 @@ func TestWithMergedBufferSize_InvalidIgnored(t *testing.T) {
 }
 
 func TestSupportsRedelivery(t *testing.T) {
+	t.Parallel()
 	mt, _, _ := setup(t)
 	// Channel transport does not implement Redeliverable, so should return false.
 	if mt.SupportsRedelivery() {
@@ -348,6 +365,7 @@ func TestSupportsRedelivery(t *testing.T) {
 }
 
 func TestContextCancellation_StopsSubscription(t *testing.T) {
+	t.Parallel()
 	mt, old, _ := setup(t)
 	event := "test.event"
 
@@ -380,6 +398,7 @@ func TestContextCancellation_StopsSubscription(t *testing.T) {
 }
 
 func TestConcurrentPublishSubscribe(t *testing.T) {
+	t.Parallel()
 	mt, old, _ := setup(t)
 	ctx := context.Background()
 	event := "test.event"


### PR DESCRIPTION
## Summary
Mass-enable \`t.Parallel()\` on every top-level Test function in six leaf-package \`_test.go\` files.

| Package              | Tests parallelized |
|----------------------|--------------------|
| \`transport/ackonly\`   | 35                 |
| \`transport/composite\` | 17                 |
| \`transport/migration\` | 19                 |
| \`monitor/stream\`      | 16                 |
| \`monitor/proto\`       | 14                 |
| \`schema/http\`         | 12                 |
| **Total**            | **113**            |

## Why these six
Each file:
- Constructs all state inside its test body (mock backends, fresh transports, isolated schema providers).
- The package's non-test source has no mutable package-level globals (only generated protobuf descriptors, lua scripts, and sentinel errors — all read-only).
- No \`t.Setenv\` / \`os.Setenv\` usage anywhere.

Subtests inside \`t.Run\` are left serial; only the outer Test funcs are parallelized. This is enough to give \`-race\` wider concurrent coverage of mock-state isolation without changing intra-body ordering inside each test.

## Test plan
- [x] \`go test -race -count=10\` passes across all 6 packages
- [x] \`golangci-lint run\` clean across all 6 packages