### PR TITLE
test: enable t.Parallel() across transport/redis, transport/bridge, monitor (89 tests)

### DIFF
--- a/monitor/grpc/grpc_test.go
+++ b/monitor/grpc/grpc_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestServiceNew(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -23,6 +24,7 @@ func TestServiceNew(t *testing.T) {
 }
 
 func TestServiceNewWithPollInterval(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -36,6 +38,7 @@ func TestServiceNewWithPollInterval(t *testing.T) {
 }
 
 func TestServiceList(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -98,6 +101,7 @@ func TestServiceList(t *testing.T) {
 }
 
 func TestServiceGet(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -158,6 +162,7 @@ func TestServiceGet(t *testing.T) {
 }
 
 func TestServiceGetByEventID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -203,6 +208,7 @@ func TestServiceGetByEventID(t *testing.T) {
 }
 
 func TestServiceCount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -253,6 +259,7 @@ func TestServiceCount(t *testing.T) {
 }
 
 func TestServiceDeleteOlderThan(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -307,6 +314,7 @@ func TestServiceDeleteOlderThan(t *testing.T) {
 }
 
 func TestServiceStreamRequiresBroadcaster(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 

--- a/monitor/http/coverage_test.go
+++ b/monitor/http/coverage_test.go
@@ -57,6 +57,7 @@ func setupCoverageBus(t *testing.T, busName, evName string) (event.EventInfo, fu
 }
 
 func TestHandleCoverage_BroadcastMatch(t *testing.T) {
+	t.Parallel()
 	busName := "cov-broadcast-" + t.Name()
 	evName := "coverage.broadcast"
 	ctx := context.Background()
@@ -121,6 +122,7 @@ func TestHandleCoverage_BroadcastMatch(t *testing.T) {
 }
 
 func TestHandleCoverage_WorkerPoolGroupMatch(t *testing.T) {
+	t.Parallel()
 	busName := "cov-wp-" + t.Name()
 	evName := "coverage.workergroup"
 	ctx := context.Background()
@@ -168,6 +170,7 @@ func TestHandleCoverage_WorkerPoolGroupMatch(t *testing.T) {
 }
 
 func TestHandleCoverage_MissingCount(t *testing.T) {
+	t.Parallel()
 	busName := "cov-missing-" + t.Name()
 	evName := "coverage.missing"
 	ctx := context.Background()
@@ -209,6 +212,7 @@ func TestHandleCoverage_MissingCount(t *testing.T) {
 }
 
 func TestHandleCoverage_EmptyEventID(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -223,6 +227,7 @@ func TestHandleCoverage_EmptyEventID(t *testing.T) {
 }
 
 func TestHandleCoverage_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 

--- a/monitor/http/http_test.go
+++ b/monitor/http/http_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestHandlerNew(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -23,6 +24,7 @@ func TestHandlerNew(t *testing.T) {
 }
 
 func TestHandlerList(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -115,6 +117,7 @@ func TestHandlerList(t *testing.T) {
 }
 
 func TestHandlerGetEntry(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -167,6 +170,7 @@ func TestHandlerGetEntry(t *testing.T) {
 }
 
 func TestHandlerGetByEventID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -219,6 +223,7 @@ func TestHandlerGetByEventID(t *testing.T) {
 }
 
 func TestHandlerCount(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -294,6 +299,7 @@ func TestHandlerCount(t *testing.T) {
 }
 
 func TestHandlerDelete(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	t.Run("DELETE with default 24h", func(t *testing.T) {
@@ -400,6 +406,7 @@ func TestHandlerDelete(t *testing.T) {
 }
 
 func TestHandlerQueryParams(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -492,6 +499,7 @@ func TestHandlerQueryParams(t *testing.T) {
 }
 
 func TestHandlerContentType(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 

--- a/monitor/http/summary_test.go
+++ b/monitor/http/summary_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestHandlerSummary(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()

--- a/monitor/http/system_test.go
+++ b/monitor/http/system_test.go
@@ -40,6 +40,7 @@ func (m *mockDLQProvider) Health(ctx context.Context) *health.Result {
 }
 
 func TestHandleSystemView(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -140,6 +141,7 @@ func TestHandleSystemView(t *testing.T) {
 }
 
 func TestHandleSystemHealth(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -200,6 +202,7 @@ func TestHandleSystemHealth(t *testing.T) {
 }
 
 func TestBackgroundRefresh(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
@@ -247,6 +250,7 @@ func TestBackgroundRefresh(t *testing.T) {
 }
 
 func TestBackgroundRefresh_Health(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -274,6 +278,7 @@ func TestBackgroundRefresh_Health(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -297,6 +302,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestDisabledRefresh(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -328,6 +334,7 @@ func TestDisabledRefresh(t *testing.T) {
 }
 
 func TestCachedTopology(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -357,6 +364,7 @@ func (m *mockStuckPendingProvider) StuckPendingStats(_ context.Context) (*StuckP
 }
 
 func TestHandleSystemView_StuckPending(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 

--- a/monitor/http/workers_test.go
+++ b/monitor/http/workers_test.go
@@ -25,6 +25,7 @@ func newWorkerTestHandler(t *testing.T) (*Handler, *distributed.MemoryStateManag
 }
 
 func TestWorkerEndpointsDisabledWithoutStore(t *testing.T) {
+	t.Parallel()
 	store := monitor.NewMemoryStore()
 	defer store.Close()
 
@@ -41,6 +42,7 @@ func TestWorkerEndpointsDisabledWithoutStore(t *testing.T) {
 }
 
 func TestWorkerList(t *testing.T) {
+	t.Parallel()
 	h, sm := newWorkerTestHandler(t)
 	ctx := context.Background()
 
@@ -82,6 +84,7 @@ func TestWorkerList(t *testing.T) {
 }
 
 func TestWorkerListFilterByStatus(t *testing.T) {
+	t.Parallel()
 	h, sm := newWorkerTestHandler(t)
 	ctx := context.Background()
 
@@ -110,6 +113,7 @@ func TestWorkerListFilterByStatus(t *testing.T) {
 }
 
 func TestWorkerListStaleTimeout(t *testing.T) {
+	t.Parallel()
 	h, sm := newWorkerTestHandler(t)
 	ctx := context.Background()
 
@@ -137,6 +141,7 @@ func TestWorkerListStaleTimeout(t *testing.T) {
 }
 
 func TestWorkerGetByID(t *testing.T) {
+	t.Parallel()
 	h, sm := newWorkerTestHandler(t)
 	ctx := context.Background()
 
@@ -175,6 +180,7 @@ func TestWorkerGetByID(t *testing.T) {
 }
 
 func TestWorkerCount(t *testing.T) {
+	t.Parallel()
 	h, sm := newWorkerTestHandler(t)
 	ctx := context.Background()
 
@@ -231,6 +237,7 @@ func TestWorkerCount(t *testing.T) {
 }
 
 func TestWorkerPagination(t *testing.T) {
+	t.Parallel()
 	h, sm := newWorkerTestHandler(t)
 	ctx := context.Background()
 

--- a/transport/bridge/bridge_test.go
+++ b/transport/bridge/bridge_test.go
@@ -226,6 +226,7 @@ func (m *testMessage) Ack(err error) error {
 // -----------------------------------------------------------------------------
 
 func TestNew_errors(t *testing.T) {
+	t.Parallel()
 	sink := newFakeTransport()
 	src := newFakeTransport()
 
@@ -242,6 +243,7 @@ func TestNew_errors(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestPump_forwardsMessages(t *testing.T) {
+	t.Parallel()
 	src := newFakeTransport()
 	sink := newFakeTransport()
 	ctx := context.Background()
@@ -280,6 +282,7 @@ func TestPump_forwardsMessages(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestPublishDelegatesToSink(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -303,6 +306,7 @@ func TestPublishDelegatesToSink(t *testing.T) {
 }
 
 func TestSubscribeDelegatesToSink(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -335,6 +339,7 @@ func TestSubscribeDelegatesToSink(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDedupMiddleware_suppressesDuplicates(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -371,6 +376,7 @@ func TestDedupMiddleware_suppressesDuplicates(t *testing.T) {
 }
 
 func TestDedupMiddleware_differentIDsPassThrough(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -390,6 +396,7 @@ func TestDedupMiddleware_differentIDsPassThrough(t *testing.T) {
 }
 
 func TestDedup_failClosedOnCoordinatorError(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -421,6 +428,7 @@ func TestDedup_failClosedOnCoordinatorError(t *testing.T) {
 }
 
 func TestDedup_failOpenOnCoordinatorError(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -444,6 +452,7 @@ func TestDedup_failOpenOnCoordinatorError(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDistributedDedup_isolatesEventNames(t *testing.T) {
+	t.Parallel()
 	// Regression: when multiple events share the same source (fan-out pattern,
 	// e.g. MongoDB change stream delivering to Created/Updated/Deleted pumps
 	// on the same bus), all pumps receive the same message. Without scoping the
@@ -498,6 +507,7 @@ func TestDistributedDedup_isolatesEventNames(t *testing.T) {
 }
 
 func TestDistributedDedup_crossReplicaDedup_stillWorks(t *testing.T) {
+	t.Parallel()
 	// Two bridges sharing the same coordinator simulate two replicas watching
 	// the same source. For the same event name, only one replica should
 	// publish each message.
@@ -554,6 +564,7 @@ func TestDistributedDedup_crossReplicaDedup_stillWorks(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestDLQMiddleware_catchesSinkErrors(t *testing.T) {
+	t.Parallel()
 	src, sink, dlq := newFakeTransport(), newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -590,6 +601,7 @@ func TestDLQMiddleware_catchesSinkErrors(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestFilterMiddleware(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -614,6 +626,7 @@ func TestFilterMiddleware(t *testing.T) {
 }
 
 func TestTransformMiddleware(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -636,6 +649,7 @@ func TestTransformMiddleware(t *testing.T) {
 }
 
 func TestObserveMiddleware_hooksFire(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -674,6 +688,7 @@ func TestObserveMiddleware_hooksFire(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestPump_recoversFromPanic(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -706,6 +721,7 @@ func TestPump_recoversFromPanic(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestClose_stopsPumps(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -727,6 +743,7 @@ func TestClose_stopsPumps(t *testing.T) {
 }
 
 func TestUnregisterEvent(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -748,6 +765,7 @@ func TestUnregisterEvent(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestMemoryCoordinator_claimsAndExpires(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c := bridge.NewMemoryCoordinator()
 
@@ -777,6 +795,7 @@ func TestMemoryCoordinator_claimsAndExpires(t *testing.T) {
 }
 
 func TestNoopCoordinator_alwaysClaims(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	c := bridge.NoopCoordinator{}
 	for range 3 {
@@ -814,6 +833,7 @@ func (h *healthyFakeTransport) Health(_ context.Context) *transport.HealthCheckR
 }
 
 func TestHealth_BothHealthy(t *testing.T) {
+	t.Parallel()
 	src := newHealthFake(transport.HealthStatusHealthy, "ok")
 	sink := newHealthFake(transport.HealthStatusHealthy, "ok")
 	ctx := context.Background()
@@ -833,6 +853,7 @@ func TestHealth_BothHealthy(t *testing.T) {
 }
 
 func TestHealth_SourceUnhealthy(t *testing.T) {
+	t.Parallel()
 	src := newHealthFake(transport.HealthStatusUnhealthy, "source down")
 	sink := newHealthFake(transport.HealthStatusHealthy, "ok")
 	ctx := context.Background()
@@ -848,6 +869,7 @@ func TestHealth_SourceUnhealthy(t *testing.T) {
 }
 
 func TestHealth_SinkDegraded(t *testing.T) {
+	t.Parallel()
 	src := newHealthFake(transport.HealthStatusHealthy, "ok")
 	sink := newHealthFake(transport.HealthStatusDegraded, "slow")
 	ctx := context.Background()
@@ -862,6 +884,7 @@ func TestHealth_SinkDegraded(t *testing.T) {
 }
 
 func TestHealth_AfterClose(t *testing.T) {
+	t.Parallel()
 	src := newHealthFake(transport.HealthStatusHealthy, "ok")
 	sink := newHealthFake(transport.HealthStatusHealthy, "ok")
 	ctx := context.Background()
@@ -876,6 +899,7 @@ func TestHealth_AfterClose(t *testing.T) {
 }
 
 func TestHealth_NonHealthCheckerTransports(t *testing.T) {
+	t.Parallel()
 	// Plain fakeTransport does NOT implement HealthChecker.
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()

--- a/transport/bridge/metrics_test.go
+++ b/transport/bridge/metrics_test.go
@@ -80,6 +80,7 @@ func histBridgeCount(m *metricdata.Metrics) uint64 {
 // ---------- MetricsMiddleware ----------
 
 func TestMetricsMiddleware_ForwardedCounter(t *testing.T) {
+	t.Parallel()
 	m, reader := testBridgeMetrics(t)
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
@@ -115,6 +116,7 @@ func TestMetricsMiddleware_ForwardedCounter(t *testing.T) {
 }
 
 func TestMetricsMiddleware_FailedCounter(t *testing.T) {
+	t.Parallel()
 	m, reader := testBridgeMetrics(t)
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
@@ -154,6 +156,7 @@ func TestMetricsMiddleware_FailedCounter(t *testing.T) {
 }
 
 func TestMetricsMiddleware_Duration(t *testing.T) {
+	t.Parallel()
 	m, reader := testBridgeMetrics(t)
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
@@ -192,6 +195,7 @@ func TestMetricsMiddleware_Duration(t *testing.T) {
 }
 
 func TestMetricsMiddleware_NilMetrics(t *testing.T) {
+	t.Parallel()
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
 	_ = src.RegisterEvent(ctx, "x")
@@ -210,6 +214,7 @@ func TestMetricsMiddleware_NilMetrics(t *testing.T) {
 // ---------- RecordSkip ----------
 
 func TestRecordSkip(t *testing.T) {
+	t.Parallel()
 	m, reader := testBridgeMetrics(t)
 	ctx := context.Background()
 
@@ -226,6 +231,7 @@ func TestRecordSkip(t *testing.T) {
 }
 
 func TestRecordSkip_NilMetrics(t *testing.T) {
+	t.Parallel()
 	var m *bridge.Metrics
 	// Must not panic.
 	m.RecordSkip(context.Background(), "x", "insert")
@@ -234,6 +240,7 @@ func TestRecordSkip_NilMetrics(t *testing.T) {
 // ---------- Dedup + Metrics composition ----------
 
 func TestDedupWithMetricsSkip(t *testing.T) {
+	t.Parallel()
 	m, reader := testBridgeMetrics(t)
 	src, sink := newFakeTransport(), newFakeTransport()
 	ctx := context.Background()
@@ -288,6 +295,7 @@ func TestDedupWithMetricsSkip(t *testing.T) {
 // ---------- Namespace ----------
 
 func TestMetrics_WithNamespace(t *testing.T) {
+	t.Parallel()
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })

--- a/transport/redis/redis_test.go
+++ b/transport/redis/redis_test.go
@@ -305,6 +305,7 @@ func testMessage(source, payload string) message.Message {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	t.Run("nil client returns error", func(t *testing.T) {
 		_, err := New(nil)
 		if err != ErrClientRequired {
@@ -326,6 +327,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestTransportOptions(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 
 	tr, err := New(client,
@@ -351,6 +353,7 @@ func TestTransportOptions(t *testing.T) {
 }
 
 func TestTransportRegisterEvent(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -405,6 +408,7 @@ func TestTransportRegisterEvent(t *testing.T) {
 // behind. The stream itself is created by XADD on first publish; consumer
 // groups are created only when Subscribe runs.
 func TestPublishOnlyDoesNotCreateConsumerGroup(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -435,6 +439,7 @@ func TestPublishOnlyDoesNotCreateConsumerGroup(t *testing.T) {
 // invariant for the default worker pool: the base consumer group is created
 // by the first Subscribe call, not by RegisterEvent.
 func TestDefaultWorkerPoolCreatesBaseGroupOnSubscribe(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client, WithConsumerGroup("bus-a"))
 	defer tr.Close(context.Background())
@@ -472,6 +477,7 @@ func TestDefaultWorkerPoolCreatesBaseGroupOnSubscribe(t *testing.T) {
 }
 
 func TestTransportUnregisterEvent(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -495,6 +501,7 @@ func TestTransportUnregisterEvent(t *testing.T) {
 }
 
 func TestTransportPublish(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -537,6 +544,7 @@ func TestTransportPublish(t *testing.T) {
 }
 
 func TestTransportSubscribe(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -763,6 +771,7 @@ func TestTransportSubscribe(t *testing.T) {
 }
 
 func TestTransportStreamName(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -774,6 +783,7 @@ func TestTransportStreamName(t *testing.T) {
 }
 
 func TestSubscriptionClose(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, _ := New(client)
 	defer tr.Close(context.Background())
@@ -797,6 +807,7 @@ func TestSubscriptionClose(t *testing.T) {
 }
 
 func TestTransportErrorHandler(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.xaddErr = errors.New("xadd failed")
 
@@ -820,6 +831,7 @@ func TestTransportErrorHandler(t *testing.T) {
 }
 
 func TestConsumerLag_OldestPending(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	tr, err := New(client)
 	if err != nil {
@@ -884,6 +896,7 @@ func TestConsumerLag_OldestPending(t *testing.T) {
 // Regression for the shutdown-burst NOGROUP errors seen in event-server with
 // per-Subscribe broadcast consumer groups (call-scheduler-<uuid>).
 func TestBroadcastCloseDoesNotRaceWithConsumeLoop(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 
@@ -974,6 +987,7 @@ func pickBlockedGroup(t *testing.T, m *mockRedisClient, stream string) string {
 }
 
 func TestAutoRecreateGroup_BroadcastRecoversFromNoGroup(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 
@@ -1039,6 +1053,7 @@ func TestAutoRecreateGroup_BroadcastRecoversFromNoGroup(t *testing.T) {
 }
 
 func TestAutoRecreateGroup_WorkerPoolRecoversFromNoGroup(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 
@@ -1097,6 +1112,7 @@ func TestAutoRecreateGroup_WorkerPoolRecoversFromNoGroup(t *testing.T) {
 }
 
 func TestAutoRecreateGroup_DisabledLeavesErrorLog(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 
@@ -1153,6 +1169,7 @@ func TestAutoRecreateGroup_DisabledLeavesErrorLog(t *testing.T) {
 }
 
 func TestAutoRecreateGroup_WrongModeLeavesErrorLog(t *testing.T) {
+	t.Parallel()
 	// Worker-pool subscription, but only RecreateBroadcast is enabled. Recovery
 	// must NOT fire for the worker subscription.
 	client := newMockRedisClient()
@@ -1206,6 +1223,7 @@ func TestAutoRecreateGroup_WrongModeLeavesErrorLog(t *testing.T) {
 }
 
 func TestRecreateMode_String(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		mode RecreateMode
 		want string
@@ -1228,6 +1246,7 @@ func TestRecreateMode_String(t *testing.T) {
 // unreachable), the consume loop falls through to the existing error log +
 // exponential backoff path and the recreate handler is NOT invoked.
 func TestAutoRecreateGroup_RecreateFailsFallsBack(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 
@@ -1287,6 +1306,7 @@ func TestAutoRecreateGroup_RecreateFailsFallsBack(t *testing.T) {
 // sibling who already recreated the group (yielding BUSYGROUP on our retry)
 // is treated as success rather than a hard failure.
 func TestAutoRecreateGroup_BusyGroupTreatedAsSuccess(t *testing.T) {
+	t.Parallel()
 	client := newMockRedisClient()
 	client.blockReadGroup = true
 


### PR DESCRIPTION
## Summary
Fourth batch of the \`t.Parallel()\` rollout (continuing #158, #159, #160).

| Package          | Tests parallelized |
|------------------|--------------------|
| \`transport/redis\` | 20                 |
| \`transport/bridge\` | 32 (bridge + metrics) |
| \`monitor/http\`   | 29 (5 files)       |
| \`monitor/grpc\`   | 8                  |
| **Total**        | **89**             |

\`transport/nats/*_test.go\` already used \`t.Parallel()\` at every Test func so it was skipped.

Same selection criteria as prior batches: package non-test source has no mutable globals (\`bridge.pumpRegistering\` is a read-only sentinel pointer), tests build state per-test, no \`t.Setenv\`.

## Test plan
- [x] \`go test -race -count=10\` passes for all four packages
- [x] \`golangci-lint run\` clean