### PR TITLE
test: enable t.Parallel() across 5 more leaf packages (53 tests)

### DIFF
--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestConstant(t *testing.T) {
+	t.Parallel()
 	strategy := &Constant{Delay: 100 * time.Millisecond}
 
 	for i := 0; i < 10; i++ {
@@ -17,6 +18,7 @@ func TestConstant(t *testing.T) {
 }
 
 func TestLinear(t *testing.T) {
+	t.Parallel()
 	strategy := &Linear{
 		Initial: 100 * time.Millisecond,
 		Step:    50 * time.Millisecond,
@@ -45,6 +47,7 @@ func TestLinear(t *testing.T) {
 }
 
 func TestLinear_NoMax(t *testing.T) {
+	t.Parallel()
 	strategy := &Linear{
 		Initial: 100 * time.Millisecond,
 		Step:    100 * time.Millisecond,
@@ -59,6 +62,7 @@ func TestLinear_NoMax(t *testing.T) {
 }
 
 func TestExponential(t *testing.T) {
+	t.Parallel()
 	strategy := &Exponential{
 		Initial:    100 * time.Millisecond,
 		Multiplier: 2.0,
@@ -87,6 +91,7 @@ func TestExponential(t *testing.T) {
 }
 
 func TestExponential_DefaultMultiplier(t *testing.T) {
+	t.Parallel()
 	strategy := &Exponential{
 		Initial:    100 * time.Millisecond,
 		Multiplier: 0, // Should default to 2.0
@@ -101,6 +106,7 @@ func TestExponential_DefaultMultiplier(t *testing.T) {
 }
 
 func TestExponential_NoMax(t *testing.T) {
+	t.Parallel()
 	strategy := &Exponential{
 		Initial:    100 * time.Millisecond,
 		Multiplier: 2.0,
@@ -116,6 +122,7 @@ func TestExponential_NoMax(t *testing.T) {
 }
 
 func TestExponential_WithJitter(t *testing.T) {
+	t.Parallel()
 	strategy := &Exponential{
 		Initial:    100 * time.Millisecond,
 		Multiplier: 2.0,
@@ -139,6 +146,7 @@ func TestExponential_WithJitter(t *testing.T) {
 }
 
 func TestDefault(t *testing.T) {
+	t.Parallel()
 	strategy := Default()
 
 	// Verify it's an Exponential strategy
@@ -162,6 +170,7 @@ func TestDefault(t *testing.T) {
 }
 
 func TestNone(t *testing.T) {
+	t.Parallel()
 	strategy := None()
 
 	for i := 0; i < 10; i++ {
@@ -173,6 +182,7 @@ func TestNone(t *testing.T) {
 }
 
 func TestFixed(t *testing.T) {
+	t.Parallel()
 	strategy := Fixed(500 * time.Millisecond)
 
 	for i := 0; i < 10; i++ {
@@ -184,6 +194,7 @@ func TestFixed(t *testing.T) {
 }
 
 func TestExponential_CustomMultiplier(t *testing.T) {
+	t.Parallel()
 	strategy := &Exponential{
 		Initial:    100 * time.Millisecond,
 		Multiplier: 3.0,

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -26,6 +26,7 @@ var _ Checker = (*mockChecker)(nil)
 var _ Checker = (*panicChecker)(nil)
 
 func TestResultStatusMethods(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		status    Status
@@ -56,6 +57,7 @@ func TestResultStatusMethods(t *testing.T) {
 }
 
 func TestResultFields(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	r := &Result{
 		Status:    StatusHealthy,
@@ -83,6 +85,7 @@ func TestResultFields(t *testing.T) {
 }
 
 func TestAggregate_AllHealthy(t *testing.T) {
+	t.Parallel()
 	components := map[string]*Result{
 		"db":    {Status: StatusHealthy},
 		"cache": {Status: StatusHealthy},
@@ -102,6 +105,7 @@ func TestAggregate_AllHealthy(t *testing.T) {
 }
 
 func TestAggregate_DegradedWins(t *testing.T) {
+	t.Parallel()
 	components := map[string]*Result{
 		"db":    {Status: StatusHealthy},
 		"cache": {Status: StatusDegraded},
@@ -115,6 +119,7 @@ func TestAggregate_DegradedWins(t *testing.T) {
 }
 
 func TestAggregate_UnhealthyWins(t *testing.T) {
+	t.Parallel()
 	components := map[string]*Result{
 		"db":    {Status: StatusUnhealthy},
 		"cache": {Status: StatusDegraded},
@@ -129,6 +134,7 @@ func TestAggregate_UnhealthyWins(t *testing.T) {
 }
 
 func TestAggregate_NilComponent(t *testing.T) {
+	t.Parallel()
 	components := map[string]*Result{
 		"db":    {Status: StatusHealthy},
 		"cache": nil,
@@ -142,6 +148,7 @@ func TestAggregate_NilComponent(t *testing.T) {
 }
 
 func TestAggregate_EmptyComponents(t *testing.T) {
+	t.Parallel()
 	agg := Aggregate(map[string]*Result{})
 
 	if agg.Status != StatusHealthy {
@@ -150,6 +157,7 @@ func TestAggregate_EmptyComponents(t *testing.T) {
 }
 
 func TestCheckAll_BasicCheckers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	checkers := map[string]Checker{
 		"healthy": &mockChecker{result: &Result{
@@ -180,6 +188,7 @@ func TestCheckAll_BasicCheckers(t *testing.T) {
 }
 
 func TestCheckAll_PanicRecovery(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	checkers := map[string]Checker{
 		"healthy": &mockChecker{result: &Result{
@@ -207,6 +216,7 @@ func TestCheckAll_PanicRecovery(t *testing.T) {
 }
 
 func TestCheckAll_NilChecker(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	checkers := map[string]Checker{
 		"healthy": &mockChecker{result: &Result{
@@ -228,6 +238,7 @@ func TestCheckAll_NilChecker(t *testing.T) {
 }
 
 func TestCheckAll_EmptyCheckers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	agg := CheckAll(ctx, map[string]Checker{})
 
@@ -240,6 +251,7 @@ func TestCheckAll_EmptyCheckers(t *testing.T) {
 }
 
 func TestStatusConstants(t *testing.T) {
+	t.Parallel()
 	if StatusHealthy != "healthy" {
 		t.Errorf("StatusHealthy = %q, want %q", StatusHealthy, "healthy")
 	}

--- a/internal/msgpacklimit/validate_test.go
+++ b/internal/msgpacklimit/validate_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestValidate_ValidInputs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		value any
@@ -39,6 +40,7 @@ func TestValidate_ValidInputs(t *testing.T) {
 }
 
 func TestValidate_OversizedArray(t *testing.T) {
+	t.Parallel()
 	// Craft a msgpack array32 header claiming 2 billion elements
 	// 0xdd = array32, followed by 4-byte big-endian length
 	data := []byte{0xdd, 0x77, 0x35, 0x94, 0x00} // ~2 billion
@@ -49,6 +51,7 @@ func TestValidate_OversizedArray(t *testing.T) {
 }
 
 func TestValidate_OversizedMap(t *testing.T) {
+	t.Parallel()
 	// Craft a msgpack map32 header claiming 2 billion elements
 	data := []byte{0xdf, 0x77, 0x35, 0x94, 0x00}
 	err := Validate(data)
@@ -58,6 +61,7 @@ func TestValidate_OversizedMap(t *testing.T) {
 }
 
 func TestValidate_NestedOversizedArray(t *testing.T) {
+	t.Parallel()
 	// fixarray(1) containing an array32 with huge length
 	data := []byte{
 		0x91,                         // fixarray of 1 element
@@ -70,6 +74,7 @@ func TestValidate_NestedOversizedArray(t *testing.T) {
 }
 
 func TestValidate_CrashInput(t *testing.T) {
+	t.Parallel()
 	// The actual crash input from ClusterFuzzLite: 118x 0xdd + 0xc3 0xc3 0x81 0x81 0xc3
 	data := make([]byte, 123)
 	for i := 0; i < 118; i++ {
@@ -88,6 +93,7 @@ func TestValidate_CrashInput(t *testing.T) {
 }
 
 func TestValidate_EmptyInput(t *testing.T) {
+	t.Parallel()
 	if err := Validate(nil); err != nil {
 		t.Errorf("Validate(nil) = %v, want nil", err)
 	}
@@ -97,6 +103,7 @@ func TestValidate_EmptyInput(t *testing.T) {
 }
 
 func TestValidate_TruncatedInput(t *testing.T) {
+	t.Parallel()
 	// Truncated array32 header (missing length bytes)
 	if err := Validate([]byte{0xdd, 0x00}); err != nil {
 		t.Errorf("Validate(truncated) = %v, want nil", err)
@@ -104,6 +111,7 @@ func TestValidate_TruncatedInput(t *testing.T) {
 }
 
 func TestValidate_CumulativeBudgetExceeded(t *testing.T) {
+	t.Parallel()
 	// Chain of nested array32 headers each declaring 99,999 elements (under per-collection limit of 100K).
 	// 11 such headers = 1,099,989 total elements > maxTotalElements (1M).
 	// Each array32 header: 0xdd + 4-byte big-endian length
@@ -119,6 +127,7 @@ func TestValidate_CumulativeBudgetExceeded(t *testing.T) {
 }
 
 func TestValidate_CumulativeBudgetOK(t *testing.T) {
+	t.Parallel()
 	// 2 nested array32 headers each declaring 99,999 elements = 199,998 total (under 1M).
 	data := []byte{
 		0xdd, 0x00, 0x01, 0x86, 0x9F, // array32(99999)
@@ -131,6 +140,7 @@ func TestValidate_CumulativeBudgetOK(t *testing.T) {
 }
 
 func TestValidate_PerCollectionLimitExceeded(t *testing.T) {
+	t.Parallel()
 	// array32 with 200,000 elements (over per-collection limit of 100K)
 	data := []byte{0xdd, 0x00, 0x03, 0x0D, 0x40} // 200000
 	err := Validate(data)

--- a/transport/noop/noop_test.go
+++ b/transport/noop/noop_test.go
@@ -15,6 +15,7 @@ func testMessage(id string, payload []byte) transport.Message {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	if tr == nil {
 		t.Fatal("expected non-nil transport")
@@ -25,6 +26,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestRegisterEvent(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -40,6 +42,7 @@ func TestRegisterEvent(t *testing.T) {
 }
 
 func TestUnregisterEvent(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -61,6 +64,7 @@ func TestUnregisterEvent(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -85,6 +89,7 @@ func TestPublish(t *testing.T) {
 }
 
 func TestSubscribe(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -113,6 +118,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestSubscribeNeverReceivesMessages(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -137,6 +143,7 @@ func TestSubscribeNeverReceivesMessages(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -179,6 +186,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestHealth(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 
@@ -209,6 +217,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestUnregisterClosesSubscriptions(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	ctx := context.Background()
 

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -25,6 +25,7 @@ type Item struct {
 }
 
 func TestNewJSONSchemaValidator(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -110,6 +111,7 @@ func TestNewJSONSchemaValidator(t *testing.T) {
 }
 
 func TestJSONSchemaValidator_Validate(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -211,6 +213,7 @@ func TestJSONSchemaValidator_Validate(t *testing.T) {
 }
 
 func TestJSONSchemaValidator_ComplexSchema(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -279,6 +282,7 @@ func TestJSONSchemaValidator_ComplexSchema(t *testing.T) {
 }
 
 func TestValidateMiddleware(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -362,6 +366,7 @@ func TestValidateMiddleware(t *testing.T) {
 }
 
 func TestCompositeValidator(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -426,6 +431,7 @@ func TestCompositeValidator(t *testing.T) {
 }
 
 func TestFuncValidator(t *testing.T) {
+	t.Parallel()
 	t.Run("function is called", func(t *testing.T) {
 		called := false
 		v := FuncValidator(func(payload any) error {
@@ -453,6 +459,7 @@ func TestFuncValidator(t *testing.T) {
 }
 
 func TestValidationError(t *testing.T) {
+	t.Parallel()
 	t.Run("error string with path", func(t *testing.T) {
 		err := &ValidationError{
 			Message: "invalid value",
@@ -487,6 +494,7 @@ func TestValidationError(t *testing.T) {
 }
 
 func TestJSONSchemaValidator_BytesReader(t *testing.T) {
+	t.Parallel()
 	schema := `{"type": "object", "properties": {"name": {"type": "string"}}}`
 
 	// Test with bytes.Buffer
@@ -503,6 +511,7 @@ func TestJSONSchemaValidator_BytesReader(t *testing.T) {
 }
 
 func TestJSONSchemaValidator_EnumValidation(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -535,6 +544,7 @@ func TestJSONSchemaValidator_EnumValidation(t *testing.T) {
 }
 
 func TestJSONSchemaValidator_PatternValidation(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {
@@ -567,6 +577,7 @@ func TestJSONSchemaValidator_PatternValidation(t *testing.T) {
 }
 
 func TestJSONSchemaValidator_NestedObjects(t *testing.T) {
+	t.Parallel()
 	schema := `{
 		"type": "object",
 		"properties": {


### PR DESCRIPTION
## Summary
Continuation of #158. Mass-enable \`t.Parallel()\` on every top-level Test function in five more leaf packages.

| Package                 | Tests parallelized |
|-------------------------|--------------------|
| \`backoff\`               | 11                 |
| \`validation\`            | 11                 |
| \`health\`                | 12                 |
| \`internal/msgpacklimit\` | 10                 |
| \`transport/noop\`        | 9                  |
| **Total**               | **53**             |

Same selection criteria as #158: each package's non-test source has no mutable globals, tests construct state per-test, and no test uses \`t.Setenv\`.

## Test plan
- [x] \`go test -race -count=10\` passes across all 5 packages
- [x] \`golangci-lint run\` clean