### PR TITLE
test: enable t.Parallel() across outbox, persistent, channel, distributed (126 tests)

### DIFF
--- a/distributed/distributed_test.go
+++ b/distributed/distributed_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestMemoryStateManager_Acquire(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := NewMemoryStateManager()
 	defer sm.Close()
@@ -44,6 +45,7 @@ func TestMemoryStateManager_Acquire(t *testing.T) {
 }
 
 func TestMemoryStateManager_MarkProcessed(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := NewMemoryStateManager()
 	defer sm.Close()
@@ -67,6 +69,7 @@ func TestMemoryStateManager_MarkProcessed(t *testing.T) {
 }
 
 func TestMemoryStateManager_Reset(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := NewMemoryStateManager()
 	defer sm.Close()
@@ -90,6 +93,7 @@ func TestMemoryStateManager_Reset(t *testing.T) {
 }
 
 func TestMemoryStateManager_Expiry(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -111,6 +115,7 @@ func TestMemoryStateManager_Expiry(t *testing.T) {
 }
 
 func TestStateOptions(t *testing.T) {
+	t.Parallel()
 	opts := defaultStateOptions()
 
 	// Test defaults
@@ -151,6 +156,7 @@ func TestStateOptions(t *testing.T) {
 }
 
 func TestMemoryStateManager_ListStale(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := NewMemoryStateManager(
 		WithCleanup(false, 0), // Disable cleanup for this test
@@ -196,6 +202,7 @@ func TestMemoryStateManager_ListStale(t *testing.T) {
 }
 
 func TestMemoryStateManager_ResetStale(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := NewMemoryStateManager(
 		WithCleanup(false, 0),
@@ -230,6 +237,7 @@ func TestMemoryStateManager_ResetStale(t *testing.T) {
 }
 
 func TestRecoveryRunner_RecoverOnce(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -274,6 +282,7 @@ func TestRecoveryRunner_RecoverOnce(t *testing.T) {
 }
 
 func TestRecoveryRunner_Run(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -349,6 +358,7 @@ func (s *countingSender) Send(_ context.Context, eventName, _ string, payload []
 // called after MarkProcessed succeeds. If MarkProcessed fails, payload must be
 // retained so the next recovery cycle can retry the re-publish.
 func TestRecovery_ClearPayloadAfterMarkProcessed(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	inner, clk := newSMWithFakeClock()

--- a/distributed/memory_worker_store_test.go
+++ b/distributed/memory_worker_store_test.go
@@ -29,6 +29,7 @@ func newTestMemoryWorkerStoreWithClock(t *testing.T) (*MemoryStateManager, *cloc
 }
 
 func TestMemoryListWorkers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 
@@ -46,6 +47,7 @@ func TestMemoryListWorkers(t *testing.T) {
 }
 
 func TestMemoryListWorkersFilterStatus(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 
@@ -85,6 +87,7 @@ func TestMemoryListWorkersFilterStatus(t *testing.T) {
 }
 
 func TestMemoryListWorkersStaleTimeout(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
@@ -107,6 +110,7 @@ func TestMemoryListWorkersStaleTimeout(t *testing.T) {
 }
 
 func TestMemoryListWorkersCreatedRange(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
@@ -142,6 +146,7 @@ func TestMemoryListWorkersCreatedRange(t *testing.T) {
 }
 
 func TestMemoryListWorkersOrderDesc(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
@@ -168,6 +173,7 @@ func TestMemoryListWorkersOrderDesc(t *testing.T) {
 }
 
 func TestMemoryListWorkersPagination(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newTestMemoryWorkerStoreWithClock(t)
 
@@ -234,6 +240,7 @@ func TestMemoryListWorkersPagination(t *testing.T) {
 }
 
 func TestMemoryListWorkersCursorPastEnd(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 
@@ -267,6 +274,7 @@ func TestMemoryListWorkersCursorPastEnd(t *testing.T) {
 }
 
 func TestMemoryListWorkersInvalidCursor(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 
@@ -277,6 +285,7 @@ func TestMemoryListWorkersInvalidCursor(t *testing.T) {
 }
 
 func TestMemoryCountWorkers(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 
@@ -321,6 +330,7 @@ func TestMemoryCountWorkers(t *testing.T) {
 }
 
 func TestMemoryGetWorker(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 
@@ -342,6 +352,7 @@ func TestMemoryGetWorker(t *testing.T) {
 }
 
 func TestMemoryGetWorkerNotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm := newTestMemoryWorkerStore(t)
 

--- a/distributed/middleware_test.go
+++ b/distributed/middleware_test.go
@@ -79,6 +79,7 @@ func mustMW[T any](mw event.Middleware[T], err error) event.Middleware[T] {
 }
 
 func TestMiddleware_NoEventID_PassesThrough(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordinator{acquireResult: true}
 	handler := &testHandler[string]{}
 
@@ -100,6 +101,7 @@ func TestMiddleware_NoEventID_PassesThrough(t *testing.T) {
 }
 
 func TestMiddleware_AcquireFails_FailOpen(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordinator{acquireErr: errors.New("redis down")}
 	handler := &testHandler[string]{}
 
@@ -117,6 +119,7 @@ func TestMiddleware_AcquireFails_FailOpen(t *testing.T) {
 }
 
 func TestMiddleware_NotAcquired_Skips(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordinator{acquireResult: false}
 	handler := &testHandler[string]{}
 
@@ -134,6 +137,7 @@ func TestMiddleware_NotAcquired_Skips(t *testing.T) {
 }
 
 func TestMiddleware_Acquired_CallsHandlerAndMarksProcessed(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordinator{acquireResult: true}
 	handler := &testHandler[string]{}
 
@@ -157,6 +161,7 @@ func TestMiddleware_Acquired_CallsHandlerAndMarksProcessed(t *testing.T) {
 }
 
 func TestMiddleware_HandlerError_ResetsState(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordinator{acquireResult: true}
 	handlerErr := errors.New("processing failed")
 	handler := &testHandler[string]{err: handlerErr}
@@ -178,6 +183,7 @@ func TestMiddleware_HandlerError_ResetsState(t *testing.T) {
 }
 
 func TestMiddleware_NoPayloadInContext_NoStore(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordWithPayload{
 		mockCoordinator: mockCoordinator{acquireResult: true},
 	}
@@ -206,6 +212,7 @@ func TestMiddleware_NoPayloadInContext_NoStore(t *testing.T) {
 }
 
 func TestMiddleware_PayloadStored_ClearedOnSuccess(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordWithPayload{
 		mockCoordinator: mockCoordinator{acquireResult: true},
 	}
@@ -238,6 +245,7 @@ func TestMiddleware_PayloadStored_ClearedOnSuccess(t *testing.T) {
 }
 
 func TestMiddleware_PayloadStored_NotClearedOnHandlerError(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordWithPayload{
 		mockCoordinator: mockCoordinator{acquireResult: true},
 	}
@@ -270,6 +278,7 @@ func TestMiddleware_PayloadStored_NotClearedOnHandlerError(t *testing.T) {
 }
 
 func TestMiddleware_StorePayloadFails_NoClearOnSuccess(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordWithPayload{
 		mockCoordinator: mockCoordinator{acquireResult: true},
 		storeErr:        errors.New("store failed"),
@@ -297,6 +306,7 @@ func TestMiddleware_StorePayloadFails_NoClearOnSuccess(t *testing.T) {
 }
 
 func TestMiddleware_MaxPayloadSize(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordWithPayload{
 		mockCoordinator: mockCoordinator{acquireResult: true},
 	}
@@ -328,6 +338,7 @@ func TestMiddleware_MaxPayloadSize(t *testing.T) {
 }
 
 func TestWorkerPoolMiddleware_NilCoord_ReturnsError(t *testing.T) {
+	t.Parallel()
 	_, err := WorkerPoolMiddleware[string](nil, time.Minute)
 	if err == nil {
 		t.Fatal("expected error for nil coordinator")
@@ -335,6 +346,7 @@ func TestWorkerPoolMiddleware_NilCoord_ReturnsError(t *testing.T) {
 }
 
 func TestWorkerPoolMiddleware_WithBusNil_ReturnsError(t *testing.T) {
+	t.Parallel()
 	coord := &mockCoordinator{acquireResult: true}
 	_, err := WorkerPoolMiddleware[string](coord, time.Minute, WithBus(nil))
 	if err == nil {
@@ -343,6 +355,7 @@ func TestWorkerPoolMiddleware_WithBusNil_ReturnsError(t *testing.T) {
 }
 
 func TestMiddleware_CoordWithoutPayloadStore(t *testing.T) {
+	t.Parallel()
 	// Plain coordinator without PayloadStore
 	coord := &mockCoordinator{acquireResult: true}
 	handler := &testHandler[string]{}

--- a/distributed/payload_test.go
+++ b/distributed/payload_test.go
@@ -24,6 +24,7 @@ func newSMWithFakeClock(opts ...Option) (*MemoryStateManager, *clock.Fake) {
 }
 
 func TestMemoryCoordinator_AcquireAndStorePayload(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, _ := newSMWithFakeClock()
 	defer sm.Close()
@@ -67,6 +68,7 @@ func TestMemoryCoordinator_AcquireAndStorePayload(t *testing.T) {
 }
 
 func TestMemoryCoordinator_Acquire_Expiry(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -88,6 +90,7 @@ func TestMemoryCoordinator_Acquire_Expiry(t *testing.T) {
 }
 
 func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -156,6 +159,7 @@ func TestMemoryPayloadStore_LoadStalePayloads(t *testing.T) {
 }
 
 func TestMemoryPayloadStore_ClearPayload(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, _ := newSMWithFakeClock()
 	defer sm.Close()
@@ -189,6 +193,7 @@ func TestMemoryPayloadStore_ClearPayload(t *testing.T) {
 }
 
 func TestStaleMessage_HasPayload(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		msg      StaleMessage
@@ -221,6 +226,7 @@ func TestStaleMessage_HasPayload(t *testing.T) {
 }
 
 func TestCompileTimeChecks(t *testing.T) {
+	t.Parallel()
 	// Verify interface implementations
 	var _ Coordinator = (*MemoryStateManager)(nil)
 	var _ PayloadStore = (*MemoryStateManager)(nil)
@@ -249,6 +255,7 @@ func (m *mockPublisher) Send(_ context.Context, eventName, eventID string, paylo
 }
 
 func TestRecoveryRunner_BasicReset(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -286,6 +293,7 @@ func TestRecoveryRunner_BasicReset(t *testing.T) {
 }
 
 func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -340,6 +348,7 @@ func TestRecoveryRunner_Phase1And2Exclusion(t *testing.T) {
 }
 
 func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -369,6 +378,7 @@ func TestRecoveryRunner_BatchLimitZero(t *testing.T) {
 }
 
 func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -436,6 +446,7 @@ func TestRecoveryRunner_PayloadRepublish(t *testing.T) {
 }
 
 func TestRecoveryRunner_PublishFailure_SkipsEntry(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
@@ -481,6 +492,7 @@ func (p *failingPublisher) Send(_ context.Context, _, _ string, _ []byte, _ map[
 }
 
 func TestRecoveryRunner_WithRealBus(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Create a real bus with channel transport
@@ -537,6 +549,7 @@ func TestRecoveryRunner_WithRealBus(t *testing.T) {
 }
 
 func TestBus_SupportsRedelivery(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	ch := channel.New()
@@ -552,6 +565,7 @@ func TestBus_SupportsRedelivery(t *testing.T) {
 }
 
 func TestPoolOption_WithPayloadRecovery(t *testing.T) {
+	t.Parallel()
 	o := &poolOptions{}
 
 	if o.storePayload != nil {
@@ -565,6 +579,7 @@ func TestPoolOption_WithPayloadRecovery(t *testing.T) {
 }
 
 func TestPoolOption_WithMaxPayloadSize(t *testing.T) {
+	t.Parallel()
 	o := &poolOptions{}
 
 	if o.maxPayloadSize != 0 {
@@ -587,6 +602,7 @@ func TestPoolOption_WithMaxPayloadSize(t *testing.T) {
 }
 
 func TestRecoveryMetrics_NilSafe(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	var m *RecoveryMetrics
 	m.recordRecovered(ctx)
@@ -600,6 +616,7 @@ func TestRecoveryMetrics_NilSafe(t *testing.T) {
 }
 
 func TestRecoveryMetrics_BatchNilSafe(t *testing.T) {
+	t.Parallel()
 	var m *RecoveryMetrics
 	ctx := context.Background()
 	// Batch methods with n <= 0 should be no-ops
@@ -610,6 +627,7 @@ func TestRecoveryMetrics_BatchNilSafe(t *testing.T) {
 }
 
 func TestNewRecoveryRunner_NilCoordinator_ReturnsError(t *testing.T) {
+	t.Parallel()
 	_, err := NewRecoveryRunner(nil)
 	if err == nil {
 		t.Fatal("expected error for nil coordinator")
@@ -617,6 +635,7 @@ func TestNewRecoveryRunner_NilCoordinator_ReturnsError(t *testing.T) {
 }
 
 func TestRecoveryMetrics_Creation(t *testing.T) {
+	t.Parallel()
 	m, err := NewRecoveryMetrics()
 	if err != nil {
 		t.Fatalf("unexpected error creating metrics: %v", err)
@@ -635,6 +654,7 @@ func TestRecoveryMetrics_Creation(t *testing.T) {
 }
 
 func TestRecoveryMetrics_WithNamespace(t *testing.T) {
+	t.Parallel()
 	m, err := NewRecoveryMetrics(WithRecoveryMetricsNamespace("myapp"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -645,6 +665,7 @@ func TestRecoveryMetrics_WithNamespace(t *testing.T) {
 }
 
 func TestRecoveryOption_WithRecoveryLogger(t *testing.T) {
+	t.Parallel()
 	o := &recoveryOptions{}
 	WithRecoveryLogger(nil)(o)
 	if o.logger != nil {
@@ -653,6 +674,7 @@ func TestRecoveryOption_WithRecoveryLogger(t *testing.T) {
 }
 
 func TestRecoveryOption_WithBackoff(t *testing.T) {
+	t.Parallel()
 	o := &recoveryOptions{}
 	WithBackoff(nil)(o)
 	if o.backoff != nil {
@@ -661,6 +683,7 @@ func TestRecoveryOption_WithBackoff(t *testing.T) {
 }
 
 func TestRecoveryRunner_RecoverOnce_NoStaleEntries(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, _ := newSMWithFakeClock()
 	defer sm.Close()
@@ -683,6 +706,7 @@ func TestRecoveryRunner_RecoverOnce_NoStaleEntries(t *testing.T) {
 }
 
 func TestMemoryStateManager_CleanupExpired(t *testing.T) {
+	t.Parallel()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()
 
@@ -703,6 +727,7 @@ func TestMemoryStateManager_CleanupExpired(t *testing.T) {
 }
 
 func TestRecoveryRunner_WithMetrics(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sm, clk := newSMWithFakeClock()
 	defer sm.Close()

--- a/distributed/redis_test.go
+++ b/distributed/redis_test.go
@@ -48,6 +48,7 @@ func setupRedisStateManagerWithClock(t *testing.T, opts ...Option) (*RedisStateM
 }
 
 func TestRedisStateManager_Acquire(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -83,6 +84,7 @@ func TestRedisStateManager_Acquire(t *testing.T) {
 }
 
 func TestRedisStateManager_Acquire_Expiry(t *testing.T) {
+	t.Parallel()
 	sm, mr := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -102,6 +104,7 @@ func TestRedisStateManager_Acquire_Expiry(t *testing.T) {
 }
 
 func TestRedisStateManager_MarkProcessed(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -124,6 +127,7 @@ func TestRedisStateManager_MarkProcessed(t *testing.T) {
 }
 
 func TestRedisStateManager_MarkProcessed_AtomicNoRecreate(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -144,6 +148,7 @@ func TestRedisStateManager_MarkProcessed_AtomicNoRecreate(t *testing.T) {
 }
 
 func TestRedisStateManager_Reset(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -166,6 +171,7 @@ func TestRedisStateManager_Reset(t *testing.T) {
 }
 
 func TestRedisStateManager_ListStale(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
@@ -202,6 +208,7 @@ func TestRedisStateManager_ListStale(t *testing.T) {
 }
 
 func TestRedisStateManager_ResetStale(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
@@ -226,6 +233,7 @@ func TestRedisStateManager_ResetStale(t *testing.T) {
 }
 
 func TestRedisStateManager_ResetStale_Limit(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
@@ -246,6 +254,7 @@ func TestRedisStateManager_ResetStale_Limit(t *testing.T) {
 }
 
 func TestRedisStateManager_StorePayload(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -263,6 +272,7 @@ func TestRedisStateManager_StorePayload(t *testing.T) {
 }
 
 func TestRedisStateManager_StorePayload_SkipsWhenNoState(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -283,6 +293,7 @@ func TestRedisStateManager_StorePayload_SkipsWhenNoState(t *testing.T) {
 }
 
 func TestRedisStateManager_StorePayload_NilOrEmpty(t *testing.T) {
+	t.Parallel()
 	sm, _ := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -300,6 +311,7 @@ func TestRedisStateManager_StorePayload_NilOrEmpty(t *testing.T) {
 }
 
 func TestRedisStateManager_LoadStalePayloads(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
@@ -335,6 +347,7 @@ func TestRedisStateManager_LoadStalePayloads(t *testing.T) {
 }
 
 func TestRedisStateManager_ClearPayload(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
@@ -362,6 +375,7 @@ func TestRedisStateManager_ClearPayload(t *testing.T) {
 }
 
 func TestRedisStateManager_Prefix(t *testing.T) {
+	t.Parallel()
 	sm1, _ := setupRedisStateManager(t, WithPrefix("app1:"))
 	sm2, _ := setupRedisStateManager(t, WithPrefix("app2:"))
 	ctx := context.Background()
@@ -379,6 +393,7 @@ func TestRedisStateManager_Prefix(t *testing.T) {
 }
 
 func TestRedisStateManager_RecoveryRunner(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 
@@ -420,6 +435,7 @@ func TestRedisStateManager_RecoveryRunner(t *testing.T) {
 }
 
 func TestRedisStatusConstants(t *testing.T) {
+	t.Parallel()
 	// Verify Redis status constants match expected values
 	if redisStatusProcessing != "processing" {
 		t.Errorf("redisStatusProcessing = %q, want %q", redisStatusProcessing, "processing")
@@ -430,6 +446,7 @@ func TestRedisStatusConstants(t *testing.T) {
 }
 
 func TestRedisStateManager_StorePayload_AtomicTTL(t *testing.T) {
+	t.Parallel()
 	sm, mr := setupRedisStateManager(t)
 	ctx := context.Background()
 
@@ -474,6 +491,7 @@ func TestRedisStateManager_StorePayload_AtomicTTL(t *testing.T) {
 }
 
 func TestRedisStateManager_PayloadRecovery(t *testing.T) {
+	t.Parallel()
 	sm, _, clk := setupRedisStateManagerWithClock(t)
 	ctx := context.Background()
 

--- a/outbox/outbox_test.go
+++ b/outbox/outbox_test.go
@@ -152,6 +152,7 @@ func (s *mockStore) publishedCount() int {
 // Tests
 
 func TestStatusConstants(t *testing.T) {
+	t.Parallel()
 	if StatusPending != "pending" {
 		t.Errorf("expected pending, got %s", StatusPending)
 	}
@@ -167,6 +168,7 @@ func TestStatusConstants(t *testing.T) {
 }
 
 func TestNewRelay(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	tr := channel.New()
 	relay := NewRelay(store, tr)
@@ -189,6 +191,7 @@ func TestNewRelay(t *testing.T) {
 }
 
 func TestRelayOptions(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	tr := channel.New()
 
@@ -210,6 +213,7 @@ func TestRelayOptions(t *testing.T) {
 }
 
 func TestRelayPublishOnce(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := newMockStore()
 	tr := channel.New()
@@ -266,6 +270,7 @@ func TestRelayPublishOnce(t *testing.T) {
 }
 
 func TestRelayPublishFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := newMockStore()
 	tr := channel.New()
@@ -300,6 +305,7 @@ func TestRelayPublishFailure(t *testing.T) {
 }
 
 func TestRelayStartStop(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	tr := channel.New()
 
@@ -328,6 +334,7 @@ func TestRelayStartStop(t *testing.T) {
 }
 
 func TestRelayMultipleMessages(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := newMockStore()
 	tr := channel.New()
@@ -371,6 +378,7 @@ func TestRelayMultipleMessages(t *testing.T) {
 }
 
 func TestMockStoreGetPendingError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := newMockStore()
 	store.getPendingErr = errors.New("db connection failed")
@@ -408,6 +416,7 @@ func (s *mockProcessPendingStore) ProcessPending(ctx context.Context, limit int,
 }
 
 func TestRelayProcessPendingPreferred(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	inner := newMockStore()
 	store := &mockProcessPendingStore{mockStore: inner}
@@ -437,6 +446,7 @@ func TestRelayProcessPendingPreferred(t *testing.T) {
 }
 
 func TestRelayCleanup(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	store.deleted = 5 // simulate 5 deleted
 	tr := channel.New()
@@ -449,6 +459,7 @@ func TestRelayCleanup(t *testing.T) {
 }
 
 func TestRelayMarkFailedOnPublishError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := newMockStore()
 	tr := channel.New()
@@ -473,6 +484,7 @@ func TestRelayMarkFailedOnPublishError(t *testing.T) {
 }
 
 func TestRelayEmptyStore(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := newMockStore()
 	tr := channel.New()
@@ -487,6 +499,7 @@ func TestRelayEmptyStore(t *testing.T) {
 }
 
 func TestRelayDeleteError(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	store.deleteErr = errors.New("delete failed")
 	tr := channel.New()
@@ -497,6 +510,7 @@ func TestRelayDeleteError(t *testing.T) {
 }
 
 func TestMessageStruct(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	msg := Message{
 		ID:         1,
@@ -524,6 +538,7 @@ func TestMessageStruct(t *testing.T) {
 }
 
 func TestRelayMaxRetries(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	tr := channel.New(channel.WithBufferSize(100))
 	relay := NewRelay(store, tr,
@@ -561,6 +576,7 @@ func TestRelayMaxRetries(t *testing.T) {
 }
 
 func TestRelayAdaptiveBackpressure(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	tr := channel.New(channel.WithBufferSize(100))
 
@@ -595,6 +611,7 @@ func (b *testBackoff) NextDelay(attempt int) time.Duration {
 }
 
 func TestRelayPriority(t *testing.T) {
+	t.Parallel()
 	store := newMockStore()
 	ctx := context.Background()
 
@@ -639,6 +656,7 @@ func TestRelayPriority(t *testing.T) {
 }
 
 func TestPostgresTransaction_PiggyBack(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Simulate already being inside a Postgres transaction.
@@ -663,6 +681,7 @@ func TestPostgresTransaction_PiggyBack(t *testing.T) {
 }
 
 func TestPostgresTransaction_PiggyBack_PropagatesError(t *testing.T) {
+	t.Parallel()
 	ctx := event.WithOutboxTx(context.Background(), &sql.Tx{})
 
 	testErr := errors.New("business logic failed")
@@ -675,6 +694,7 @@ func TestPostgresTransaction_PiggyBack_PropagatesError(t *testing.T) {
 }
 
 func TestPostgresTransaction_NoPiggyBackOnMongoSession(t *testing.T) {
+	t.Parallel()
 	// Set a non-*sql.Tx session (simulating a Mongo context.Context session).
 	// PostgresTransaction should NOT piggy-back — it should try to start a new tx.
 	ctx := event.WithOutboxTx(context.Background(), context.Background())
@@ -698,6 +718,7 @@ func TestPostgresTransaction_NoPiggyBackOnMongoSession(t *testing.T) {
 }
 
 func TestPostgresStoreImplementsOutboxStore(t *testing.T) {
+	t.Parallel()
 	var s interface{} = &PostgresStore{}
 	if _, ok := s.(event.OutboxStore); !ok {
 		t.Fatal("PostgresStore should implement event.OutboxStore")
@@ -705,6 +726,7 @@ func TestPostgresStoreImplementsOutboxStore(t *testing.T) {
 }
 
 func TestPostgresStore_Store_WrongSessionType(t *testing.T) {
+	t.Parallel()
 	store := &PostgresStore{tableName: "event_outbox"}
 	// Put a non-*sql.Tx session in context.
 	ctx := event.WithOutboxTx(context.Background(), "not-a-sql-tx")

--- a/transport/channel/channel_test.go
+++ b/transport/channel/channel_test.go
@@ -17,6 +17,7 @@ func testMessage(id, source, payload string) transport.Message {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	tr := New()
 	if tr == nil {
 		t.Fatal("expected transport, got nil")
@@ -25,6 +26,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewWithOptions(t *testing.T) {
+	t.Parallel()
 	tr := New(
 		WithBufferSize(100),
 		WithTimeout(time.Second),
@@ -40,6 +42,7 @@ func TestNewWithOptions(t *testing.T) {
 }
 
 func TestRegisterEvent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 	defer tr.Close(ctx)
@@ -70,6 +73,7 @@ func TestRegisterEvent(t *testing.T) {
 }
 
 func TestUnregisterEvent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 	defer tr.Close(ctx)
@@ -92,6 +96,7 @@ func TestUnregisterEvent(t *testing.T) {
 }
 
 func TestPublish(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 	defer tr.Close(ctx)
@@ -128,6 +133,7 @@ func TestPublish(t *testing.T) {
 }
 
 func TestSubscribe(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 	defer tr.Close(ctx)
@@ -161,6 +167,7 @@ func TestSubscribe(t *testing.T) {
 }
 
 func TestPublishSubscribeIntegration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
 	defer tr.Close(ctx)
@@ -189,6 +196,7 @@ func TestPublishSubscribeIntegration(t *testing.T) {
 }
 
 func TestBroadcastMode(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
 	defer tr.Close(ctx)
@@ -229,6 +237,7 @@ func TestBroadcastMode(t *testing.T) {
 }
 
 func TestWorkerPoolMode(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
 	defer tr.Close(ctx)
@@ -297,6 +306,7 @@ func TestWorkerPoolMode(t *testing.T) {
 }
 
 func TestWorkerGroups(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
 	defer tr.Close(ctx)
@@ -375,6 +385,7 @@ func TestWorkerGroups(t *testing.T) {
 }
 
 func TestWorkerGroupSingleWorker(t *testing.T) {
+	t.Parallel()
 	// Test a worker group with only one worker
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
@@ -417,6 +428,7 @@ done:
 }
 
 func TestWorkerGroupMixedWithDefaultPool(t *testing.T) {
+	t.Parallel()
 	// Test mixing named worker groups with default (unnamed) worker pool
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
@@ -486,6 +498,7 @@ func TestWorkerGroupMixedWithDefaultPool(t *testing.T) {
 }
 
 func TestWorkerGroupEmptyStringIsSameAsDefault(t *testing.T) {
+	t.Parallel()
 	// Empty string worker group should be treated the same as no group (default)
 	ctx := context.Background()
 	tr := New(WithBufferSize(10))
@@ -544,6 +557,7 @@ func TestWorkerGroupEmptyStringIsSameAsDefault(t *testing.T) {
 }
 
 func TestSubscriptionClose(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 	defer tr.Close(ctx)
@@ -566,6 +580,7 @@ func TestSubscriptionClose(t *testing.T) {
 }
 
 func TestTransportClose(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 
@@ -592,6 +607,7 @@ func TestTransportClose(t *testing.T) {
 }
 
 func TestHealth(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New()
 
@@ -612,6 +628,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestWithBufferSizeOption(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tr := New(WithBufferSize(50))
 	defer tr.Close(ctx)

--- a/transport/persistent/persistent_test.go
+++ b/transport/persistent/persistent_test.go
@@ -26,6 +26,7 @@ func testMessage(payload []byte) transport.Message {
 var errProcessingFailed = errors.New("processing failed")
 
 func TestNewTransport(t *testing.T) {
+	t.Parallel()
 	t.Run("requires store", func(t *testing.T) {
 		_, err := New(nil)
 		if err != ErrStoreRequired {
@@ -47,6 +48,7 @@ func TestNewTransport(t *testing.T) {
 }
 
 func TestRegisterEvent(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	tr, _ := New(store)
 	defer tr.Close(context.Background())
@@ -69,6 +71,7 @@ func TestRegisterEvent(t *testing.T) {
 }
 
 func TestPublishSubscribe(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	tr, _ := New(store, WithPollInterval(10*time.Millisecond))
 	defer tr.Close(context.Background())
@@ -111,6 +114,7 @@ func TestPublishSubscribe(t *testing.T) {
 }
 
 func TestMessageRedelivery(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	tr, _ := New(store, WithPollInterval(10*time.Millisecond))
 	defer tr.Close(context.Background())
@@ -166,6 +170,7 @@ func TestMessageRedelivery(t *testing.T) {
 }
 
 func TestCheckpointPersistence(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	checkpointStore := NewMemoryCheckpointStore()
 	tr, _ := New(store,
@@ -218,6 +223,7 @@ func TestCheckpointPersistence(t *testing.T) {
 }
 
 func TestSequentialProcessing(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	tr, _ := New(store, WithPollInterval(10*time.Millisecond))
 	defer tr.Close(context.Background())
@@ -264,6 +270,7 @@ func TestSequentialProcessing(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	tr, _ := New(store)
 	defer tr.Close(context.Background())
@@ -286,6 +293,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryStore()
 	tr, _ := New(store)
 
@@ -313,6 +321,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestMemoryStore(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("append and fetch", func(t *testing.T) {
@@ -423,6 +432,7 @@ func TestMemoryStore(t *testing.T) {
 }
 
 func TestMemoryCheckpointStore(t *testing.T) {
+	t.Parallel()
 	store := NewMemoryCheckpointStore()
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
Third batch of the \`t.Parallel()\` rollout (continuing #158 and #159).

| File / Package                            | Tests |
|-------------------------------------------|-------|
| \`outbox/outbox_test.go\`                   | 22    |
| \`transport/persistent/persistent_test.go\` | 10    |
| \`transport/channel/channel_test.go\`       | 17    |
| \`distributed/distributed_test.go\`         | 10    |
| \`distributed/payload_test.go\`             | 25    |
| \`distributed/middleware_test.go\`          | 13    |
| \`distributed/redis_test.go\`               | 18    |
| \`distributed/memory_worker_store_test.go\` | 11    |
| **Total**                                 | **126** |

Same selection criteria as #158/#159: no package-level mutable globals, no \`t.Setenv\`, every test builds its own state. The five distributed test files share the \`distributed\` package and parallelize as one set — each test constructs its own \`MemoryStateManager\` or miniredis-backed \`RedisStore\`.

## Test plan
- [x] \`go test -race -count=10\` passes for outbox, persistent, channel, distributed
- [x] \`golangci-lint run\` clean