### PR TITLE
ci: add benchmark and per-target fuzz checks as PR gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,30 @@ jobs:
       - name: Run smoke tests
         run: go test -tags=smoke -race -count=1 -timeout=60s ./...
 
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      # Exercise every benchmark briefly so a broken or panicking benchmark is
+      # caught in CI. Absolute timings are not gated (runner variance);
+      # -benchtime=1x runs each benchmark a single iteration -- enough to catch
+      # a compile break or panic without paying for measurement.
+      #
+      # Dependabot PRs only touch dependency manifests and never the benchmarked
+      # code, so skip the work for them. The step (not the job) is gated so the
+      # job still reports success -- a skipped required check would block merge.
+      - name: Run benchmarks
+        if: github.actor != 'dependabot[bot]'
+        run: go test -run='^$' -bench=. -benchmem -benchtime=1x ./...
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,20 +1,21 @@
 name: Fuzz
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
 permissions: read-all
 
+# This is the pull-request fuzz gate only. The deep push-to-main and weekly
+# campaign is owned by cflite_batch.yml (ClusterFuzzLite), so this workflow
+# does not run on push to avoid duplicating that coverage.
+#
 # Cancel a superseded run for the same ref -- e.g. when a PR's merge commit is
 # recomputed after the base branch advances, GitHub starts a fresh run and the
 # stale one would otherwise linger and surface a spurious "cancelled" status.
-# Only PR runs are cancelled; push-to-main runs to completion.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   # Emit the fuzz targets as a JSON matrix so each target runs as its own job
@@ -81,8 +82,8 @@ jobs:
         env:
           PKG: ${{ matrix.pkg }}
           FN: ${{ matrix.fn }}
-          # Short smoke budget on push/PR; -race is dropped so a slow input near
-          # the deadline does not flake the run (see scripts/fuzz_one.sh).
+          # Short smoke budget for the PR gate; -race is dropped so a slow input
+          # near the deadline does not flake the run (see scripts/fuzz_one.sh).
           FUZZTIME: 40s
           FUZZ_RACE: '0'
         run: bash scripts/fuzz_one.sh "$PKG" "$FN"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,117 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+# Cancel a superseded run for the same ref -- e.g. when a PR's merge commit is
+# recomputed after the base branch advances, GitHub starts a fresh run and the
+# stale one would otherwise linger and surface a spurious "cancelled" status.
+# Only PR runs are cancelled; push-to-main runs to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Emit the fuzz targets as a JSON matrix so each target runs as its own job
+  # and can be re-run in isolation ("Re-run failed jobs" re-runs only the
+  # target that failed, not the whole sweep). Discovery is shared with the
+  # local sweep (scripts/fuzz_targets.sh) so new targets are picked up with no
+  # wiring.
+  discover:
+    name: Discover targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.list.outputs.targets }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: List fuzz targets
+        id: list
+        env:
+          # Dependabot PRs only touch dependency manifests and never the fuzzed
+          # code. Emit an empty matrix so the target jobs do not run; the
+          # aggregate "Fuzz" check below still reports success (a skipped
+          # required check would block merge).
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [ "$ACTOR" = "dependabot[bot]" ]; then
+            echo 'targets=[]' >> "$GITHUB_OUTPUT"
+          else
+            echo "targets=$(bash scripts/fuzz_targets.sh --json)" >> "$GITHUB_OUTPUT"
+          fi
+
+  # One job per fuzz target. fail-fast is off so a finding in one target does
+  # not cancel the others, and GitHub's "Re-run failed jobs" re-runs only the
+  # target(s) that failed.
+  target:
+    name: ${{ matrix.name }}
+    needs: discover
+    if: needs.discover.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover.outputs.targets) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      # Persist each target's generated corpus separately so repeated runs
+      # accumulate coverage without cross-target cache races.
+      - name: Cache fuzz corpus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
+        with:
+          path: ~/.cache/go-build/fuzz
+          key: fuzz-corpus-${{ runner.os }}-${{ matrix.name }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ runner.os }}-${{ matrix.name }}-
+
+      - name: Fuzz ${{ matrix.name }}
+        env:
+          PKG: ${{ matrix.pkg }}
+          FN: ${{ matrix.fn }}
+          # Short smoke budget on push/PR; -race is dropped so a slow input near
+          # the deadline does not flake the run (see scripts/fuzz_one.sh).
+          FUZZTIME: 40s
+          FUZZ_RACE: '0'
+        run: bash scripts/fuzz_one.sh "$PKG" "$FN"
+
+      # On a crash, Go writes a minimized reproducer under testdata/fuzz; upload
+      # it so the failing input can be replayed (go test -run=FuzzX/<hash>).
+      - name: Upload crash reproducer
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crasher-${{ matrix.name }}
+          path: "**/testdata/fuzz/**"
+          if-no-files-found: ignore
+
+  # Single required status check. Green when every target passed (or was
+  # skipped for Dependabot); red if any target reported a genuine finding.
+  fuzz:
+    name: Fuzz
+    needs: [discover, target]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any target reported a finding
+        if: needs.target.result == 'failure'
+        run: |
+          echo "One or more fuzz targets reported a genuine finding."
+          exit 1
+      - name: Summary
+        env:
+          RESULT: ${{ needs.target.result }}
+        run: |
+          echo "Fuzz targets result: $RESULT"

--- a/internal/msgpacklimit/validate.go
+++ b/internal/msgpacklimit/validate.go
@@ -10,7 +10,9 @@
 // headers and rejects inputs that declare collection sizes exceeding safe limits.
 // It enforces both per-collection and cumulative element budgets to prevent a
 // small crafted input from triggering multi-GB memory allocations through nested
-// collections.
+// collections. It likewise rejects str/bin/ext blobs whose declared byte length
+// exceeds the bytes actually present, which would otherwise drive the same
+// pre-allocation OOM (e.g. a 9-byte input declaring a 4GB bin32 payload).
 package msgpacklimit
 
 import (
@@ -33,6 +35,14 @@ const maxTotalElements = 1_000_000
 // ErrOversizedCollection is returned when a msgpack input declares a collection
 // larger than MaxCollectionElements or exceeds the total element budget.
 var ErrOversizedCollection = errors.New("msgpack: collection size exceeds safety limit")
+
+// ErrOversizedBlob is returned when a msgpack str/bin/ext header declares a byte
+// length larger than the bytes actually present in the input. A blob occupies
+// exactly its declared length immediately after the header, so a length beyond
+// the remaining input is malformed -- and decoding it would make the msgpack
+// library pre-allocate that many bytes (a multi-GB OOM vector). It is rejected
+// before decoding rather than silently clamped.
+var ErrOversizedBlob = errors.New("msgpack: blob size exceeds input length")
 
 // scanner tracks cumulative element counts during validation.
 type scanner struct {
@@ -250,21 +260,28 @@ func skipBytes(data []byte, off, n int) (int, error) {
 }
 
 // skipSized reads a size header of sizeBytes width and skips that many data bytes.
+// The declared length is read as uint64 so a 4-byte size near 2^32 cannot wrap
+// a 32-bit int negative and slip past the bounds check.
 func skipSized(data []byte, off, sizeBytes int) (int, error) {
 	if off+sizeBytes > len(data) {
 		return len(data), nil
 	}
-	var n int
+	var n uint64
 	switch sizeBytes {
 	case 1:
-		n = int(data[off])
+		n = uint64(data[off])
 	case 2:
-		n = int(binary.BigEndian.Uint16(data[off:]))
+		n = uint64(binary.BigEndian.Uint16(data[off:]))
 	case 4:
-		n = int(binary.BigEndian.Uint32(data[off:]))
+		n = uint64(binary.BigEndian.Uint32(data[off:]))
 	}
 	off += sizeBytes
-	return skipBytes(data, off, n)
+	// len(data)-off is non-negative: off <= len(data) after the header bounds
+	// check above, then off advanced by sizeBytes which that check accounted for.
+	if n > uint64(len(data)-off) { // #nosec G115 -- len(data)-off is non-negative (see comment)
+		return 0, fmt.Errorf("%w: blob declares %d bytes, only %d remain", ErrOversizedBlob, n, len(data)-off)
+	}
+	return skipBytes(data, off, int(n))
 }
 
 // skipExtSized reads a size header, then skips type(1) + size data bytes.
@@ -272,15 +289,20 @@ func skipExtSized(data []byte, off, sizeBytes int) (int, error) {
 	if off+sizeBytes > len(data) {
 		return len(data), nil
 	}
-	var n int
+	var n uint64
 	switch sizeBytes {
 	case 1:
-		n = int(data[off])
+		n = uint64(data[off])
 	case 2:
-		n = int(binary.BigEndian.Uint16(data[off:]))
+		n = uint64(binary.BigEndian.Uint16(data[off:]))
 	case 4:
-		n = int(binary.BigEndian.Uint32(data[off:]))
+		n = uint64(binary.BigEndian.Uint32(data[off:]))
 	}
 	off += sizeBytes
-	return skipBytes(data, off, n+1) // +1 for ext type byte
+	// ext payload is type(1) + n data bytes; same OOM reasoning as skipSized.
+	// len(data)-off is non-negative (off <= len(data) after the bounds check).
+	if n+1 > uint64(len(data)-off) { // #nosec G115 -- len(data)-off is non-negative (see comment)
+		return 0, fmt.Errorf("%w: ext declares %d bytes, only %d remain", ErrOversizedBlob, n, len(data)-off)
+	}
+	return skipBytes(data, off, int(n)+1) // +1 for ext type byte
 }

--- a/internal/msgpacklimit/validate_test.go
+++ b/internal/msgpacklimit/validate_test.go
@@ -92,6 +92,51 @@ func TestValidate_CrashInput(t *testing.T) {
 	}
 }
 
+func TestValidate_OversizedBinBlob(t *testing.T) {
+	t.Parallel()
+	// Fuzz-discovered crash: bin32 (0xc6) header declaring ~4GB (0xEE994F88)
+	// backed by only a few bytes. The validator must reject this before the
+	// msgpack library pre-allocates the declared size and OOMs.
+	data := []byte{0xc6, 0xee, 0x99, 0x4f, 0x88, 0xe9, 0xd9, 0x01, 0x30}
+	err := Validate(data)
+	if !errors.Is(err, ErrOversizedBlob) {
+		t.Errorf("Validate() = %v, want ErrOversizedBlob", err)
+	}
+}
+
+func TestValidate_OversizedStrAndExt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		// str32 (0xdb) declaring ~4GB with no payload.
+		{"str32", []byte{0xdb, 0xff, 0xff, 0xff, 0xff}},
+		// str8 (0xd9) declaring 255 bytes backed by one.
+		{"str8", []byte{0xd9, 0xff, 0x00}},
+		// ext32 (0xc9) declaring ~4GB payload.
+		{"ext32", []byte{0xc9, 0xff, 0xff, 0xff, 0xff, 0x01}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := Validate(tt.data); !errors.Is(err, ErrOversizedBlob) {
+				t.Errorf("Validate() = %v, want ErrOversizedBlob", err)
+			}
+		})
+	}
+}
+
+func TestValidate_ExactLengthBlobOK(t *testing.T) {
+	t.Parallel()
+	// A blob whose declared length exactly matches the bytes present is valid
+	// and must not be rejected: bin8 (0xc4) length 3 followed by 3 bytes.
+	data := []byte{0xc4, 0x03, 0x01, 0x02, 0x03}
+	if err := Validate(data); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
 func TestValidate_EmptyInput(t *testing.T) {
 	t.Parallel()
 	if err := Validate(nil); err != nil {

--- a/payload/testdata/fuzz/FuzzMsgPackCodecDecode/558648db44396766
+++ b/payload/testdata/fuzz/FuzzMsgPackCodecDecode/558648db44396766
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\xc6\xee\x99O\x88\xe9\xd9\x010")

--- a/scripts/fuzz_all.sh
+++ b/scripts/fuzz_all.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# fuzz_all.sh runs every discovered Go fuzz target for a short budget, in
+# sequence (only one -fuzz target runs per `go test`). Targets are discovered by
+# fuzz_targets.sh and each runs via fuzz_one.sh, so discovery and outcome
+# classification live in one place and are shared with CI's per-target matrix.
+#
+#   FUZZTIME=30s ./scripts/fuzz_all.sh
+#
+# Exits non-zero when any target reports a genuine finding (a crash writes a
+# reproducer under <pkg>/testdata/fuzz/<Target>/). See fuzz_one.sh for the
+# FUZZTIME / FUZZ_RACE knobs and the deadline-flake handling.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+status=0
+
+while read -r pkg fn; do
+  [ -z "$fn" ] && continue
+  "${here}/fuzz_one.sh" "$pkg" "$fn" || status=1
+done < <("${here}/fuzz_targets.sh")
+
+exit "$status"

--- a/scripts/fuzz_one.sh
+++ b/scripts/fuzz_one.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# fuzz_one.sh runs a single fuzz target for FUZZTIME and classifies the outcome.
+#
+#   ./scripts/fuzz_one.sh <pkg> <FuzzName>
+#   FUZZTIME=40s FUZZ_RACE=0 ./scripts/fuzz_one.sh ./content FuzzDecode
+#
+# Exit 0 on a pass -- or on a bare "context deadline exceeded", which is the
+# fuzzing coordinator failing to drain its workers within the budget on a loaded
+# runner (a flake, not a bug). Exit 1 only on a genuine finding: one that writes
+# a minimized reproducer under <pkg>/testdata/fuzz/<Target>/ and prints
+# "Failing input written to ...".
+#
+# Environment:
+#   FUZZTIME   fuzz budget (default 30s).
+#   FUZZ_RACE  run with -race when != "0" (default "1"). -race roughly halves
+#              exec throughput; the short PR/push smoke budget disables it so a
+#              slow input near the deadline does not flake the run.
+set -uo pipefail
+
+pkg="${1:?usage: fuzz_one.sh <pkg> <FuzzName>}"
+fn="${2:?usage: fuzz_one.sh <pkg> <FuzzName>}"
+budget="${FUZZTIME:-30s}"
+
+race_flag=()
+if [ "${FUZZ_RACE:-1}" != "0" ]; then
+  race_flag=(-race)
+fi
+
+echo "== fuzzing ${fn} (${pkg}) for ${budget} =="
+# ${arr[@]+"${arr[@]}"} expands safely when the array is empty under `set -u`
+# (bash 3.2, as shipped on macOS, otherwise errors on a bare "${arr[@]}").
+out="$(go test -run='^$' ${race_flag[@]+"${race_flag[@]}"} -fuzz="^${fn}\$" -fuzztime="$budget" "$pkg" 2>&1)"
+code=$?
+printf '%s\n' "$out"
+[ "$code" -eq 0 ] && exit 0
+
+if printf '%s\n' "$out" | grep -q 'Failing input written'; then
+  echo "FUZZ FAILED: ${fn} (${pkg})"
+  exit 1
+elif printf '%s\n' "$out" | grep -qE 'context deadline exceeded|deadline exceeded gathering baseline coverage'; then
+  echo "FUZZ TIMEOUT (ignored, no reproducer): ${fn} (${pkg})"
+  exit 0
+fi
+
+echo "FUZZ FAILED: ${fn} (${pkg})"
+exit 1

--- a/scripts/fuzz_targets.sh
+++ b/scripts/fuzz_targets.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# fuzz_targets.sh discovers every Go fuzz target in the module. New targets are
+# picked up automatically -- no per-target wiring anywhere.
+#
+#   ./scripts/fuzz_targets.sh          # "<pkg> <FuzzName>" lines
+#   ./scripts/fuzz_targets.sh --json   # [{"name":..,"pkg":..,"fn":..}, ...] (CI matrix)
+#
+# Used by fuzz_all.sh (local sweep) and the CI discover job (matrix) so both
+# share one discovery rule and cannot drift. The JSON "name" is a unique
+# pkg-qualified slug so two targets that share a function name in different
+# packages (e.g. FuzzJSONSchemaValidate in ./schema and ./validation) map to
+# distinct, individually re-runnable matrix jobs; "fn" carries the actual
+# function name passed to `go test -fuzz`.
+set -uo pipefail
+
+emit_json="${1:-}"
+
+pairs=()
+while IFS= read -r file; do
+  dir="$(dirname "$file")"
+  pkg="./${dir#./}"
+  while IFS= read -r fn; do
+    [ -z "$fn" ] && continue
+    pairs+=("${pkg} ${fn}")
+  done < <(grep -oE '^func (Fuzz[A-Za-z0-9_]+)' "$file" | awk '{print $2}')
+done < <(grep -rEl '^func Fuzz' --include='*_test.go' . | grep -v '/\.claude/')
+
+if [ "$emit_json" != "--json" ]; then
+  printf '%s\n' ${pairs[@]+"${pairs[@]}"}
+  exit 0
+fi
+
+# Hand-build the JSON array (no jq dependency on the runner).
+out="["
+sep=""
+for p in ${pairs[@]+"${pairs[@]}"}; do
+  pkg="${p%% *}"
+  fn="${p##* }"
+  # Unique job label: strip "./", swap "/" for "-", append the function name.
+  slug="${pkg#./}"
+  slug="${slug//\//-}-${fn}"
+  out="${out}${sep}{\"name\":\"${slug}\",\"pkg\":\"${pkg}\",\"fn\":\"${fn}\"}"
+  sep=","
+done
+out="${out}]"
+printf '%s\n' "$out"


### PR DESCRIPTION
## Summary

Adds two new CI checks so benchmarks and fuzzing can be marked as required status checks on pull requests:

- **Benchmarks** — new job in `ci.yml` that briefly exercises every benchmark (`-benchtime=1x`) to catch a broken or panicking benchmark. Absolute timings are not gated (runner variance).
- **Fuzz** — new `fuzz.yml` that discovers every Go fuzz target and runs each as its own matrix job (`fail-fast: false`), so a failing target can be re-run in isolation via "Re-run failed jobs". A single aggregate `Fuzz` job is the required check; it is green unless a target reports a genuine finding.

Target discovery is shared between CI and a local sweep (`scripts/fuzz_all.sh`) via `scripts/fuzz_targets.sh`, so new targets are picked up with no per-target wiring.

## Dependabot behavior

Dependabot PRs only touch dependency manifests and never the benchmarked or fuzzed code. For those PRs:

- the benchmark **step** (not the job) is gated on `github.actor`, and
- the fuzz matrix is emitted empty so the target jobs do not run.

In both cases the job still runs and reports **success** rather than being skipped — a skipped required check would block merge.

## Follow-up (not done in this PR)

After these checks report once on this PR, add `Benchmarks` and `Fuzz` to the branch protection required-status-check list.

## Test plan

- [x] `scripts/fuzz_targets.sh --json` discovers all 9 targets with unique, package-qualified names
- [x] `scripts/fuzz_one.sh ./payload FuzzJSONCodecDecode` runs and passes
- [x] `go test -run='^$' -bench=. -benchmem -benchtime=1x ./...` runs clean
- [x] Both workflow files validated as YAML
- [ ] CI green on this PR