### PR TITLE
test(event): consolidate eventually helpers into helpers_test.go

### DIFF
--- a/ack_policy_test.go
+++ b/ack_policy_test.go
@@ -11,23 +11,6 @@ import (
 	"github.com/rbaliyan/event/v3/transport/channel"
 )
 
-// eventuallyEqInt32 polls until atomic.Int32 reaches want or the deadline
-// fires. Replaces the time.Sleep + assert pattern: the test passes the
-// instant the contract is met, and only burns the timeout when something
-// is actually wrong. Defined here (not in internal/testutil) because the
-// root event package cannot import testutil — it would create an import
-// cycle through internal/testutil/bus.go.
-func eventuallyEqInt32(t testing.TB, timeout time.Duration, counter *atomic.Int32, want int32, msg string) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for counter.Load() != want {
-		if time.Now().After(deadline) {
-			t.Fatalf("%s: got %d, want %d (after %s)", msg, counter.Load(), want, timeout)
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-}
-
 func TestWithBestEffort_AutoAcksAndSuppressesErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -3,7 +3,6 @@ package event
 import (
 	"log/slog"
 	"os"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,23 +15,6 @@ func testLogger() *slog.Logger {
 
 func newTestMsg(id string) message.Message {
 	return message.New(id, "test", []byte("{}"), nil)
-}
-
-// waitInputsHandled blocks until counter reaches at least want, or the
-// deadline fires. Replaces the time.Sleep gaps that were used between
-// sequential sends on coal.incoming: those sleeps existed because the
-// coalescer's run() goroutine selects between incoming and done, and a
-// queued done could be picked up before its preceding incoming messages
-// without an explicit sync barrier.
-func waitInputsHandled(t testing.TB, counter *atomic.Int64, want int64) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for counter.Load() < want {
-		if time.Now().After(deadline) {
-			t.Fatalf("inputsHandled did not reach %d (got %d)", want, counter.Load())
-		}
-		time.Sleep(time.Millisecond)
-	}
 }
 
 func TestCoalescer_BasicDelivery(t *testing.T) {

--- a/event_test.go
+++ b/event_test.go
@@ -69,35 +69,6 @@ func wait(ch chan struct{}, timeout int) bool {
 	}
 }
 
-// eventuallyTrue polls predicate until it returns true or the deadline fires.
-// Replaces post-publish / post-cancel time.Sleep + assert patterns. Lives in
-// this file (not internal/testutil) because the root event package cannot
-// import testutil — that would create an import cycle.
-func eventuallyTrue(t testing.TB, timeout time.Duration, predicate func() bool, msg string) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for !predicate() {
-		if time.Now().After(deadline) {
-			t.Fatalf("%s (after %s)", msg, timeout)
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-}
-
-// consistentlyEqInt32 polls counter for the given window and fails the test
-// if it ever observes a value other than want. Use for negative-stable
-// assertions such as "after a duplicate publish, callCount must stay at N".
-func consistentlyEqInt32(t testing.TB, window time.Duration, counter *atomic.Int32, want int32, msg string) {
-	t.Helper()
-	deadline := time.Now().Add(window)
-	for time.Now().Before(deadline) {
-		if got := counter.Load(); got != want {
-			t.Fatalf("%s: got %d, want %d", msg, got, want)
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-}
-
 // testDLQStore is a simple DLQStore for testing that signals when Store is called.
 type testDLQStore struct {
 	called chan struct{}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,75 @@
+package event
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// This file collects the deterministic polling helpers used across the root
+// event package's test suite. Each helper exists because the root package
+// cannot import internal/testutil (that would create a cycle through
+// internal/testutil/bus.go), so the same shape lives here instead.
+//
+// Use these instead of time.Sleep + assert. The benefits are the same as
+// testutil.Eventually elsewhere in the repo:
+//   - The test passes the instant the contract is met.
+//   - Only failing runs burn the full timeout.
+//   - There is no slack budget that grows stale on slow CI.
+
+// eventuallyEqInt32 polls until counter reaches want or the deadline fires.
+// Use for atomic.Int32 call counts / message counts.
+func eventuallyEqInt32(t testing.TB, timeout time.Duration, counter *atomic.Int32, want int32, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for counter.Load() != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: got %d, want %d (after %s)", msg, counter.Load(), want, timeout)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// eventuallyTrue polls predicate until it returns true or the deadline fires.
+// Use for atomic.Bool, *eventImpl.Subscribers(), mock-store probes, etc.
+func eventuallyTrue(t testing.TB, timeout time.Duration, predicate func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !predicate() {
+		if time.Now().After(deadline) {
+			t.Fatalf("%s (after %s)", msg, timeout)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// consistentlyEqInt32 polls counter for the given window and fails the test
+// if it ever observes a value other than want. Use for negative-stable
+// assertions such as "after a duplicate publish, callCount must stay at N".
+func consistentlyEqInt32(t testing.TB, window time.Duration, counter *atomic.Int32, want int32, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		if got := counter.Load(); got != want {
+			t.Fatalf("%s: got %d, want %d", msg, got, want)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// waitInputsHandled blocks until counter reaches at least want or the
+// deadline fires. Replaces the time.Sleep gaps that were used between
+// sequential sends on coal.incoming: those sleeps existed because the
+// coalescer's run() goroutine selects between incoming and done, and a
+// queued done could be picked up before its preceding incoming messages
+// without an explicit sync barrier.
+func waitInputsHandled(t testing.TB, counter *atomic.Int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for counter.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("inputsHandled did not reach %d (got %d)", want, counter.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
The root event package had four deterministic polling helpers scattered across three test files. Move them into a new \`helpers_test.go\` so the canonical home for these utilities is obvious.

| Helper                | Previously in          |
|-----------------------|------------------------|
| \`eventuallyEqInt32\`   | \`ack_policy_test.go\`   |
| \`eventuallyTrue\`      | \`event_test.go\`        |
| \`consistentlyEqInt32\` | \`event_test.go\`        |
| \`waitInputsHandled\`   | \`coalesce_test.go\`     |

No behavior changes; the helper bodies are byte-for-byte identical. A shared header on the new file explains why the root package can't import \`internal/testutil.Eventually\` (import cycle through \`testutil/bus.go\`).

\`eventuallyMetrics\` stays in \`bus_metrics_test.go\` because it's tightly coupled to that file's \`collectMetrics\` helper and the OTel-specific reader setup.

## Test plan
- [x] \`go test -race -count=10 .\` — green
- [x] \`golangci-lint run .\` clean