### PR TITLE
test(event): parallelize 35 remaining root-package tests

### DIFF
--- a/ack_policy_test.go
+++ b/ack_policy_test.go
@@ -29,6 +29,7 @@ func eventuallyEqInt32(t testing.TB, timeout time.Duration, counter *atomic.Int3
 }
 
 func TestWithBestEffort_AutoAcksAndSuppressesErrors(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -65,6 +66,7 @@ func TestWithBestEffort_AutoAcksAndSuppressesErrors(t *testing.T) {
 }
 
 func TestWithAckPolicy_ExplicitIsDefault(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -102,6 +104,7 @@ func TestWithAckPolicy_ExplicitIsDefault(t *testing.T) {
 }
 
 func TestSubscribeOptionValidation_CoalesceAndLatestOnly(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	bus := mustNewBus(t, "validate-"+randomString(6), WithTransport(channel.New()))
 	defer bus.Close(ctx)
@@ -123,6 +126,7 @@ func TestSubscribeOptionValidation_CoalesceAndLatestOnly(t *testing.T) {
 }
 
 func TestSubscribeOptionValidation_BothCoalesceOptions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	bus := mustNewBus(t, "validate2-"+randomString(6), WithTransport(channel.New()))
 	defer bus.Close(ctx)
@@ -144,6 +148,7 @@ func TestSubscribeOptionValidation_BothCoalesceOptions(t *testing.T) {
 }
 
 func TestBestEffortMiddleware(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -176,6 +181,7 @@ func TestBestEffortMiddleware(t *testing.T) {
 }
 
 func TestContextCoalescedCount_DefaultZero(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	if count := ContextCoalescedCount(ctx); count != 0 {
 		t.Errorf("expected 0, got %d", count)
@@ -183,6 +189,7 @@ func TestContextCoalescedCount_DefaultZero(t *testing.T) {
 }
 
 func TestContextCoalescedCount_Set(t *testing.T) {
+	t.Parallel()
 	ctx := contextWithInfo(context.Background(), contextInfo{
 		id: "id", name: "name", source: "source", subID: "sub",
 		msgTime: time.Now(), mode: Broadcast, coalescedCount: 5,
@@ -193,6 +200,7 @@ func TestContextCoalescedCount_Set(t *testing.T) {
 }
 
 func TestWithCoalesceByKey_SupersedesPendingMessages(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -36,6 +36,7 @@ func waitInputsHandled(t testing.TB, counter *atomic.Int64, want int64) {
 }
 
 func TestCoalescer_BasicDelivery(t *testing.T) {
+	t.Parallel()
 	coal := newCoalescer[string](1000, testLogger())
 	defer coal.Close()
 
@@ -60,6 +61,7 @@ func TestCoalescer_BasicDelivery(t *testing.T) {
 }
 
 func TestCoalescer_SupersedesOldMessage(t *testing.T) {
+	t.Parallel()
 	coal := newCoalescer[string](1000, testLogger())
 	defer coal.Close()
 
@@ -107,6 +109,7 @@ func TestCoalescer_SupersedesOldMessage(t *testing.T) {
 }
 
 func TestCoalescer_DifferentKeysDeliverIndependently(t *testing.T) {
+	t.Parallel()
 	coal := newCoalescer[string](1000, testLogger())
 	defer coal.Close()
 
@@ -130,6 +133,7 @@ func TestCoalescer_DifferentKeysDeliverIndependently(t *testing.T) {
 }
 
 func TestCoalescer_EmptyKeyBypassesCoalescing(t *testing.T) {
+	t.Parallel()
 	coal := newCoalescer[string](1000, testLogger())
 	defer coal.Close()
 
@@ -148,6 +152,7 @@ func TestCoalescer_EmptyKeyBypassesCoalescing(t *testing.T) {
 }
 
 func TestCoalescer_ShutdownDrainsPending(t *testing.T) {
+	t.Parallel()
 	coal := newCoalescer[string](1000, testLogger())
 
 	// Send a message but don't consume it.
@@ -183,6 +188,7 @@ func TestCoalescer_ShutdownDrainsPending(t *testing.T) {
 }
 
 func TestRawCoalescer_BasicDelivery(t *testing.T) {
+	t.Parallel()
 	coal := newRawCoalescer("doc_key", 1000, testLogger())
 	defer coal.Close()
 
@@ -201,6 +207,7 @@ func TestRawCoalescer_BasicDelivery(t *testing.T) {
 }
 
 func TestRawCoalescer_SupersedesByMetadataKey(t *testing.T) {
+	t.Parallel()
 	coal := newRawCoalescer("doc_key", 1000, testLogger())
 	defer coal.Close()
 
@@ -240,6 +247,7 @@ func TestRawCoalescer_SupersedesByMetadataKey(t *testing.T) {
 }
 
 func TestRawCoalescer_MissingMetadataKeyBypassesCoalescing(t *testing.T) {
+	t.Parallel()
 	coal := newRawCoalescer("doc_key", 1000, testLogger())
 	defer coal.Close()
 
@@ -260,6 +268,7 @@ func TestRawCoalescer_MissingMetadataKeyBypassesCoalescing(t *testing.T) {
 }
 
 func TestCoalescer_MaxKeysEviction(t *testing.T) {
+	t.Parallel()
 	// Create coalescer with max 2 keys.
 	coal := newCoalescer[string](2, testLogger())
 	defer coal.Close()
@@ -306,6 +315,7 @@ func TestCoalescer_MaxKeysEviction(t *testing.T) {
 }
 
 func TestCoalescer_EvictionSkipsInflightKeys(t *testing.T) {
+	t.Parallel()
 	// Create coalescer with max 2 keys.
 	coal := newCoalescer[string](2, testLogger())
 	defer coal.Close()

--- a/codec_test.go
+++ b/codec_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestJSONCodecEncode(t *testing.T) {
+	t.Parallel()
 	// Use the default codec
 	c := codec.Default()
 
@@ -44,6 +45,7 @@ func TestJSONCodecEncode(t *testing.T) {
 }
 
 func TestJSONCodecDecode(t *testing.T) {
+	t.Parallel()
 	c := codec.Default()
 
 	jsonData := `{"id":"msg-123","source":"src-456","payload":"dGVzdCBkYXRh","metadata":{"foo":"bar"}}`
@@ -72,6 +74,7 @@ func TestJSONCodecDecode(t *testing.T) {
 }
 
 func TestJSONCodecRoundTrip(t *testing.T) {
+	t.Parallel()
 	c := codec.Default()
 
 	type TestPayload struct {
@@ -134,6 +137,7 @@ func TestJSONCodecRoundTrip(t *testing.T) {
 }
 
 func TestJSONCodecDecodeInvalidJSON(t *testing.T) {
+	t.Parallel()
 	c := codec.Default()
 
 	_, err := c.Decode([]byte("not valid json"))
@@ -143,6 +147,7 @@ func TestJSONCodecDecodeInvalidJSON(t *testing.T) {
 }
 
 func TestJSONCodecEncodeNilMetadata(t *testing.T) {
+	t.Parallel()
 	c := codec.Default()
 
 	msg := message.New("test-id", "test-source", []byte("data"), nil)
@@ -165,6 +170,7 @@ func TestJSONCodecEncodeNilMetadata(t *testing.T) {
 }
 
 func TestJSONCodecDecodeNoMetadata(t *testing.T) {
+	t.Parallel()
 	c := codec.Default()
 
 	jsonData := `{"id":"msg-123","source":"src-456","payload":"dGVzdA=="}`

--- a/publish_audit_test.go
+++ b/publish_audit_test.go
@@ -40,6 +40,7 @@ func (f *fakePublishAuditStore) Len() int {
 }
 
 func TestPublishAudit_RecordsOnSuccessfulPublish(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	audit := &fakePublishAuditStore{}
 
@@ -81,6 +82,7 @@ func TestPublishAudit_RecordsOnSuccessfulPublish(t *testing.T) {
 }
 
 func TestPublishAudit_NotCalledWhenStoreNil(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	bus := mustNewBus(t, "audit-nil-"+randomString(5),
 		WithTransport(channel.New()),
@@ -102,6 +104,7 @@ func TestPublishAudit_NotCalledWhenStoreNil(t *testing.T) {
 }
 
 func TestPublishAudit_AccessorReturnsConfiguredStore(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	audit := &fakePublishAuditStore{}
 
@@ -121,6 +124,7 @@ func TestPublishAudit_AccessorReturnsConfiguredStore(t *testing.T) {
 }
 
 func TestPublishAudit_NotCalledOnClosedBus(t *testing.T) {
+	t.Parallel()
 	// Verifies that audit recording happens only on successful transport.Publish:
 	// publishes against a closed bus short-circuit before transport.Publish and
 	// so should not produce audit entries.

--- a/route_test.go
+++ b/route_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRoutingKey(t *testing.T) {
+	t.Parallel()
 	got := RoutingKey("region")
 	want := "X-Route-region"
 	if got != want {
@@ -16,6 +17,7 @@ func TestRoutingKey(t *testing.T) {
 }
 
 func TestHasRoutingKeys(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		metadata map[string]string
@@ -39,6 +41,7 @@ func TestHasRoutingKeys(t *testing.T) {
 }
 
 func TestMatchesRouteFilters(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		metadata map[string]string
@@ -67,6 +70,7 @@ func TestMatchesRouteFilters(t *testing.T) {
 }
 
 func TestContextWithRoutingKey(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Add a routing key
@@ -93,6 +97,7 @@ func TestContextWithRoutingKey(t *testing.T) {
 }
 
 func TestContextWithRoutingKey_OverwriteExisting(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	ctx = ContextWithRoutingKey(ctx, "region", "us-east")
 	ctx = ContextWithRoutingKey(ctx, "region", "eu-west")
@@ -104,6 +109,7 @@ func TestContextWithRoutingKey_OverwriteExisting(t *testing.T) {
 }
 
 func TestMatchesRouteFilters_Reexport(t *testing.T) {
+	t.Parallel()
 	// Verify the re-exported function works identically
 	meta := map[string]string{"X-Route-region": "us-east"}
 	if !MatchesRouteFilters(meta, map[string]string{"X-Route-region": "us-east"}) {
@@ -115,6 +121,7 @@ func TestMatchesRouteFilters_Reexport(t *testing.T) {
 }
 
 func TestWithRouteMatch_Composition(t *testing.T) {
+	t.Parallel()
 	// Two predicates composed with AND semantics
 	var opts []SubscribeOption[string]
 	opts = append(opts,


### PR DESCRIPTION
## Summary
Continuation of #162. Add \`t.Parallel()\` to the five root-package test files that hadn't yet been parallelized.

| File                      | Tests parallelized |
|---------------------------|--------------------|
| \`ack_policy_test.go\`      | 8                  |
| \`coalesce_test.go\`        | 10                 |
| \`codec_test.go\`           | 6                  |
| \`publish_audit_test.go\`   | 4                  |
| \`route_test.go\`           | 7                  |
| **Total**                 | **35**             |

Each file already uses random-suffixed bus names (or no \`mustNewBus\` at all), so no registry collisions are introduced.

## Why bus_metrics_test.go is excluded
\`setupMetricsProvider\` swaps the global \`otel.MeterProvider\` on each call (and \`resetGauges()\` rebinds the package's metric handles). Parallelizing those tests would race on the global provider. They stay serial.

## Test plan
- [x] \`go test -race -count=10 .\` — green
- [x] \`golangci-lint run .\` clean