### PR TITLE
fix(channel): synchronize send against subscription close

### DIFF
--- a/transport/base/subscription.go
+++ b/transport/base/subscription.go
@@ -126,6 +126,38 @@ func (s *Subscription) Close(cleanup func() error) error {
 	return cleanupErr
 }
 
+// SendGuard locks the subscription against Close closing the message channel
+// for the duration of an external send on Ch(), reporting whether the
+// subscription is still open. On success the caller MUST invoke the returned
+// release function once the send completes (typically via defer):
+//
+//	release, open := sub.SendGuard()
+//	if !open {
+//	    return transport.ErrSubscriptionClosed
+//	}
+//	defer release()
+//	select {
+//	case <-sub.ClosedCh():
+//	    return transport.ErrSubscriptionClosed
+//	case sub.Ch() <- msg:
+//	    return nil
+//	}
+//
+// Transports that send to Ch() directly instead of via SendToChannel must hold
+// this guard, otherwise Close may close the channel concurrently with the send
+// (a data race and potential "send on closed channel" panic). The send select
+// must still watch ClosedCh so it unblocks when Close signals shutdown — Close
+// closes ClosedCh before acquiring the write lock, so a guarded sender never
+// deadlocks Close.
+func (s *Subscription) SendGuard() (release func(), open bool) {
+	s.chMu.RLock()
+	if s.IsClosed() {
+		s.chMu.RUnlock()
+		return func() {}, false
+	}
+	return s.chMu.RUnlock, true
+}
+
 // SendToChannel sends a message to the channel with optional timeout.
 // Returns SendOK on success, SendClosed if subscription closed, SendTimeout on timeout.
 func (s *Subscription) SendToChannel(msg transport.Message) SendResult {

--- a/transport/channel/channel.go
+++ b/transport/channel/channel.go
@@ -299,6 +299,16 @@ func (t *Transport) Publish(ctx context.Context, name string, msg transport.Mess
 }
 
 func (t *Transport) sendToSubscriber(ctx context.Context, sub *subscription, msg transport.Message) error {
+	// Guard against Close closing sub.Ch() concurrently with the sends below.
+	// Publish collects subscribers and then sends to them; a subscriber can be
+	// closed in that window, so without this guard the send below would race
+	// (and can panic) on a closed channel.
+	release, open := sub.SendGuard()
+	if !open {
+		return transport.ErrSubscriptionClosed
+	}
+	defer release()
+
 	// Use timeout if configured
 	timeout := atomic.LoadInt64(&t.timeout)
 	if timeout > 0 {

--- a/transport/channel/channel_test.go
+++ b/transport/channel/channel_test.go
@@ -16,6 +16,75 @@ func testMessage(id, source, payload string) transport.Message {
 	return message.New(id, source, []byte(payload), nil)
 }
 
+// TestPublishCloseRace exercises concurrent Publish and subscription Close.
+//
+// Publish collects matching subscribers and then sends to them; a subscriber
+// can be closed in that window. The send must be synchronized against the
+// subscription closing its channel, otherwise sendToSubscriber sends on a
+// closed channel — a data race (and potential "send on closed channel" panic).
+// Run with -race; without the synchronization fix this fails reliably.
+func TestPublishCloseRace(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	for i := 0; i < 200; i++ {
+		tr := New(WithBufferSize(1))
+		if err := tr.RegisterEvent(ctx, "race"); err != nil {
+			t.Fatalf("RegisterEvent: %v", err)
+		}
+		sub, err := tr.Subscribe(ctx, "race")
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+
+		// Drain so publishes complete quickly and the publish loops spin fast,
+		// maximizing the number of sends in flight when Close races in.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case _, ok := <-sub.Messages():
+					if !ok {
+						return
+					}
+				case <-stop:
+					return
+				}
+			}
+		}()
+
+		// Several publishers hammer the subscription concurrently.
+		const publishers = 4
+		for p := 0; p < publishers; p++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						// Errors once Close races in are expected and ignored.
+						_ = tr.Publish(ctx, "race", testMessage("m", "s", "p"))
+					}
+				}
+			}()
+		}
+
+		// Let the publishers saturate, then close mid-flight: this races
+		// close(s.ch) against the send on s.ch inside sendToSubscriber.
+		time.Sleep(time.Millisecond)
+		_ = sub.Close(ctx)
+		close(stop)
+		wg.Wait()
+		_ = tr.Close(ctx)
+	}
+}
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 	tr := New()


### PR DESCRIPTION
## Summary

The channel transport could send on a closed channel, producing a data race (and an occasional `send on closed channel` panic) under `-race`. This surfaced as flaky CI in a downstream repo:

```
WARNING: DATA RACE
Write ... base.(*Subscription).Close()        subscription.go:123  (close(s.ch))
Previous read ... channel.(*Transport).sendToSubscriber()  channel.go:339  (sub.Ch() <- msg)
```

## Root cause

`sendToSubscriber` sent directly to `sub.Ch() <- msg`, bypassing `base.Subscription.SendToChannel` — the method that holds the `chMu` read-lock so it cannot run concurrently with `Close()`, which takes the write-lock before `close(s.ch)`.

`Publish` collects matching subscribers under `subscribers.Range` (with a racy `IsClosed()` check) and then sends to them. A subscriber can be closed in that window, so the unguarded send raced with `Close()` closing the channel.

## Fix

- Add `base.Subscription.SendGuard()`, which acquires the same read-lock `SendToChannel` uses and reports whether the subscription is still open. It returns a release function for the caller to defer. Transports that send to `Ch()` directly can now serialize against `Close`.
- Hold the guard in `sendToSubscriber`.

No deadlock: `Close` closes `ClosedCh` *before* taking the write-lock, and every blocking send already watches `ClosedCh`, so a guarded sender unblocks on shutdown and releases the read-lock promptly.

## Test

`TestPublishCloseRace` hammers `Publish` from several goroutines while closing the subscription. Under `-race` it fails reliably before the fix (data race + `send on closed channel` panic) and passes after. Verified with `-count=10`; the full `./transport/...` suite and the root package pass under `-race`.

## Related (not in this PR)

The same direct-send-to-`Ch()` pattern exists in two other transports that send from the publish/callback path (not joined by `Close`'s `WaitGroup`), so they share this race and should get the same `SendGuard` treatment in a follow-up:

- `transport/ackonly/ackonly.go` (publish dispatch loop)
- `transport/nats/core.go` (NATS message handler; non-blocking send, so data-race only)

`transport/composite/subscription.go` sends to `Ch()` too but is **safe** — its send runs in the subscription's own goroutine, which `Close()` joins via `wg.Wait()` before closing the channel.